### PR TITLE
Add AI-powered delay risk explanation via Claude Haiku

### DIFF
--- a/api/delay-explain.js
+++ b/api/delay-explain.js
@@ -1,0 +1,92 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { createRateLimiter } from './_rate-limit.js';
+
+const isRateLimited = createRateLimiter('delay-explain', 20);
+
+let client = null;
+function getClient() {
+  if (!client) client = new Anthropic();
+  return client;
+}
+
+// Simple in-memory cache — avoids redundant AI calls for same flight state
+const cache = new Map();
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+function getCacheKey(ctx) {
+  return `${ctx.flight}:${ctx.riskScore}:${(ctx.factors || []).join(',')}`;
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const origin = req.headers?.origin || '';
+  if (origin && origin !== 'https://theblueboard.co' && !/^http:\/\/localhost(:\d+)?$/.test(origin)) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  if (isRateLimited(req)) {
+    return res.status(429).json({ error: 'Rate limited — try again shortly' });
+  }
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return res.status(503).json({ error: 'AI analysis unavailable — no API key configured' });
+  }
+
+  try {
+    const ctx = typeof req.body === 'string' ? JSON.parse(req.body) : req.body;
+    if (!ctx || !ctx.flight) {
+      return res.status(400).json({ error: 'Missing flight context' });
+    }
+
+    // Check cache
+    const key = getCacheKey(ctx);
+    const cached = cache.get(key);
+    if (cached && Date.now() - cached.time < CACHE_TTL) {
+      return res.status(200).json({ explanation: cached.text, cached: true });
+    }
+
+    // Build token-efficient prompt (~200-300 input tokens)
+    const lines = [
+      `You are a United Airlines operations analyst briefing a passenger. Give a concise explanation (3-5 sentences) of the delay risk for their flight. Be specific about causes and what to expect. Use a helpful, calm tone.`,
+      ``,
+      `Flight: ${ctx.flight} (${ctx.route || 'unknown route'})`,
+      `Status: ${ctx.status || 'scheduled'}`,
+      `Risk Level: ${ctx.riskLabel || 'LOW'} (score ${ctx.riskScore || 0}/100)`,
+    ];
+    if (ctx.factors && ctx.factors.length > 0) {
+      lines.push(`Contributing factors: ${ctx.factors.join('; ')}`);
+    }
+    if (ctx.otp) lines.push(`Hub on-time performance: ${ctx.otp}%`);
+    if (ctx.weather) lines.push(`Weather conditions: ${ctx.weather}`);
+    if (ctx.inbound) lines.push(`Inbound aircraft: ${ctx.inbound}`);
+
+    const message = await getClient().messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 200,
+      messages: [{ role: 'user', content: lines.join('\n') }],
+    });
+
+    const text = message.content[0]?.text || 'Unable to generate analysis.';
+
+    // Cache the result
+    cache.set(key, { text, time: Date.now() });
+    // Evict old entries periodically
+    if (cache.size > 200) {
+      const now = Date.now();
+      for (const [k, v] of cache) {
+        if (now - v.time > CACHE_TTL) cache.delete(k);
+      }
+    }
+
+    res.setHeader('Cache-Control', 'no-store');
+    return res.status(200).json({ explanation: text, cached: false });
+  } catch (e) {
+    console.error('Delay explain API error:', e);
+    if (e.status === 401) return res.status(503).json({ error: 'Invalid API key' });
+    if (e.status === 429) return res.status(429).json({ error: 'AI rate limited — try again shortly' });
+    return res.status(502).json({ error: 'AI analysis temporarily unavailable' });
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,32 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.78.0",
         "astro": "^5.0.0",
         "fast-xml-parser": "^5.3.7"
       },
       "devDependencies": {
         "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.78.0.tgz",
+      "integrity": "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -118,6 +139,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -2959,6 +2989,19 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -4733,6 +4776,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/tsconfck": {
       "version": "3.1.6",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.78.0",
     "astro": "^5.0.0",
     "fast-xml-parser": "^5.3.7"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -320,6 +320,15 @@ main{flex:1;min-height:0;display:flex;flex-direction:column;overflow:hidden}
 .ac-modal-footer{padding:10px 20px;border-top:1px solid var(--ua-border);display:flex;gap:8px;flex-wrap:wrap;align-items:center;flex-shrink:0}
 .ac-action-btn{background:rgba(0,93,170,.15);border:1px solid rgba(0,93,170,.3);color:var(--ua-accent);padding:4px 10px;border-radius:4px;font-size:10px;font-family:var(--font-mono);cursor:pointer;text-decoration:none;transition:background .2s}
 .ac-action-btn:hover{background:rgba(0,93,170,.25)}
+.delay-explain-text{font-size:12px;line-height:1.7;color:var(--ua-text);margin-bottom:12px}
+.delay-explain-factors{border-top:1px solid var(--ua-border);padding-top:10px;margin-top:10px}
+.delay-explain-factor{font-size:10px;color:var(--ua-muted);padding:2px 0}
+.delay-explain-footer{font-size:9px;color:var(--ua-muted);text-align:center;padding-top:8px;border-top:1px solid var(--ua-border);margin-top:12px}
+.delay-explain-loading{text-align:center;padding:24px;color:var(--ua-muted);font-size:11px}
+.delay-explain-loading .shimmer{display:inline-block;width:60%;height:10px;background:linear-gradient(90deg,transparent,rgba(138,180,248,.15),transparent);background-size:200% 100%;animation:shimmer 1.5s infinite;border-radius:4px;margin:6px 0}
+.delay-explain-error{text-align:center;padding:16px;color:#f59e0b;font-size:11px}
+.delay-explain-btn{background:rgba(138,180,248,.1);border:1px solid rgba(138,180,248,.2);color:var(--ua-accent);padding:3px 8px;border-radius:3px;font-size:9px;font-family:var(--font-mono);cursor:pointer}
+.delay-explain-btn:hover{background:rgba(138,180,248,.2)}
 .ac-reg-link{color:var(--ua-accent);cursor:pointer;text-decoration:none;border-bottom:1px dotted rgba(138,180,248,.3);transition:border-color .2s}
 .ac-reg-link:hover{border-bottom-color:var(--ua-accent)}
 .starlink-badge{background:rgba(34,197,94,.2);color:var(--ua-green);padding:2px 6px;border-radius:3px;font-size:9px;font-weight:700}
@@ -4406,7 +4415,7 @@ function renderScheduleTable() {
 
     // Delay risk scoring
     const dRisk = computeDelayRiskForScheduleFlight(fl, hub);
-    const riskCell = dRisk ? `<span class="delay-risk-badge" style="background:${dRisk.color}20;color:${dRisk.color}" title="${escapeHtml(dRisk.factors.join(', '))}">${dRisk.label}</span>` : '';
+    const riskCell = dRisk ? `<span class="delay-risk-badge" data-action="explain-delay" data-flight="${escapeHtml(ident)}" data-route="${escapeHtml(origCode + '\u2192' + destCode)}" data-status="${escapeHtml(status.text)}" data-risk-label="${dRisk.label}" data-risk-score="${dRisk.score}" data-risk-factors="${escapeHtml(dRisk.factors.join('|'))}" data-hub="${escapeHtml(hub)}" style="background:${dRisk.color}20;color:${dRisk.color};cursor:pointer" title="Click for AI analysis">${dRisk.label}</span>` : '';
 
     return `<tr>
       <td>${escapeHtml(timeStr)}${timeExtra}</td>
@@ -5295,8 +5304,10 @@ function buildMyFlightCard(watched, td) {
   // Delay risk — pass timeData and liveFlight for multi-signal scoring
   let riskHtml = '';
   const risk = computeDelayRisk(watched, origCode, destCode, td, liveFlight);
+  const riskOtp = hubHealthData[origCode];
+  const riskWx = weatherOpsByHub[origCode];
   if (risk && (resolvedStatus === 'scheduled' || resolvedStatus === 'delayed' || resolvedStatus === '' || !resolvedStatus)) {
-    riskHtml = `<span class="delay-risk-badge" style="background:${risk.color}20;color:${risk.color}" title="${escapeHtml(risk.factors.join(', '))}">${risk.label} RISK</span>`;
+    riskHtml = `<span class="delay-risk-badge" data-action="explain-delay" data-flight="${flightNum}" data-route="${escapeHtml(origCode + '\u2192' + destCode)}" data-status="${escapeHtml(resolvedStatus || 'scheduled')}" data-risk-label="${risk.label}" data-risk-score="${risk.score}" data-risk-factors="${escapeHtml(risk.factors.join('|'))}" data-hub="${escapeHtml(origCode)}"${riskOtp !== undefined ? ' data-otp="' + riskOtp + '"' : ''}${riskWx ? ' data-weather="' + escapeHtml(riskWx.level + (riskWx.reasons.length ? ': ' + riskWx.reasons.join(', ') : '')) + '"' : ''} style="background:${risk.color}20;color:${risk.color};cursor:pointer" title="Click for AI analysis">${risk.label} RISK</span>`;
   }
 
   // Departure/arrival time data attributes for countdown timer
@@ -5324,6 +5335,7 @@ function buildMyFlightCard(watched, td) {
     <div class="mf-actions">
       ${liveFlight ? `<button data-action="focus-flight" data-icao24="${escapeHtml(liveFlight.icao24)}">View on Map</button>` : ''}
       ${reg ? `<button data-action="aircraft-detail" data-reg="${escapeHtml(reg)}">Aircraft Details</button>` : ''}
+      ${risk ? `<button class="delay-explain-btn" data-action="explain-delay" data-flight="${flightNum}" data-route="${escapeHtml(origCode + '\u2192' + destCode)}" data-status="${escapeHtml(resolvedStatus || 'scheduled')}" data-risk-label="${risk.label}" data-risk-score="${risk.score}" data-risk-factors="${escapeHtml(risk.factors.join('|'))}" data-hub="${escapeHtml(origCode)}"${riskOtp !== undefined ? ' data-otp="' + riskOtp + '"' : ''}${riskWx ? ' data-weather="' + escapeHtml(riskWx.level + (riskWx.reasons.length ? ': ' + riskWx.reasons.join(', ') : '')) + '"' : ''}>Explain Delay Risk</button>` : ''}
       <button data-action="toggle-watch-flight" data-flight="${flightNum}" data-route="${escapeHtml(watched.route)}" data-status="${escapeHtml(watched.status)}" data-stop-prop="1">Unwatch</button>
     </div>
   </div>`;
@@ -6001,6 +6013,26 @@ document.addEventListener('click', function(e) {
       if (modal) modal.style.display = 'none';
       break;
     }
+    case 'explain-delay': {
+      const el = actionEl;
+      showDelayExplanation({
+        flight: el.dataset.flight,
+        route: el.dataset.route,
+        status: el.dataset.status,
+        riskLabel: el.dataset.riskLabel,
+        riskScore: el.dataset.riskScore,
+        factors: (el.dataset.riskFactors || '').split('|').filter(Boolean),
+        hub: el.dataset.hub,
+        otp: el.dataset.otp,
+        weather: el.dataset.weather,
+      });
+      break;
+    }
+    case 'close-delay-explain': {
+      const dem = document.getElementById('delay-explain-modal');
+      if (dem) dem.style.display = 'none';
+      break;
+    }
     case 'aircraft-detail': {
       const reg = actionEl.dataset.reg;
       if (reg) showAircraftDetail(reg);
@@ -6318,6 +6350,84 @@ const SEAT_BAR_COLORS = {
   'PP':'rgba(20,184,166,.5)','PE':'rgba(20,184,166,.5)',
   'E+':'rgba(34,197,94,.5)','Y':'rgba(100,116,139,.5)'
 };
+
+// ═══ AI DELAY EXPLANATION MODAL ═══
+function showDelayExplanation(ctx) {
+  if (!ctx || !ctx.flight) return;
+
+  let modal = document.getElementById('delay-explain-modal');
+  if (!modal) {
+    modal = document.createElement('div');
+    modal.id = 'delay-explain-modal';
+    modal.style.cssText = 'position:fixed;inset:0;z-index:10001;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.7);backdrop-filter:blur(4px)';
+    modal.addEventListener('click', function(e) { if (e.target === modal) modal.style.display = 'none'; });
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape' && modal.style.display !== 'none') modal.style.display = 'none';
+    });
+    document.body.appendChild(modal);
+  }
+
+  const riskColor = ctx.riskLabel === 'HIGH' ? '#ef4444' : ctx.riskLabel === 'MOD' ? '#eab308' : '#22c55e';
+  const factorsHtml = (ctx.factors || []).map(function(f) {
+    return '<div class="delay-explain-factor">\u2022 ' + escapeHtml(f) + '</div>';
+  }).join('');
+
+  modal.style.display = 'flex';
+  modal.innerHTML = '<div class="ac-modal-card" style="max-width:400px">' +
+    '<div class="ac-modal-header">' +
+    '<button class="ac-modal-close" data-action="close-delay-explain" aria-label="Close">\u2715</button>' +
+    '<div style="font-size:16px;font-weight:700;color:var(--ua-accent)">\u2708\uFE0F ' + escapeHtml(ctx.flight) + '</div>' +
+    '<div style="font-size:11px;color:var(--ua-muted);margin-top:2px">' + escapeHtml(ctx.route || '') + '</div>' +
+    '<div style="margin-top:6px"><span class="delay-risk-badge" style="background:' + riskColor + '20;color:' + riskColor + ';font-size:11px;padding:2px 8px">' + escapeHtml(ctx.riskLabel || 'LOW') + ' RISK</span> <span style="font-size:10px;color:var(--ua-muted)">score ' + (ctx.riskScore || 0) + '/100</span></div>' +
+    '</div>' +
+    '<div class="ac-modal-body">' +
+    '<div id="delay-explain-content" class="delay-explain-loading">' +
+    '<div style="font-size:13px;margin-bottom:8px">\u2728 Analyzing delay risk...</div>' +
+    '<div class="shimmer"></div><div class="shimmer" style="width:80%"></div><div class="shimmer" style="width:90%"></div>' +
+    '</div>' +
+    (factorsHtml ? '<div class="delay-explain-factors"><div style="font-size:9px;text-transform:uppercase;color:var(--ua-muted);letter-spacing:.5px;margin-bottom:6px;font-weight:700">Contributing Factors</div>' + factorsHtml + '</div>' : '') +
+    '</div>' +
+    '<div class="delay-explain-footer">Powered by Claude AI</div>' +
+    '</div>';
+
+  // Fetch AI explanation
+  fetchDelayExplanation(ctx);
+}
+
+async function fetchDelayExplanation(ctx) {
+  const contentEl = document.getElementById('delay-explain-content');
+  if (!contentEl) return;
+
+  try {
+    const resp = await fetch('/api/delay-explain', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        flight: ctx.flight,
+        route: ctx.route,
+        status: ctx.status,
+        riskLabel: ctx.riskLabel,
+        riskScore: ctx.riskScore,
+        factors: ctx.factors,
+        hub: ctx.hub,
+        otp: ctx.otp,
+        weather: ctx.weather,
+      }),
+    });
+
+    if (!resp.ok) {
+      const err = await resp.json().catch(function() { return {}; });
+      contentEl.innerHTML = '<div class="delay-explain-error">\u26A0\uFE0F ' + escapeHtml(err.error || 'Unable to generate analysis') + '</div>';
+      return;
+    }
+
+    const data = await resp.json();
+    contentEl.className = 'delay-explain-text';
+    contentEl.textContent = data.explanation || 'No analysis available.';
+  } catch (e) {
+    contentEl.innerHTML = '<div class="delay-explain-error">\u26A0\uFE0F Unable to reach analysis service</div>';
+  }
+}
 
 function showAircraftDetail(reg) {
   if (!reg) return;

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,8 @@
     "functions": {
         "api/irrops.js": { "maxDuration": 90 },
         "api/schedule.js": { "maxDuration": 60 },
-        "api/cron/warm-schedules.js": { "maxDuration": 300 }
+        "api/cron/warm-schedules.js": { "maxDuration": 300 },
+        "api/delay-explain.js": { "maxDuration": 15 }
     },
     "crons": [
         { "path": "/api/cron/warm-schedules", "schedule": "*/5 * * * *" }


### PR DESCRIPTION
Click any delay risk badge (My Flights or Schedule tabs) or the new "Explain Delay Risk" button to get a natural-language AI briefing explaining what's causing the delay risk and what to expect.

- New /api/delay-explain.js endpoint calling Claude Haiku
- Token-efficient prompt (~450 tokens/call) with 5-min response cache
- Modal UI following existing aircraft-detail pattern
- Risk badges now clickable with cursor:pointer and data attributes
- Graceful error handling for missing API key or rate limits
- 20 req/min rate limit on AI endpoint
- Added @anthropic-ai/sdk dependency
- Updated vercel.json with 15s maxDuration for AI endpoint