### PR TITLE
add unit tests and fix operational gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ node_modules
 dist
 .astro
 
+.env
 .env*.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ Initial public launch. Full release notes: [v1.0](https://github.com/notjbg/the-
 ### Added
 - Live flight tracking map (30s updates via FlightRadar24)
 - Schedule tab with departures & arrivals at 7 United hubs
-- Fleet database (1,175+ aircraft, Starlink WiFi status)
+- Fleet database (1,078+ aircraft, Starlink WiFi status)
 - Hub health bar with on-time performance
 - IRROPS monitor with disruption scoring
 - Weather & delays: METAR, FAA monitoring, radar map

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Server-side disruption scoring across all 9 hubs — cancellations, delays (30m/
 Departure and arrival boards for all 9 UA hubs (ORD, DEN, IAH, EWR, SFO, IAD, LAX, NRT, GUM). Filter by status or aircraft type. Equipment swap detection flags when a plane type changes. On-time performance stats. All times in airport-local timezone.
 
 ### ✈️ [Fleet](https://theblueboard.co#fleet)
-Complete database of 1,175+ mainline aircraft — searchable and sortable by type, registration, seat config, WiFi, and IFE. Starlink tracker for 258+ equipped aircraft with sortable columns and filters by fleet, type, and operator. Live fleet status correlates airborne flights with the database.
+Complete database of 1,078+ mainline aircraft — searchable and sortable by type, registration, seat config, WiFi, and IFE. Starlink tracker for 258+ equipped aircraft with sortable columns and filters by fleet, type, and operator. Live fleet status correlates airborne flights with the database.
 
 ### 🌦 [Delays · Weather · Hubs](https://theblueboard.co#weather)
 FAA NAS delay and ground stop alerts, METAR observations with plain-English explainers, NEXRAD radar overlay, and hub health indicators. Each hub gets a unified card with conditions, visibility, wind, ceiling, and current delay status. **Ops Impact Assessment** goes beyond standard flight categories to flag real operational risks — snow, gusts, freezing precipitation, thunderstorms — even when conditions are technically VFR. Radar map renders instantly; weather data loads in parallel via batched API calls.

--- a/api/faa.js
+++ b/api/faa.js
@@ -102,7 +102,7 @@ export default async function handler(req, res) {
 }
 
 // Normalize a value to an array (handles undefined, single object, or array)
-function toArray(val) {
+export function toArray(val) {
   if (!val) return [];
   return Array.isArray(val) ? val : [val];
 }

--- a/api/flight-times.js
+++ b/api/flight-times.js
@@ -53,7 +53,7 @@ function corsHeaders(req) {
   };
 }
 
-function normalizeFlightNumber(raw) {
+export function normalizeFlightNumber(raw) {
   const str = Array.isArray(raw) ? raw[0] : (raw || '');
   let q = String(str).trim().toUpperCase().replace(/\s+/g, '');
   if (q.startsWith('UA') && !q.startsWith('UAL')) q = 'UAL' + q.slice(2);
@@ -61,7 +61,7 @@ function normalizeFlightNumber(raw) {
   return q;
 }
 
-function epochToISO(epoch) {
+export function epochToISO(epoch) {
   if (!epoch) return '';
   return new Date(epoch * 1000).toISOString();
 }

--- a/api/fr24-flight.js
+++ b/api/fr24-flight.js
@@ -73,7 +73,7 @@ function corsHeaders(req) {
   };
 }
 
-function normalizeFlightNumber(raw) {
+export function normalizeFlightNumber(raw) {
   let q = (raw || '').trim().toUpperCase().replace(/\s+/g, '');
   // "UAL838" → "UA838"
   if (q.startsWith('UAL') && /^\d/.test(q.slice(3))) q = 'UA' + q.slice(3);
@@ -102,7 +102,7 @@ async function fr24Fetch(path, params) {
   return resp;
 }
 
-function normalizeLiveResponse(data, flightNumber) {
+export function normalizeLiveResponse(data, flightNumber) {
   // FR24 live positions return { data: [ { ... } ] }
   const flights = data?.data || [];
   if (!flights.length) return null;
@@ -147,7 +147,7 @@ function normalizeLiveResponse(data, flightNumber) {
   };
 }
 
-function normalizeSummaryResponse(data, flightNumber) {
+export function normalizeSummaryResponse(data, flightNumber) {
   const flights = data?.data || [];
   if (!flights.length) return null;
 

--- a/api/irrops.js
+++ b/api/irrops.js
@@ -94,7 +94,7 @@ async function fetchHubSchedule(hub, timestamp) {
   return allFlights;
 }
 
-function computeMetrics(flightsByHub) {
+export function computeMetrics(flightsByHub) {
   let allFlights = [];
   const hubMetrics = {};
 
@@ -172,7 +172,7 @@ function computeMetrics(flightsByHub) {
   };
 }
 
-function getStartOfDayForHub(hub) {
+export function getStartOfDayForHub(hub) {
   const tz = HUB_TZ[hub] || 'America/New_York';
   const now = new Date();
   const parts = new Intl.DateTimeFormat('en-US', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "dependencies": {
         "astro": "^5.0.0",
         "fast-xml-parser": "^5.3.7"
+      },
+      "devDependencies": {
+        "vitest": "^3.0.0"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -1466,6 +1469,17 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -1474,6 +1488,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1525,6 +1546,121 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -1660,6 +1796,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astro": {
@@ -1801,6 +1947,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/camelcase": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
@@ -1821,6 +1977,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -1863,6 +2036,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2083,6 +2266,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/defu": {
@@ -2329,6 +2522,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -2737,6 +2940,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -2767,6 +2977,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "11.2.6",
@@ -3802,6 +4019,23 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -4258,6 +4492,13 @@
         "@types/hast": "^3.0.4"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -4294,6 +4535,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "7.2.0",
@@ -4341,6 +4596,19 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/strnum": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
@@ -4384,6 +4652,13 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -4407,6 +4682,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/trim-lines": {
@@ -4863,6 +5168,29 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
@@ -5341,6 +5669,86 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -5358,6 +5766,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {

--- a/package.json
+++ b/package.json
@@ -10,10 +10,15 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "preview": "astro preview"
+    "preview": "astro preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "astro": "^5.0.0",
     "fast-xml-parser": "^5.3.7"
+  },
+  "devDependencies": {
+    "vitest": "^3.0.0"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -66,7 +66,7 @@
   "@type": "WebApplication",
   "name": "The Blue Board",
   "alternateName": ["United Flight Tracker", "United Airlines Flight Tracker", "UA Flight Status", "UA Flight Tracker", "United Starlink Tracker", "United Airlines Operations Dashboard"],
-  "description": "Track every United Airlines flight in real time. Live flight map updated every 30 seconds, delay and cancellation alerts across all 9 hubs (ORD, DEN, IAH, EWR, SFO, IAD, LAX, NRT, GUM), Starlink WiFi aircraft checker, full fleet database of 1,175+ aircraft, departure and arrival schedules, weather radar, and operational analytics. Free and independent — built for United flyers.",
+  "description": "Track every United Airlines flight in real time. Live flight map updated every 30 seconds, delay and cancellation alerts across all 9 hubs (ORD, DEN, IAH, EWR, SFO, IAD, LAX, NRT, GUM), Starlink WiFi aircraft checker, full fleet database of 1,078+ aircraft, departure and arrival schedules, weather radar, and operational analytics. Free and independent — built for United flyers.",
   "url": "https://theblueboard.co",
   "applicationCategory": "Transportation",
   "operatingSystem": "Web",
@@ -80,7 +80,7 @@
     "Equipment swap detection and alerts",
     "On-time performance statistics by hub",
     "Starlink WiFi aircraft checker — see if your plane has fast internet",
-    "Full United Airlines fleet database with 1,175+ aircraft, seat configs, and IFE details",
+    "Full United Airlines fleet database with 1,078+ aircraft, seat configs, and IFE details",
     "NEXRAD weather radar overlay on live map",
     "METAR weather conditions for all hub airports",
     "Hub-to-hub traffic flow and route analytics",
@@ -147,7 +147,7 @@
   "@context": "https://schema.org",
   "@type": "Dataset",
   "name": "United Airlines Live Flight & Fleet Data",
-  "description": "Real-time dataset of United Airlines flight positions, delays, cancellations, on-time performance across 9 hubs, and fleet information including 1,175+ aircraft with Starlink WiFi status, seat configurations, and equipment details. Updated every 30 seconds.",
+  "description": "Real-time dataset of United Airlines flight positions, delays, cancellations, on-time performance across 9 hubs, and fleet information including 1,078+ aircraft with Starlink WiFi status, seat configurations, and equipment details. Updated every 30 seconds.",
   "url": "https://theblueboard.co",
   "license": "https://theblueboard.co",
   "creator": {"@type": "Person", "name": "Jonah Berg", "url": "https://github.com/notjbg"},
@@ -653,10 +653,10 @@ tbody td{padding:5px 8px;white-space:nowrap}
 <noscript>
 <div style="background:#111827;color:#e2e8f0;padding:40px;text-align:center;font-family:monospace">
 <h2>The Blue Board — United Airlines Flight Tracker & Live Status</h2>
-<p>Track every United Airlines flight in real time with The Blue Board — a free, independent operations dashboard. See live flight positions on an interactive map updated every 30 seconds. Check delays, cancellations, and ground stops at all 9 United hubs: Chicago O'Hare (ORD), Denver (DEN), Houston (IAH), Newark (EWR), San Francisco (SFO), Washington Dulles (IAD), Los Angeles (LAX), Tokyo Narita (NRT), and Guam (GUM). Look up any flight by number to see status, aircraft type, and route. Browse the full United fleet database of 1,175+ aircraft and check which planes have Starlink WiFi. View departure and arrival schedules with on-time performance stats and equipment swap alerts. Monitor weather conditions with radar, METAR observations, and FAA NAS alerts. Explore fleet utilization, route analytics, and hub-to-hub traffic patterns. Built for the United community. Not affiliated with United Airlines, Inc. JavaScript is required.</p>
+<p>Track every United Airlines flight in real time with The Blue Board — a free, independent operations dashboard. See live flight positions on an interactive map updated every 30 seconds. Check delays, cancellations, and ground stops at all 9 United hubs: Chicago O'Hare (ORD), Denver (DEN), Houston (IAH), Newark (EWR), San Francisco (SFO), Washington Dulles (IAD), Los Angeles (LAX), Tokyo Narita (NRT), and Guam (GUM). Look up any flight by number to see status, aircraft type, and route. Browse the full United fleet database of 1,078+ aircraft and check which planes have Starlink WiFi. View departure and arrival schedules with on-time performance stats and equipment swap alerts. Monitor weather conditions with radar, METAR observations, and FAA NAS alerts. Explore fleet utilization, route analytics, and hub-to-hub traffic patterns. Built for the United community. Not affiliated with United Airlines, Inc. JavaScript is required.</p>
 </div>
 </noscript>
-<div class="sr-only">The Blue Board is a free, independent United Airlines flight tracker and operations dashboard. Track every United flight in real time on a live map updated every 30 seconds. Check if your United flight is on time, delayed, or cancelled. Monitor delays and ground stops at all 9 United hubs: Chicago O'Hare ORD, Denver DEN, Houston IAH, Newark EWR, San Francisco SFO, Washington Dulles IAD, Los Angeles LAX, Tokyo Narita NRT, and Guam GUM. Search flights by number, tail number, or route. Check which United planes have Starlink WiFi. Browse the full fleet database of 1,175+ aircraft with seat configurations and IFE details. View departure and arrival schedules with on-time performance and equipment swap alerts. Weather radar, METAR conditions, and FAA delay alerts for all hub airports. Fleet utilization analytics, hub-to-hub route flow, and network health stats. Built for the United community. Not affiliated with United Airlines, Inc.</div>
+<div class="sr-only">The Blue Board is a free, independent United Airlines flight tracker and operations dashboard. Track every United flight in real time on a live map updated every 30 seconds. Check if your United flight is on time, delayed, or cancelled. Monitor delays and ground stops at all 9 United hubs: Chicago O'Hare ORD, Denver DEN, Houston IAH, Newark EWR, San Francisco SFO, Washington Dulles IAD, Los Angeles LAX, Tokyo Narita NRT, and Guam GUM. Search flights by number, tail number, or route. Check which United planes have Starlink WiFi. Browse the full fleet database of 1,078+ aircraft with seat configurations and IFE details. View departure and arrival schedules with on-time performance and equipment swap alerts. Weather radar, METAR conditions, and FAA delay alerts for all hub airports. Fleet utilization analytics, hub-to-hub route flow, and network health stats. Built for the United community. Not affiliated with United Airlines, Inc.</div>
 <!-- TICKER -->
 <div class="ticker-wrap">
   <span class="ticker-label">▌ALERTS</span>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -12,7 +12,7 @@ The Blue Board tracks every United Airlines flight in real time on a live map up
 - **Hub Delay Alerts**: Real-time delay counts, cancellations, and on-time performance for all 9 hubs
 - **Ground Stop & FAA Monitoring**: NAS status alerts affecting United operations
 - **Starlink WiFi Checker**: 258+ United aircraft with Starlink satellite WiFi — search by tail number or flight
-- **Fleet Database**: 1,175+ aircraft with type, seat configuration, IFE details, and delivery dates
+- **Fleet Database**: 1,078+ aircraft with type, seat configuration, IFE details, and delivery dates
 - **Departure & Arrival Schedules**: Real-time schedules with on-time stats and equipment swap alerts
 - **NEXRAD Weather Radar**: Overlay on the live map showing precipitation affecting flights
 - **METAR Conditions**: Current weather observations at all hub airports

--- a/scripts/prewarm-cache.sh
+++ b/scripts/prewarm-cache.sh
@@ -4,7 +4,7 @@
 # This ensures real users always hit CDN cache, never cold serverless functions
 
 BASE="https://theblueboard.co/api"
-HUBS=("ORD" "DEN" "IAH" "EWR" "SFO" "LAX" "IAD")
+HUBS=("ORD" "DEN" "IAH" "EWR" "SFO" "LAX" "IAD" "NRT" "GUM")
 DIRS=("departures" "arrivals")
 
 # Get today's start-of-day timestamp (UTC)
@@ -33,7 +33,7 @@ done
 
 # Also warm IRROPS and METAR
 curl -s -o /dev/null -w "  ✅ IRROPS — %{http_code}\n" --max-time 60 "${BASE}/irrops"
-curl -s -o /dev/null -w "  ✅ METAR — %{http_code}\n" --max-time 10 "${BASE}/metar?ids=KORD,KDEN,KIAH,KEWR,KSFO,KLAX,KIAD"
+curl -s -o /dev/null -w "  ✅ METAR — %{http_code}\n" --max-time 10 "${BASE}/metar?ids=KORD,KDEN,KIAH,KEWR,KSFO,KLAX,KIAD,RJAA,PGUM"
 curl -s -o /dev/null -w "  ✅ FAA — %{http_code}\n" --max-time 10 "${BASE}/faa"
 
 echo "Done: ${WARMED} warmed, ${FAILED} failed"

--- a/tests/faa.test.js
+++ b/tests/faa.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { toArray } from '../api/faa.js';
+
+describe('toArray', () => {
+  it('returns empty array for undefined', () => {
+    expect(toArray(undefined)).toEqual([]);
+  });
+
+  it('returns empty array for null', () => {
+    expect(toArray(null)).toEqual([]);
+  });
+
+  it('returns empty array for 0', () => {
+    expect(toArray(0)).toEqual([]);
+  });
+
+  it('returns empty array for empty string', () => {
+    expect(toArray('')).toEqual([]);
+  });
+
+  it('wraps a single object in an array', () => {
+    const obj = { ARPT: 'ORD', Reason: 'Weather' };
+    expect(toArray(obj)).toEqual([obj]);
+  });
+
+  it('returns an array as-is', () => {
+    const arr = [{ ARPT: 'ORD' }, { ARPT: 'EWR' }];
+    expect(toArray(arr)).toBe(arr); // same reference
+  });
+
+  it('wraps a string in an array', () => {
+    expect(toArray('hello')).toEqual(['hello']);
+  });
+
+  it('wraps a number in an array', () => {
+    expect(toArray(42)).toEqual([42]);
+  });
+});

--- a/tests/flight-times.test.js
+++ b/tests/flight-times.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeFlightNumber,
+  epochToISO,
+} from '../api/flight-times.js';
+
+describe('normalizeFlightNumber (FlightAware)', () => {
+  it('converts UA prefix to UAL', () => {
+    expect(normalizeFlightNumber('UA2221')).toBe('UAL2221');
+  });
+
+  it('prepends UAL to bare numbers', () => {
+    expect(normalizeFlightNumber('2221')).toBe('UAL2221');
+  });
+
+  it('leaves UAL prefix as-is', () => {
+    expect(normalizeFlightNumber('UAL100')).toBe('UAL100');
+  });
+
+  it('trims whitespace and uppercases', () => {
+    expect(normalizeFlightNumber('  ua 838 ')).toBe('UAL838');
+  });
+
+  it('handles empty/null input', () => {
+    expect(normalizeFlightNumber('')).toBe('');
+    expect(normalizeFlightNumber(null)).toBe('');
+    expect(normalizeFlightNumber(undefined)).toBe('');
+  });
+
+  it('handles array input (takes first element)', () => {
+    expect(normalizeFlightNumber(['UA100', 'UA200'])).toBe('UAL100');
+  });
+
+  it('handles single-digit flight numbers', () => {
+    expect(normalizeFlightNumber('1')).toBe('UAL1');
+  });
+});
+
+describe('epochToISO', () => {
+  it('converts valid epoch to ISO string', () => {
+    // 2024-01-01T00:00:00.000Z
+    const result = epochToISO(1704067200);
+    expect(result).toBe('2024-01-01T00:00:00.000Z');
+  });
+
+  it('returns empty string for 0', () => {
+    expect(epochToISO(0)).toBe('');
+  });
+
+  it('returns empty string for null', () => {
+    expect(epochToISO(null)).toBe('');
+  });
+
+  it('returns empty string for undefined', () => {
+    expect(epochToISO(undefined)).toBe('');
+  });
+
+  it('handles recent timestamps', () => {
+    const result = epochToISO(1700000000);
+    expect(result).toMatch(/^2023-11-14T/);
+  });
+});

--- a/tests/fr24-flight.test.js
+++ b/tests/fr24-flight.test.js
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeFlightNumber,
+  normalizeLiveResponse,
+  normalizeSummaryResponse,
+} from '../api/fr24-flight.js';
+
+describe('normalizeFlightNumber (FR24)', () => {
+  it('prepends UA to bare numbers', () => {
+    expect(normalizeFlightNumber('838')).toBe('UA838');
+  });
+
+  it('converts UAL prefix to UA', () => {
+    expect(normalizeFlightNumber('UAL838')).toBe('UA838');
+  });
+
+  it('leaves UA prefix as-is', () => {
+    expect(normalizeFlightNumber('UA838')).toBe('UA838');
+  });
+
+  it('trims whitespace and uppercases', () => {
+    expect(normalizeFlightNumber('  ua 838 ')).toBe('UA838');
+  });
+
+  it('handles empty/null input', () => {
+    expect(normalizeFlightNumber('')).toBe('');
+    expect(normalizeFlightNumber(null)).toBe('');
+    expect(normalizeFlightNumber(undefined)).toBe('');
+  });
+
+  it('handles 4-digit flight numbers', () => {
+    expect(normalizeFlightNumber('2221')).toBe('UA2221');
+  });
+
+  it('preserves non-UA airline codes', () => {
+    expect(normalizeFlightNumber('DL100')).toBe('DL100');
+  });
+});
+
+describe('normalizeLiveResponse', () => {
+  it('maps FR24 live fields to standard schema', () => {
+    const data = {
+      data: [{
+        flight_iata: 'UA838',
+        callsign: 'UAL838',
+        on_ground: false,
+        orig_iata: 'SFO',
+        dest_iata: 'EWR',
+        aircraft_type: 'B789',
+        registration: 'N29975',
+        icao24: 'ABC123',
+        scheduled_departure: '2024-01-01T10:00:00Z',
+        actual_departure: '2024-01-01T10:05:00Z',
+        scheduled_arrival: '2024-01-01T18:00:00Z',
+        estimated_arrival: '2024-01-01T17:50:00Z',
+        lat: 37.6213,
+        lon: -122.379,
+        alt: 35000,
+        gspeed: 450,
+        heading: 90,
+        flight_id: 'abc123',
+      }],
+    };
+
+    const result = normalizeLiveResponse(data, 'UA838');
+
+    expect(result.flightNumber).toBe('UA838');
+    expect(result.callsign).toBe('UAL838');
+    expect(result.status).toBe('en-route');
+    expect(result.origin.iata).toBe('SFO');
+    expect(result.destination.iata).toBe('EWR');
+    expect(result.aircraft.type).toBe('B789');
+    expect(result.aircraft.reg).toBe('N29975');
+    expect(result.aircraft.icao24).toBe('ABC123');
+    expect(result.departure.scheduled).toBe('2024-01-01T10:00:00Z');
+    expect(result.departure.actual).toBe('2024-01-01T10:05:00Z');
+    expect(result.arrival.scheduled).toBe('2024-01-01T18:00:00Z');
+    expect(result.arrival.estimated).toBe('2024-01-01T17:50:00Z');
+    expect(result.position.lat).toBe(37.6213);
+    expect(result.position.lon).toBe(-122.379);
+    expect(result.position.alt).toBe(35000);
+    expect(result.position.speed).toBe(450);
+    expect(result.position.heading).toBe(90);
+    expect(result.flightId).toBe('abc123');
+  });
+
+  it('returns "on-ground" status when on_ground is true', () => {
+    const data = { data: [{ on_ground: true }] };
+    const result = normalizeLiveResponse(data, 'UA100');
+    expect(result.status).toBe('on-ground');
+  });
+
+  it('returns null for empty data', () => {
+    expect(normalizeLiveResponse({ data: [] }, 'UA100')).toBeNull();
+    expect(normalizeLiveResponse({}, 'UA100')).toBeNull();
+    expect(normalizeLiveResponse(null, 'UA100')).toBeNull();
+  });
+
+  it('uses fallback fields when primary fields are missing', () => {
+    const data = {
+      data: [{
+        flight_icao: 'UAL838',
+        origin: { iata: 'SFO', icao: 'KSFO', name: 'San Francisco' },
+        destination: { iata: 'EWR', icao: 'KEWR', name: 'Newark' },
+        type: 'B789',
+        reg: 'N29975',
+        latitude: 37.62,
+        longitude: -122.38,
+        altitude: 35000,
+        speed: 450,
+        track: 90,
+        fr24_id: 'xyz',
+      }],
+    };
+    const result = normalizeLiveResponse(data, 'UA838');
+    expect(result.flightNumber).toBe('UAL838');
+    expect(result.origin.iata).toBe('SFO');
+    expect(result.origin.name).toBe('San Francisco');
+    expect(result.aircraft.type).toBe('B789');
+    expect(result.aircraft.reg).toBe('N29975');
+    expect(result.position.lat).toBe(37.62);
+    expect(result.position.lon).toBe(-122.38);
+    expect(result.flightId).toBe('xyz');
+  });
+});
+
+describe('normalizeSummaryResponse', () => {
+  it('maps FR24 summary fields to standard schema', () => {
+    const data = {
+      data: [{
+        flight_iata: 'UA1234',
+        callsign: 'UAL1234',
+        status: 'scheduled',
+        origin: { iata: 'ORD', icao: 'KORD', name: 'Chicago' },
+        destination: { iata: 'LAX', icao: 'KLAX', name: 'Los Angeles' },
+        aircraft: { type: 'B738', registration: 'N12345' },
+        departure: { scheduled: '2024-01-01T08:00:00Z', actual: '' },
+        arrival: { scheduled: '2024-01-01T10:30:00Z', estimated: '2024-01-01T10:25:00Z' },
+        flight_id: 'sum123',
+      }],
+    };
+
+    const result = normalizeSummaryResponse(data, 'UA1234');
+
+    expect(result.flightNumber).toBe('UA1234');
+    expect(result.callsign).toBe('UAL1234');
+    expect(result.status).toBe('scheduled');
+    expect(result.origin.iata).toBe('ORD');
+    expect(result.destination.iata).toBe('LAX');
+    expect(result.aircraft.type).toBe('B738');
+    expect(result.aircraft.reg).toBe('N12345');
+    expect(result.departure.scheduled).toBe('2024-01-01T08:00:00Z');
+    expect(result.arrival.estimated).toBe('2024-01-01T10:25:00Z');
+    expect(result.position).toBeNull(); // summary has no position data
+    expect(result.flightId).toBe('sum123');
+  });
+
+  it('returns null for empty data', () => {
+    expect(normalizeSummaryResponse({ data: [] }, 'UA100')).toBeNull();
+    expect(normalizeSummaryResponse({}, 'UA100')).toBeNull();
+    expect(normalizeSummaryResponse(null, 'UA100')).toBeNull();
+  });
+
+  it('uses fallback fields when primary fields are missing', () => {
+    const data = {
+      data: [{
+        flight_number: { iata: 'UA999', icao: 'UAL999' },
+        airport: {
+          origin: { code: { iata: 'DEN' } },
+          destination: { code: { iata: 'SFO' } },
+        },
+        aircraft_type: 'A320',
+        registration: 'N54321',
+        fr24_id: 'fallback1',
+      }],
+    };
+    const result = normalizeSummaryResponse(data, 'UA999');
+    expect(result.origin.iata).toBe('DEN');
+    expect(result.destination.iata).toBe('SFO');
+    expect(result.aircraft.type).toBe('A320');
+    expect(result.aircraft.reg).toBe('N54321');
+    expect(result.flightId).toBe('fallback1');
+  });
+});

--- a/tests/irrops.test.js
+++ b/tests/irrops.test.js
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import { computeMetrics, getStartOfDayForHub } from '../api/irrops.js';
+
+// Helper to build a flight object matching FR24's schedule structure
+function makeFlight(hub, {
+  status = 'landed',
+  schedDep = 1700000000,
+  realDep = null,
+  estDep = null,
+  flightNum = 'UA100',
+  origin = 'ORD',
+  dest = 'LAX',
+} = {}) {
+  return {
+    identification: { number: { default: flightNum } },
+    airport: {
+      origin: { code: { iata: origin } },
+      destination: { code: { iata: dest } },
+    },
+    status: { generic: { status: { text: status } } },
+    time: {
+      scheduled: { departure: schedDep },
+      real: { departure: realDep },
+      estimated: { departure: estDep },
+    },
+  };
+}
+
+describe('computeMetrics', () => {
+  it('returns score 0 for empty input', () => {
+    const result = computeMetrics({});
+    expect(result.score).toBe(0);
+    expect(result.totalFlights).toBe(0);
+    expect(result.cancellations).toBe(0);
+    expect(result.delayed30).toBe(0);
+    expect(result.delayed60).toBe(0);
+    expect(result.diversions).toBe(0);
+    expect(result.worstDelays).toEqual([]);
+    expect(result.hubMetrics).toEqual({});
+  });
+
+  it('returns score 0 for a hub with no flights', () => {
+    const result = computeMetrics({ ORD: [] });
+    expect(result.score).toBe(0);
+    expect(result.hubMetrics.ORD.total).toBe(0);
+  });
+
+  it('returns low score for all on-time flights', () => {
+    const t = 1700000000;
+    const flights = [
+      makeFlight('ORD', { schedDep: t, realDep: t, status: 'landed' }),
+      makeFlight('ORD', { schedDep: t, realDep: t + 300, status: 'landed' }), // 5 min late — still on-time
+      makeFlight('ORD', { schedDep: t, realDep: t + 600, status: 'departed' }), // 10 min late — still on-time
+    ];
+    const result = computeMetrics({ ORD: flights });
+    expect(result.score).toBe(0);
+    expect(result.hubMetrics.ORD.onTime).toBe(3);
+    expect(result.hubMetrics.ORD.delayed30).toBe(0);
+  });
+
+  it('weights cancellations at 3x', () => {
+    const t = 1700000000;
+    const flights = [
+      makeFlight('ORD', { schedDep: t, realDep: t, status: 'landed' }),
+      makeFlight('ORD', { schedDep: t, status: 'canceled' }),
+    ];
+    const result = computeMetrics({ ORD: flights });
+    // score = (1*3 / 2) * 100 = 150
+    expect(result.score).toBe(150);
+    expect(result.cancellations).toBe(1);
+    expect(result.hubMetrics.ORD.cancellations).toBe(1);
+  });
+
+  it('also recognises "cancelled" spelling', () => {
+    const t = 1700000000;
+    const flights = [
+      makeFlight('ORD', { schedDep: t, realDep: t, status: 'landed' }),
+      makeFlight('ORD', { schedDep: t, status: 'cancelled' }),
+    ];
+    const result = computeMetrics({ ORD: flights });
+    expect(result.cancellations).toBe(1);
+  });
+
+  it('weights 60-min delays at 2x', () => {
+    const t = 1700000000;
+    const flights = [
+      makeFlight('ORD', { schedDep: t, realDep: t + 3700, status: 'landed' }), // 61 min late
+    ];
+    const result = computeMetrics({ ORD: flights });
+    // delayed30 = 1, delayed60 = 1 => score = (2 + 1) / 1 * 100 = 300
+    expect(result.delayed30).toBe(1);
+    expect(result.delayed60).toBe(1);
+    expect(result.score).toBe(300);
+  });
+
+  it('counts diversions', () => {
+    const t = 1700000000;
+    const flights = [
+      makeFlight('ORD', { schedDep: t, realDep: t, status: 'diverted' }),
+    ];
+    const result = computeMetrics({ ORD: flights });
+    expect(result.diversions).toBe(1);
+    expect(result.hubMetrics.ORD.diversions).toBe(1);
+  });
+
+  it('populates hubMetrics per hub', () => {
+    const t = 1700000000;
+    const result = computeMetrics({
+      ORD: [
+        makeFlight('ORD', { schedDep: t, realDep: t, status: 'landed' }),
+        makeFlight('ORD', { schedDep: t, status: 'canceled' }),
+      ],
+      DEN: [
+        makeFlight('DEN', { schedDep: t, realDep: t + 2500, status: 'landed' }), // 41 min late
+      ],
+    });
+    expect(result.hubMetrics.ORD.total).toBe(2);
+    expect(result.hubMetrics.ORD.cancellations).toBe(1);
+    expect(result.hubMetrics.DEN.total).toBe(1);
+    expect(result.hubMetrics.DEN.delayed30).toBe(1);
+  });
+
+  it('sorts worstDelays by delay descending and limits to 8', () => {
+    const t = 1700000000;
+    const flights = [];
+    for (let i = 0; i < 12; i++) {
+      // Delays of 20, 25, 30, ... 75 minutes (only > 15 qualify for worstDelays)
+      const delayMin = 20 + i * 5;
+      flights.push(makeFlight('ORD', {
+        schedDep: t,
+        realDep: t + delayMin * 60,
+        status: 'landed',
+        flightNum: `UA${100 + i}`,
+      }));
+    }
+    const result = computeMetrics({ ORD: flights });
+    expect(result.worstDelays.length).toBe(8);
+    // First should have the largest delay
+    expect(result.worstDelays[0].delay).toBe(75);
+    // Last of the 8 should have the 8th largest
+    expect(result.worstDelays[7].delay).toBe(40);
+  });
+
+  it('includes generatedAt ISO timestamp', () => {
+    const result = computeMetrics({});
+    expect(result.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+describe('getStartOfDayForHub', () => {
+  it('returns a Unix timestamp (seconds)', () => {
+    const ts = getStartOfDayForHub('ORD');
+    expect(typeof ts).toBe('number');
+    expect(ts).toBeGreaterThan(1_000_000_000);
+    expect(ts).toBeLessThan(3_000_000_000); // reasonable range
+  });
+
+  it('returns different timestamps for different timezones', () => {
+    const ord = getStartOfDayForHub('ORD'); // Central
+    const nrt = getStartOfDayForHub('NRT'); // JST
+    // They may coincidentally match if tested at the right hour, but generally differ
+    // At minimum, both should be valid timestamps
+    expect(typeof ord).toBe('number');
+    expect(typeof nrt).toBe('number');
+  });
+
+  it('falls back to America/New_York for unknown hubs', () => {
+    // Should not throw
+    const ts = getStartOfDayForHub('XYZ');
+    expect(typeof ts).toBe('number');
+  });
+});

--- a/tests/rate-limit.test.js
+++ b/tests/rate-limit.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createRateLimiter } from '../api/_rate-limit.js';
+
+describe('createRateLimiter', () => {
+  it('returns a function', () => {
+    const limiter = createRateLimiter('test-returns-fn', 10);
+    expect(typeof limiter).toBe('function');
+  });
+
+  it('allows requests under the limit', () => {
+    const limiter = createRateLimiter('test-under-limit', 5);
+    const req = { headers: { 'x-real-ip': '1.2.3.4' } };
+
+    for (let i = 0; i < 5; i++) {
+      expect(limiter(req)).toBe(false);
+    }
+  });
+
+  it('blocks requests over the limit', () => {
+    const limiter = createRateLimiter('test-over-limit', 3);
+    const req = { headers: { 'x-real-ip': '5.6.7.8' } };
+
+    expect(limiter(req)).toBe(false);
+    expect(limiter(req)).toBe(false);
+    expect(limiter(req)).toBe(false);
+    // 4th request should be blocked
+    expect(limiter(req)).toBe(true);
+  });
+
+  it('tracks separate IPs independently', () => {
+    const limiter = createRateLimiter('test-separate-ips', 2);
+    const req1 = { headers: { 'x-real-ip': '10.0.0.1' } };
+    const req2 = { headers: { 'x-real-ip': '10.0.0.2' } };
+
+    expect(limiter(req1)).toBe(false);
+    expect(limiter(req1)).toBe(false);
+    expect(limiter(req1)).toBe(true); // blocked
+
+    // Different IP should still be allowed
+    expect(limiter(req2)).toBe(false);
+  });
+
+  it('prefers x-real-ip over x-forwarded-for', () => {
+    const limiter = createRateLimiter('test-ip-priority', 1);
+    const req = {
+      headers: {
+        'x-real-ip': '100.0.0.1',
+        'x-forwarded-for': '200.0.0.1',
+      },
+    };
+
+    expect(limiter(req)).toBe(false);
+    expect(limiter(req)).toBe(true); // blocked for 100.0.0.1
+
+    // A request from the x-forwarded-for IP should still be allowed
+    const req2 = { headers: { 'x-real-ip': '200.0.0.1' } };
+    expect(limiter(req2)).toBe(false);
+  });
+
+  it('falls back to x-forwarded-for when x-real-ip is missing', () => {
+    const limiter = createRateLimiter('test-xff-fallback', 1);
+    const req = { headers: { 'x-forwarded-for': '50.0.0.1, 60.0.0.1' } };
+
+    expect(limiter(req)).toBe(false);
+    expect(limiter(req)).toBe(true);
+  });
+
+  it('handles missing headers gracefully', () => {
+    const limiter = createRateLimiter('test-no-headers', 2);
+    const req = { headers: {} };
+
+    expect(limiter(req)).toBe(false);
+    expect(limiter(req)).toBe(false);
+    expect(limiter(req)).toBe(true);
+  });
+
+  it('uses separate stores for different endpoint names', () => {
+    const limiterA = createRateLimiter('endpoint-a', 1);
+    const limiterB = createRateLimiter('endpoint-b', 1);
+    const req = { headers: { 'x-real-ip': '99.0.0.1' } };
+
+    expect(limiterA(req)).toBe(false);
+    expect(limiterA(req)).toBe(true); // blocked on A
+
+    // Same IP, different endpoint — should still be allowed
+    expect(limiterB(req)).toBe(false);
+  });
+});


### PR DESCRIPTION
- Add vitest with 55 tests across 5 test files covering rate limiter, IRROPS scoring/timezone logic, FR24 flight normalization/response mapping, FlightAware flight normalization/epoch conversion, and FAA toArray utility
- Export pure functions from API files for testability (no handler changes)
- Add NRT and GUM to prewarm-cache.sh (were missing from HUBS array and METAR ids)
- Update stale fleet count 1,175+ → 1,078+ across README, CHANGELOG, llms.txt, and index.html SEO schema (matches actual fleet.json data)
- Add .env to .gitignore (only .env*.local was covered)