### PR TITLE
Change cron warming interval from 5min to 15min to reduce API credits

### DIFF
--- a/api/cron/warm-schedules.js
+++ b/api/cron/warm-schedules.js
@@ -1,5 +1,5 @@
 // Vercel Cron Job: warms schedule CDN + in-memory cache for all UA hubs.
-// Runs every 5 minutes to ensure users always hit warm cache.
+// Runs every 15 minutes to ensure users always hit warm cache.
 // Config in vercel.json: { "path": "/api/cron/warm-schedules", "schedule": "*/5 * * * *" }
 
 import { getStartOfDayForHub } from '../irrops.js';

--- a/api/schedule.js
+++ b/api/schedule.js
@@ -591,7 +591,7 @@ export default async function handler(req, res) {
       return res.status(400).json({ error: 'Invalid timestamp' });
     }
     const isOld = (now - ts) > 86400;
-    const ttl = isOld ? 600000 : 300000;
+    const ttl = isOld ? 600000 : 900000;
     const cdnMaxAge = isOld ? 3600 : 900;
     const swr = 300;
 

--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,7 @@
         "api/delay-explain.js": { "maxDuration": 15 }
     },
     "crons": [
-        { "path": "/api/cron/warm-schedules", "schedule": "*/5 * * * *" }
+        { "path": "/api/cron/warm-schedules", "schedule": "*/15 * * * *" }
     ],
   "buildCommand": "npm run build",
   "outputDirectory": "dist",


### PR DESCRIPTION
- vercel.json: */5 → */15 cron schedule
- warm-schedules.js: update comment
- schedule.js: increase fresh-data cache TTL from 5min to 15min to match

