### PR TITLE
Fix scroll on intl flights by moving overflow:visible override to glo…

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -511,6 +511,8 @@ tbody td{padding:5px 8px;white-space:nowrap}
 .tab-content.active{animation:fadeIn .2s ease}
 
 #sched-table-wrap{max-height:calc(100vh - 260px)}
+/* Prevent overflow:hidden on card from trapping scroll events when table is short */
+#tab-schedule .card[style*="overflow:hidden"]{overflow:visible!important}
 /* ═══ MOBILE RESPONSIVE ═══ */
 @media(max-width:768px){
   body{font-size:14px;height:calc(100vh - 56px);height:calc(100dvh - 56px)}
@@ -558,8 +560,6 @@ tbody td{padding:5px 8px;white-space:nowrap}
   #tab-schedule select,#tab-schedule input[type="text"]{width:100%!important;min-height:44px;font-size:14px!important;padding:8px 10px!important}
   #tab-schedule button{min-height:44px}
   #sched-stats.metric-row{grid-template-columns:repeat(2,1fr)!important;gap:8px}
-  /* iOS Safari can fail to paint tbody inside nested overflow+sticky containers */
-  #tab-schedule .card[style*="overflow:hidden"]{overflow:visible!important}
   #sched-table-wrap{max-height:none}
   .fleet-table-wrap{overflow-x:auto;-webkit-overflow-scrolling:touch}
   #sched-table th{position:static}


### PR DESCRIPTION
…bal scope

The schedule table's parent card has overflow:hidden, which creates a scroll trap when the filtered (intl) flights table is shorter than the max-height of #sched-table-wrap. With "all" flights the table exceeds max-height so the inner overflow-y:auto works, but with fewer intl flights scroll events get swallowed by the card's overflow:hidden before reaching .tab-content.

Move the overflow:visible!important override from the mobile-only media query to global scope so it applies on all viewport sizes.

