### PR TITLE
fix: use browser User-Agent for FR24 requests + stop irrops from clob…

### DIFF
--- a/api/schedule.js
+++ b/api/schedule.js
@@ -70,8 +70,11 @@ async function fetchWithTimeout(url, deadlineMs) {
     const resp = await fetch(url, {
       signal: controller.signal,
       headers: {
-        'User-Agent': 'TheBlueBoardDashboard/1.0 (https://theblueboard.co)',
-        'Accept': 'application/json'
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+        'Accept': 'application/json',
+        'Accept-Language': 'en-US,en;q=0.9',
+        'Referer': 'https://www.flightradar24.com/',
+        'Origin': 'https://www.flightradar24.com'
       }
     });
     clearTimeout(timeout);

--- a/public/index.html
+++ b/public/index.html
@@ -4010,30 +4010,25 @@ async function loadScheduleData() {
     const timestamp = getSchedDayTimestamp(schedCurrentDay);
     const hubKey = `${schedCurrentHub}-${schedCurrentDir}-${schedCurrentDay}`;
 
-    // Check if IRROPS already hydrated this data
+    // Always fetch from schedule API for complete data (irrops only has ~5 pages)
     let result;
-    if (schedRawByHub[hubKey] && schedRawByHub[hubKey].length) {
-      result = { flights: schedRawByHub[hubKey], cached: true, fromIrrops: true };
-    } else {
-      // Retry with exponential backoff (up to 3 attempts)
-      const MAX_RETRIES = 3;
-      let lastErr;
-      for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-        try {
-          if (attempt > 0) {
-            const delay = Math.min(1000 * Math.pow(2, attempt - 1), 4000);
-            loadEl.innerHTML = `<div style="font-size:24px;margin-bottom:8px;animation:pulse 1.5s infinite">✈️</div>Retrying ${escapeHtml(schedCurrentHub)} (attempt ${attempt + 1}/${MAX_RETRIES})...<br><span style="font-size:10px">Waiting ${delay / 1000}s before retry</span>`;
-            await new Promise(r => setTimeout(r, delay));
-          }
-          result = await fetchScheduleAggregated(schedCurrentHub, schedCurrentDir, timestamp);
-          lastErr = null;
-          break;
-        } catch (e) {
-          lastErr = e;
+    const MAX_RETRIES = 3;
+    let lastErr;
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      try {
+        if (attempt > 0) {
+          const delay = Math.min(1000 * Math.pow(2, attempt - 1), 4000);
+          loadEl.innerHTML = `<div style="font-size:24px;margin-bottom:8px;animation:pulse 1.5s infinite">✈️</div>Retrying ${escapeHtml(schedCurrentHub)} (attempt ${attempt + 1}/${MAX_RETRIES})...<br><span style="font-size:10px">Waiting ${delay / 1000}s before retry</span>`;
+          await new Promise(r => setTimeout(r, delay));
         }
+        result = await fetchScheduleAggregated(schedCurrentHub, schedCurrentDir, timestamp);
+        lastErr = null;
+        break;
+      } catch (e) {
+        lastErr = e;
       }
-      if (lastErr) throw lastErr;
     }
+    if (lastErr) throw lastErr;
     const allUAFlights = result.flights || [];
 
     // Show cache indicator
@@ -4798,12 +4793,9 @@ function renderIrropsFromAPI(data) {
       const hubKey = `${hub}-departures-0`;
       if (!schedRawByHub[hubKey]) {
         schedRawByHub[hubKey] = flights;
-        // Also populate the fetch cache so Schedule tab doesn't re-fetch
-        const timestamp = getSchedDayTimestamp(0);
-        const cacheKey = `agg-${hub}-departures-${timestamp}`;
-        if (!schedCache[cacheKey]) {
-          schedCache[cacheKey] = { flights, total: flights.length, cached: true, hub, dir: 'departures' };
-        }
+        // NOTE: Do NOT populate schedCache here — irrops only fetches 5 pages
+        // per hub, which misses international flights on later pages. Let the
+        // schedule API do a full fetch when the user opens the Schedule tab.
       }
     });
   }


### PR DESCRIPTION
…bering schedule cache

Two root causes found:

1. schedule.js sent a custom User-Agent ('TheBlueBoardDashboard/1.0') while irrops.js sent browser-like headers. FR24 blocks/rate-limits non-browser UAs, causing 502 errors. Now uses the same browser UA and Referer/Origin headers as irrops.js.

2. irrops hydration was populating schedCache with incomplete data (only 5 pages per hub), then the schedule tab would skip its own full API fetch and serve the incomplete irrops data. DEN showing 1 international flight was because irrops only scanned ~500 flights. Removed the schedCache population from irrops hydration and removed the short-circuit that skipped the full schedule fetch.

