### PR TITLE
Add aircraft journey chain tracking + upgrade AI delay explanations

### DIFF
--- a/api/aircraft-history.js
+++ b/api/aircraft-history.js
@@ -1,0 +1,152 @@
+// Aircraft History API — Fetch recent flight segments for a tail number
+// Usage: /api/aircraft-history?reg=N12345
+//
+// Uses FR24 Official API flight-summary endpoint with `regs` parameter
+// Returns the last 5 flight segments for the aircraft within a 36-hour window
+
+import { createRateLimiter } from './_rate-limit.js';
+
+const isRateLimited = createRateLimiter('aircraft-history', 15);
+
+const FR24_BASE = 'https://fr24api.flightradar24.com';
+const SUMMARY_PATH = '/api/flight-summary/light';
+const API_VERSION = 'v1';
+
+// 5-minute cache — historical data doesn't change fast
+const cache = new Map();
+const CACHE_TTL_MS = 5 * 60_000;
+
+function getCached(key) {
+  const entry = cache.get(key);
+  if (!entry) return null;
+  if (Date.now() - entry.ts > CACHE_TTL_MS) { cache.delete(key); return null; }
+  return entry.data;
+}
+
+function setCache(key, data) {
+  if (cache.size > 100) {
+    const oldest = cache.keys().next().value;
+    cache.delete(oldest);
+  }
+  cache.set(key, { data, ts: Date.now() });
+}
+
+export function normalizeSegments(data) {
+  const flights = data?.data || [];
+  if (!flights.length) return [];
+
+  return flights.map(f => {
+    const depSched = f.departure?.scheduled || f.scheduled_departure || '';
+    const depActual = f.departure?.actual || f.actual_departure || '';
+    const arrSched = f.arrival?.scheduled || f.scheduled_arrival || '';
+    const arrActual = f.arrival?.actual || f.actual_arrival || '';
+    const arrEst = f.arrival?.estimated || f.estimated_arrival || '';
+
+    // Compute departure delay in minutes
+    let delayMin = null;
+    if (depSched && depActual) {
+      const schedMs = new Date(depSched).getTime();
+      const actualMs = new Date(depActual).getTime();
+      if (!isNaN(schedMs) && !isNaN(actualMs)) {
+        delayMin = Math.round((actualMs - schedMs) / 60000);
+      }
+    }
+
+    // Determine status
+    let status = f.status || 'unknown';
+    if (typeof status === 'string') status = status.toLowerCase();
+
+    return {
+      flightNumber: f.flight_iata || f.flight_number?.iata || f.callsign || '',
+      origin: f.origin?.iata || f.airport?.origin?.code?.iata || '',
+      destination: f.destination?.iata || f.airport?.destination?.code?.iata || '',
+      status,
+      departure: { scheduled: depSched, actual: depActual },
+      arrival: { scheduled: arrSched, actual: arrActual, estimated: arrEst },
+      delayMin,
+    };
+  })
+  .filter(s => s.origin && s.destination) // Drop segments with missing airports
+  .sort((a, b) => {
+    // Sort by departure time descending (most recent first)
+    const tA = new Date(a.departure.actual || a.departure.scheduled || 0).getTime();
+    const tB = new Date(b.departure.actual || b.departure.scheduled || 0).getTime();
+    return tB - tA;
+  })
+  .slice(0, 5); // Return up to 5 segments
+}
+
+export default async function handler(req, res) {
+  const origin = req.headers?.origin || '';
+  const allowed = origin === 'https://theblueboard.co' || /^http:\/\/localhost(:\d+)?$/.test(origin);
+  res.setHeader('Access-Control-Allow-Origin', allowed ? origin : 'https://theblueboard.co');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') return res.status(204).end();
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' });
+
+  if (!process.env.FR24_API_TOKEN) {
+    return res.status(500).json({ success: false, error: 'FR24 API not configured' });
+  }
+
+  const reg = (req.query.reg || '').trim().toUpperCase().replace('-', '');
+  if (!reg || !/^[A-Z0-9]{4,8}$/.test(reg)) {
+    return res.status(400).json({ success: false, error: 'Invalid registration format' });
+  }
+
+  // Check cache
+  const cacheKey = `history:${reg}`;
+  const cached = getCached(cacheKey);
+  if (cached) {
+    res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate=600');
+    return res.status(200).json({ ...cached, cached: true });
+  }
+
+  if (isRateLimited(req)) {
+    return res.status(429).json({ success: false, error: 'Rate limited — try again shortly' });
+  }
+
+  try {
+    const now = new Date();
+    const from = new Date(now.getTime() - 36 * 60 * 60 * 1000); // 36h ago
+    const to = new Date(now.getTime() + 6 * 60 * 60 * 1000); // 6h ahead
+
+    const url = new URL(FR24_BASE + SUMMARY_PATH);
+    url.searchParams.set('regs', reg);
+    url.searchParams.set('flight_datetime_from', from.toISOString());
+    url.searchParams.set('flight_datetime_to', to.toISOString());
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 15000);
+
+    const resp = await fetch(url.toString(), {
+      signal: controller.signal,
+      headers: {
+        'Authorization': `Bearer ${process.env.FR24_API_TOKEN}`,
+        'Accept': 'application/json',
+        'Accept-Version': API_VERSION,
+        'User-Agent': 'TheBlueBoardDashboard/1.0 (https://theblueboard.co)',
+      },
+    });
+    clearTimeout(timeout);
+
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => '');
+      console.error(`FR24 aircraft history error for ${reg}: status=${resp.status} ${text.slice(0, 200)}`);
+      return res.status(502).json({ success: false, error: 'FR24 API error' });
+    }
+
+    const data = await resp.json();
+    const segments = normalizeSegments(data);
+
+    const result = { success: true, reg, segments };
+    setCache(cacheKey, result);
+    res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate=600');
+    return res.status(200).json(result);
+  } catch (e) {
+    console.error('Aircraft history error:', e);
+    if (e.name === 'AbortError') return res.status(504).json({ success: false, error: 'FR24 API timeout' });
+    return res.status(502).json({ success: false, error: 'FR24 API unavailable' });
+  }
+}

--- a/api/delay-explain.js
+++ b/api/delay-explain.js
@@ -16,7 +16,8 @@ const cache = new Map();
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
 function getCacheKey(ctx) {
-  return `${ctx.flight}:${ctx.riskScore}:${(ctx.factors || []).join(',')}`;
+  const inboundKey = ctx.inbound ? ctx.inbound.slice(0, 100) : '';
+  return `${ctx.flight}:${ctx.riskScore}:${(ctx.factors || []).join(',')}:${inboundKey}`;
 }
 
 export default async function handler(req, res) {
@@ -50,7 +51,7 @@ export default async function handler(req, res) {
       return res.status(200).json({ explanation: cached.text, cached: true });
     }
 
-    // Build token-efficient prompt (~200-300 input tokens)
+    // Build context prompt with aircraft journey chain
     const lines = [
       `Flight: ${ctx.flight} (${ctx.route || 'unknown route'})`,
       `Status: ${ctx.status || 'scheduled'}`,
@@ -61,12 +62,12 @@ export default async function handler(req, res) {
     }
     if (ctx.otp) lines.push(`Hub on-time performance: ${ctx.otp}%`);
     if (ctx.weather) lines.push(`Weather conditions: ${ctx.weather}`);
-    if (ctx.inbound) lines.push(`Inbound aircraft: ${ctx.inbound}`);
+    if (ctx.inbound) lines.push(`Aircraft journey: ${ctx.inbound}`);
 
     const message = await getClient().messages.create({
       model: 'claude-haiku-4-5-20251001',
-      max_tokens: 200,
-      system: `You are an independent flight delay analyst for The Blue Board, a third-party United Airlines flight tracker. You are NOT United Airlines — never say "we" or "our" when referring to the airline. Refer to United Airlines in the third person. Give a concise, helpful explanation (3-4 sentences) of the delay situation. Be specific about causes and what the passenger should realistically expect. Write in plain text only — no markdown, no headers, no bold, no bullet points.`,
+      max_tokens: 280,
+      system: `You are an expert flight operations analyst for The Blue Board, a third-party United Airlines flight tracker. You are NOT United Airlines — never say "we" or "our" when referring to the airline. Analyze the delay risk like a seasoned frequent flyer would. Prioritize inbound aircraft routing patterns and delay propagation over generic observations — if the aircraft has been running late across multiple segments, explain the snowball effect and what it means for this flight. If turnaround time is tight, say so directly with specifics. Give actionable insight in 3-5 sentences. Be specific about this flight's situation, not generic. Write in plain text only — no markdown, no headers, no bold, no bullet points.`,
       messages: [{ role: 'user', content: lines.join('\n') }],
     });
 

--- a/public/index.html
+++ b/public/index.html
@@ -362,6 +362,19 @@ main{flex:1;min-height:0;display:flex;flex-direction:column;overflow:hidden}
 .mf-value{font-size:12px;color:var(--ua-text);font-family:var(--mono)}
 .mf-inbound{background:rgba(0,93,170,.08);border:1px solid rgba(0,93,170,.15);border-radius:4px;padding:8px 10px;font-size:11px}
 .mf-inbound-title{font-size:9px;color:var(--ua-blue);text-transform:uppercase;letter-spacing:.5px;margin-bottom:4px;font-weight:700}
+.mf-journey{background:rgba(0,93,170,.06);border:1px solid rgba(0,93,170,.12);border-radius:6px;padding:10px 12px;font-size:11px;margin-top:6px}
+.mf-journey-title{font-size:9px;color:var(--ua-blue);text-transform:uppercase;letter-spacing:.5px;margin-bottom:8px;font-weight:700}
+.mf-journey-seg{display:flex;align-items:center;gap:8px;padding:4px 0;border-left:2px solid var(--ua-border);padding-left:10px;margin-left:4px;position:relative}
+.mf-journey-seg::before{content:'';position:absolute;left:-5px;top:50%;transform:translateY(-50%);width:8px;height:8px;border-radius:50%;background:var(--ua-border)}
+.mf-journey-seg.current{border-left-color:var(--ua-blue)}.mf-journey-seg.current::before{background:var(--ua-blue)}
+.mf-journey-seg.landed::before{background:#22c55e}
+.mf-journey-seg.airborne::before{background:#3b82f6}
+.mf-journey-flt{font-weight:700;color:var(--ua-accent);min-width:48px;font-family:var(--mono);font-size:10px}
+.mf-journey-route{color:var(--ua-text);min-width:70px;font-size:10px}
+.mf-journey-delay{font-weight:600;font-size:10px;font-family:var(--mono)}
+.mf-journey-delay.on-time{color:#22c55e}.mf-journey-delay.minor{color:#f59e0b}.mf-journey-delay.major{color:#ef4444}
+.mf-journey-status{color:var(--ua-muted);font-size:9px;margin-left:auto}
+.mf-journey-loading{color:var(--ua-muted);font-size:10px;padding:4px 0}
 .mf-weather-row{display:grid;grid-template-columns:1fr 1fr;gap:8px}
 .mf-weather-cell{background:rgba(15,23,41,.5);border:1px solid var(--ua-border);border-radius:4px;padding:6px 8px;font-size:10px}
 .mf-weather-code{font-weight:700;font-family:var(--mono)}
@@ -4841,6 +4854,7 @@ function updateHubHealth() {
 let faaDelayIndex = {};
 let weatherOpsByHub = {};  // Global METAR-derived ops impact per hub — populated by initWeatherTab()
 let irropsHubData = {};    // Global IRROPS cancellation/delay rates per hub — for delay risk engine
+let aircraftJourneyCache = {};  // { reg: { segments, ts } } — aircraft history cache (5min TTL)
 
 function updateIrrops() {
   const content = document.getElementById('irrops-content');
@@ -5186,6 +5200,15 @@ async function renderMyFlights() {
   container.innerHTML = flights.map((w, i) => buildMyFlightCard(w, timeData[i])).join('');
   detectAndRenderConnections(flights, timeData);
 
+  // Async: fetch aircraft journey chains for watched flights (non-blocking)
+  flights.forEach((w, i) => {
+    const td2 = timeData[i];
+    const reg2 = td2 ? (td2.aircraft || '').replace('-', '') : null;
+    if (!reg2) return;
+    const route2 = (w.route || '').split(/[→\-]/);
+    fetchAircraftJourney(reg2, w.flight, (route2[0] || '').trim(), (route2[1] || '').trim());
+  });
+
   // Start countdown ticker
   if (myFlightsCountdownInterval) clearInterval(myFlightsCountdownInterval);
   myFlightsCountdownInterval = setInterval(updateMyFlightsCountdowns, 1000);
@@ -5215,6 +5238,115 @@ function resolveFlightStatus(td, liveFlight) {
     if (diffMin >= 15) return 'delayed';
   }
   return 'scheduled';
+}
+
+// ═══ AIRCRAFT JOURNEY CHAIN ═══
+
+function buildJourneyChainHtml(reg, segments, myFlight, origCode, destCode) {
+  // Filter out our own flight, show prior segments (most recent last for visual timeline)
+  const priorSegs = segments
+    .filter(s => s.flightNumber !== myFlight)
+    .slice(0, 3)
+    .reverse(); // chronological order (oldest first)
+
+  if (!priorSegs.length) return '';
+
+  let html = '<div class="mf-journey">';
+  html += '<div class="mf-journey-title">Aircraft Journey (' + escapeHtml(reg) + ')</div>';
+
+  priorSegs.forEach(function(seg) {
+    var delay = seg.delayMin;
+    var delayCls = delay === null ? '' : delay <= 5 ? 'on-time' : delay <= 45 ? 'minor' : 'major';
+    var delayText = delay === null ? '' : delay <= 0 ? 'On time' : '+' + delay + 'min';
+    var statusLower = (seg.status || '').toLowerCase();
+    var isAirborne = statusLower === 'en-route' || statusLower === 'airborne' || statusLower === 'en route';
+    var isLanded = statusLower === 'landed' || statusLower === 'arrived';
+    var segCls = isAirborne ? 'airborne' : isLanded ? 'landed' : '';
+    var statusText = isAirborne ? 'Airborne' : isLanded ? 'Landed' : seg.status || '';
+
+    html += '<div class="mf-journey-seg ' + segCls + '">';
+    html += '<span class="mf-journey-flt">' + escapeHtml(seg.flightNumber) + '</span>';
+    html += '<span class="mf-journey-route">' + escapeHtml(seg.origin) + ' \u2192 ' + escapeHtml(seg.destination) + '</span>';
+    if (delayText) html += '<span class="mf-journey-delay ' + delayCls + '">' + escapeHtml(delayText) + '</span>';
+    html += '<span class="mf-journey-status">' + escapeHtml(statusText) + '</span>';
+    html += '</div>';
+  });
+
+  // Show current flight at the bottom
+  html += '<div class="mf-journey-seg current">';
+  html += '<span class="mf-journey-flt">' + escapeHtml(myFlight) + '</span>';
+  html += '<span class="mf-journey-route">' + escapeHtml(origCode) + ' \u2192 ' + escapeHtml(destCode) + '</span>';
+  html += '<span class="mf-journey-delay">Your flight</span>';
+  html += '</div>';
+
+  html += '</div>';
+  return html;
+}
+
+function buildJourneyContextStr(reg, segments, myFlight, origCode, destCode) {
+  var priorSegs = segments
+    .filter(function(s) { return s.flightNumber !== myFlight; })
+    .slice(0, 3)
+    .reverse();
+
+  if (!priorSegs.length) return '';
+
+  var lines = ['Aircraft ' + reg + ' journey today:'];
+  priorSegs.forEach(function(seg, i) {
+    var delay = seg.delayMin;
+    var delayStr = delay === null ? 'unknown delay' : delay <= 0 ? 'on time' : 'departed ' + delay + 'min late';
+    var statusLower = (seg.status || '').toLowerCase();
+    var statusStr = statusLower === 'en-route' || statusLower === 'airborne' || statusLower === 'en route'
+      ? ', currently airborne'
+      : statusLower === 'landed' || statusLower === 'arrived' ? ', landed' : '';
+    lines.push('Seg ' + (i + 1) + ': ' + seg.flightNumber + ' ' + seg.origin + '\u2192' + seg.destination + ', ' + delayStr + statusStr);
+  });
+
+  // Summary
+  var delays = priorSegs.map(function(s) { return s.delayMin; }).filter(function(d) { return d !== null && d > 0; });
+  if (delays.length > 0) {
+    var avg = Math.round(delays.reduce(function(a, b) { return a + b; }, 0) / delays.length);
+    lines.push('Your flight ' + myFlight + ' ' + origCode + '\u2192' + destCode + ' \u2014 aircraft averaging +' + avg + 'min delays across ' + delays.length + ' prior segment' + (delays.length > 1 ? 's' : ''));
+  }
+
+  return lines.join('\n');
+}
+
+async function fetchAircraftJourney(reg, myFlight, origCode, destCode) {
+  if (!reg) return;
+
+  // Check cache
+  var cached = aircraftJourneyCache[reg];
+  if (cached && Date.now() - cached.ts < 300000) return; // 5min TTL
+
+  try {
+    var resp = await fetch('/api/aircraft-history?reg=' + encodeURIComponent(reg));
+    if (!resp.ok) return;
+    var data = await resp.json();
+    if (!data.success || !data.segments) return;
+
+    aircraftJourneyCache[reg] = { segments: data.segments, ts: Date.now() };
+
+    // Update the journey chain UI in the card
+    var container = document.getElementById('journey-' + reg);
+    if (container && data.segments.length > 0) {
+      container.innerHTML = buildJourneyChainHtml(reg, data.segments, myFlight, origCode, destCode);
+
+      // Also update the data-inbound attribute on any risk badges/buttons for this flight
+      var richInbound = buildJourneyContextStr(reg, data.segments, myFlight, origCode, destCode);
+      if (richInbound) {
+        document.querySelectorAll('[data-action="explain-delay"][data-flight="' + myFlight + '"]').forEach(function(el) {
+          el.dataset.inbound = richInbound;
+        });
+      }
+    } else if (container) {
+      container.innerHTML = ''; // No history available — remove loading placeholder
+    }
+  } catch (e) {
+    // Silently fail — journey chain is supplementary
+    var c = document.getElementById('journey-' + reg);
+    if (c) c.innerHTML = '';
+  }
 }
 
 function buildMyFlightCard(watched, td) {
@@ -5308,7 +5440,7 @@ function buildMyFlightCard(watched, td) {
 
   // Equipment
   let equipHtml = '';
-  const reg = liveFlight ? liveFlight.reg?.replace('-','') : null;
+  const reg = liveFlight ? liveFlight.reg?.replace('-','') : (td && td.aircraft ? td.aircraft.replace('-','') : null);
   if (reg && FLEET_BY_REG[reg]) {
     const ac = FLEET_BY_REG[reg];
     const isStar = STARLINK_TAILS.has(reg);
@@ -5321,21 +5453,37 @@ function buildMyFlightCard(watched, td) {
     equipHtml = `<div><span class="mf-label">Aircraft</span><div class="mf-value">${escapeHtml(td.aircraft)}</div></div>`;
   }
 
-  // Inbound aircraft tracking ("Where's my plane?")
+  // Inbound aircraft tracking + journey chain
   let inboundHtml = '';
   let inboundStr = '';
-  if (reg && liveFlight && !liveFlight.onGround) {
-    // The flight itself is airborne — show its own position
-  } else if (reg) {
-    // Find this registration operating a DIFFERENT flight heading to our origin
-    const inbound = allFlights.find(f => f.reg?.replace('-','') === reg && f.flightIATA !== watched.flight && f.dest === origCode && !f.onGround);
-    if (inbound) {
+  if (reg) {
+    // Find this registration operating a DIFFERENT flight heading to our origin (only when our flight isn't airborne)
+    var inbound = null;
+    if (!(liveFlight && !liveFlight.onGround)) {
+      inbound = allFlights.find(f => f.reg?.replace('-','') === reg && f.flightIATA !== watched.flight && f.dest === origCode && !f.onGround);
+      if (inbound) {
+        const inbCity = IATA_CITIES[inbound.origin] || inbound.origin;
+        inboundStr = inbound.flightIATA + ' from ' + inbCity + ' (' + inbound.origin + '), airborne';
+      }
+    }
+    // Check if we already have cached journey data for richer inbound context
+    const cached = aircraftJourneyCache[reg];
+    if (cached && cached.segments && cached.segments.length > 0 && Date.now() - cached.ts < 300000) {
+      inboundHtml = buildJourneyChainHtml(reg, cached.segments, watched.flight, origCode, destCode);
+      inboundStr = buildJourneyContextStr(reg, cached.segments, watched.flight, origCode, destCode);
+    } else if (inbound) {
       const inbCity = IATA_CITIES[inbound.origin] || inbound.origin;
-      inboundStr = inbound.flightIATA + ' from ' + inbCity + ' (' + inbound.origin + '), airborne';
       inboundHtml = `<div class="mf-inbound">
         <div class="mf-inbound-title">Where's My Plane?</div>
-        Your aircraft is currently operating <strong>${escapeHtml(inbound.flightIATA)}</strong> from ${escapeHtml(inbCity)} (${escapeHtml(inbound.origin)}) → ${escapeHtml(origCity)} (${escapeHtml(origCode)}) at ${Math.round(inbound.alt * 3.28084).toLocaleString()}ft
+        Your aircraft is currently operating <strong>${escapeHtml(inbound.flightIATA)}</strong> from ${escapeHtml(inbCity)} (${escapeHtml(inbound.origin)}) \u2192 ${escapeHtml(origCity)} (${escapeHtml(origCode)}) at ${Math.round(inbound.alt * 3.28084).toLocaleString()}ft
       </div>`;
+    }
+    // Placeholder for async journey chain load
+    if (!inboundHtml && reg) {
+      inboundHtml = `<div class="mf-journey" id="journey-${escapeHtml(reg)}"><div class="mf-journey-loading">Loading aircraft journey\u2026</div></div>`;
+    } else if (inboundHtml && reg) {
+      // Wrap existing html with an ID for async update
+      inboundHtml = `<div id="journey-${escapeHtml(reg)}">${inboundHtml}</div>`;
     }
   }
 
@@ -5599,6 +5747,15 @@ function computeDelayRisk(watched, origHub, destHub, timeData, liveFlight) {
             score += 5; factors.push('Inbound still at cruise altitude');
           }
         }
+      }
+    }
+    // 7e: Accumulated delay across prior segments (from journey chain)
+    if (reg && aircraftJourneyCache[reg] && aircraftJourneyCache[reg].segments) {
+      var priorSegs = aircraftJourneyCache[reg].segments.filter(function(s) { return s.flightNumber !== watched.flight; });
+      var lateSegs = priorSegs.filter(function(s) { return s.delayMin !== null && s.delayMin > 15; });
+      if (lateSegs.length >= 2) {
+        var avgDelay = Math.round(lateSegs.reduce(function(a, s) { return a + s.delayMin; }, 0) / lateSegs.length);
+        factors.push('Aircraft running late all day (avg +' + avgDelay + 'min across ' + lateSegs.length + ' segments)');
       }
     }
   }

--- a/tests/irrops.test.js
+++ b/tests/irrops.test.js
@@ -389,3 +389,100 @@ describe('getStartOfDayForHub', () => {
     expect(typeof ts).toBe('number');
   });
 });
+
+// ═══ AIRCRAFT HISTORY TESTS ═══
+import { normalizeSegments } from '../api/aircraft-history.js';
+
+describe('normalizeSegments', () => {
+  it('normalizes FR24 summary data into segments with delay calculation', () => {
+    const data = {
+      data: [
+        {
+          flight_iata: 'UA302',
+          origin: { iata: 'SFO' },
+          destination: { iata: 'ORD' },
+          status: 'landed',
+          departure: { scheduled: '2026-03-10T10:00:00Z', actual: '2026-03-10T10:42:00Z' },
+          arrival: { scheduled: '2026-03-10T14:00:00Z', actual: '2026-03-10T14:38:00Z' },
+        },
+      ],
+    };
+    const segs = normalizeSegments(data);
+    expect(segs).toHaveLength(1);
+    expect(segs[0].flightNumber).toBe('UA302');
+    expect(segs[0].origin).toBe('SFO');
+    expect(segs[0].destination).toBe('ORD');
+    expect(segs[0].delayMin).toBe(42);
+    expect(segs[0].status).toBe('landed');
+  });
+
+  it('filters out segments with missing airport data', () => {
+    const data = {
+      data: [
+        { flight_iata: 'UA1', origin: { iata: 'SFO' }, destination: { iata: 'ORD' }, status: 'landed',
+          departure: { scheduled: '2026-03-10T10:00:00Z' }, arrival: {} },
+        { flight_iata: 'UA2', origin: {}, destination: { iata: 'LAX' }, status: 'landed',
+          departure: { scheduled: '2026-03-10T11:00:00Z' }, arrival: {} },
+      ],
+    };
+    const segs = normalizeSegments(data);
+    expect(segs).toHaveLength(1);
+    expect(segs[0].flightNumber).toBe('UA1');
+  });
+
+  it('sorts by departure time descending and limits to 5', () => {
+    const data = { data: [] };
+    for (let i = 0; i < 8; i++) {
+      data.data.push({
+        flight_iata: 'UA' + (100 + i),
+        origin: { iata: 'SFO' },
+        destination: { iata: 'ORD' },
+        status: 'landed',
+        departure: { scheduled: new Date(Date.now() - (i * 3600000)).toISOString() },
+        arrival: {},
+      });
+    }
+    const segs = normalizeSegments(data);
+    expect(segs).toHaveLength(5);
+    // Most recent should be first
+    expect(segs[0].flightNumber).toBe('UA100');
+  });
+
+  it('handles null/missing delay gracefully', () => {
+    const data = {
+      data: [
+        {
+          flight_iata: 'UA500',
+          origin: { iata: 'DEN' },
+          destination: { iata: 'EWR' },
+          status: 'en-route',
+          departure: { scheduled: '2026-03-10T12:00:00Z' },
+          arrival: { estimated: '2026-03-10T16:30:00Z' },
+        },
+      ],
+    };
+    const segs = normalizeSegments(data);
+    expect(segs[0].delayMin).toBeNull(); // No actual departure → can't compute delay
+  });
+
+  it('returns empty array for empty data', () => {
+    expect(normalizeSegments({})).toEqual([]);
+    expect(normalizeSegments({ data: [] })).toEqual([]);
+    expect(normalizeSegments(null)).toEqual([]);
+  });
+
+  it('computes negative delay for early departures', () => {
+    const data = {
+      data: [{
+        flight_iata: 'UA999',
+        origin: { iata: 'IAH' },
+        destination: { iata: 'LAX' },
+        status: 'landed',
+        departure: { scheduled: '2026-03-10T15:00:00Z', actual: '2026-03-10T14:55:00Z' },
+        arrival: { scheduled: '2026-03-10T17:00:00Z', actual: '2026-03-10T16:50:00Z' },
+      }],
+    };
+    const segs = normalizeSegments(data);
+    expect(segs[0].delayMin).toBe(-5); // 5 minutes early
+  });
+});


### PR DESCRIPTION
Track tail numbers across 2-3 prior flight segments to detect delay accumulation patterns ("snowball effect"), like an expert flyer would.

Changes:
- New /api/aircraft-history.js: queries FR24 flight-summary by registration to get recent segments with delay data (36h window, 5min cache)
- Journey chain UI: dedicated "Aircraft Journey" section in My Flights cards showing each prior segment's route, delay, and status with color coding
- Async loading: journey data fetched non-blocking after card render, cached client-side for 5 minutes
- Signal 7 enrichment: adds "Aircraft running late all day" factor when 2+ prior segments were >15min late, giving AI much richer context
- AI upgrade: new expert-level system prompt focused on operational analysis and delay propagation patterns; max_tokens 200→280; context now includes full aircraft journey chain instead of one-line inbound string
- Cache key updated to include inbound context for varied explanations
- 6 new tests for aircraft-history normalizeSegments (82 total, all passing)