### PR TITLE
Move hub weather cards above IRROPS monitor in weather tab

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -996,12 +996,12 @@ table,thead th,tbody td,.stat-val,.metric-val,.big-number,.ticker,.ticker-item,.
     <div class="wx-legend-item"><span class="wx-legend-dot" style="background:#ef4444"></span>IFR</div>
     <div class="wx-legend-item"><span class="wx-legend-dot" style="background:#c026d3"></span>LIFR</div>
   </div>
+  <div class="hub-cards" id="hub-cards"></div>
   <!-- IRROPS Monitor -->
   <div id="irrops-section">
     <h3>⚠️ IRROPS Monitor</h3>
     <div id="irrops-content" aria-live="polite"><div class="irrops-empty" style="color:var(--ua-muted);font-size:10px">Loading IRROPS data…</div></div>
   </div>
-  <div class="hub-cards" id="hub-cards"></div>
 </div>
 
 <!-- TAB 4: ANALYTICS -->


### PR DESCRIPTION
Better content flow: radar → hub conditions → disruption score. Hub cards are the primary content users navigate to this tab for.