### PR TITLE
Fix inverted onboarding overlay logic for first-time visitors

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5066,7 +5066,7 @@ function hideDisclaimer() {
   };
 
   var visited=localStorage.getItem('bb-visited');
-  if(!visited){localStorage.setItem('bb-visited','1');overlay.style.display='none'}
+  if(!visited){localStorage.setItem('bb-visited','1')}
   else if(localStorage.getItem('bb-onboarded')){overlay.style.display='none'}
   btn.addEventListener('click',hideOverlay);
   overlay.addEventListener('click',function(e){if(e.target===overlay)hideOverlay()});


### PR DESCRIPTION
First-time visitors (no 'bb-visited' in localStorage) were having the onboarding overlay hidden immediately — the opposite of the intended behavior. Removed the `overlay.style.display='none'` from the first-visit branch so new users now see the onboarding screen. Returning visitors who already dismissed it (bb-onboarded set) still skip it correctly.
