### PR TITLE
Handle empty FR24 schedule payloads without false upstream errors

### DIFF
--- a/api/schedule.js
+++ b/api/schedule.js
@@ -116,8 +116,20 @@ async function fetchOnePage(hub, dir, timestamp, page, deadlineMs) {
       const resp = await fetchWithTimeout(url, deadlineMs);
       if (resp.ok) {
         const data = await resp.json();
-        const sched = data?.result?.response?.airport?.pluginData?.schedule?.[dir];
-        if (!sched) return null;
+        const airportData = data?.result?.response?.airport;
+        const sched = airportData?.pluginData?.schedule?.[dir];
+        // FR24 can return a successful airport payload with no schedule block
+        // (common for lightly published future dates). Treat as an empty page,
+        // not an upstream outage.
+        if (!sched) {
+          if (airportData) {
+            return {
+              page: { current: page, total: 1 },
+              data: []
+            };
+          }
+          return null;
+        }
         return sched;
       }
       // Retry on transient FR24 errors (including 403 — FR24 uses it for rate limiting)

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import handler from '../api/schedule.js';
+
+function createRes() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: null,
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+describe('schedule API', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    delete process.env.FR24_API_TOKEN;
+  });
+
+  it('treats missing schedule block as empty data instead of upstream failure', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        result: {
+          response: {
+            airport: {
+              pluginData: {}
+            }
+          }
+        }
+      })
+    });
+
+    const ts = Math.floor(Date.now() / 1000);
+    const req = {
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'LAX', dir: 'departures', timestamp: String(ts) }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+    expect(res.body.partial).toBe(false);
+    expect(res.body.total).toBe(0);
+    expect(res.body.meta.partialReason).toBe(null);
+  });
+});


### PR DESCRIPTION
### Motivation
- FR24 can return a successful airport payload that omits the `schedule` block for some dates, which the backend was interpreting as an upstream outage and caused the UI to show "The upstream data source is not responding" and `0% loaded`.
- Treating these sparse responses as a valid empty page avoids misleading error states and improves UX for lightly-published or future dates.

### Description
- Update `fetchOnePage` in `api/schedule.js` to detect a present `airport` payload with no `pluginData.schedule` and return an empty page object (`{ page: { current, total: 1 }, data: [] }`) instead of `null` so it is treated as a valid empty result rather than an upstream failure.
- Preserve existing behavior where genuinely missing `airport` or failed responses still return `null` or appropriate error sentinels like `_rateLimited`.
- Add a regression test `tests/schedule.test.js` that mocks the FR24 response shape with `pluginData: {}` and asserts the handler returns `200` with `partial: false`, `total: 0`, and `meta.partialReason === null`.

### Testing
- Ran the new test file via `npm test -- tests/schedule.test.js` and it passed.
- Ran the full test suite with `npm test` and all tests passed (`6 files, 83 tests` all green).
- Started the dev server and captured an app screenshot to validate the UI; the server started successfully and the screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af698f1740832fbbc27ffc103ed328)