### PR TITLE
Improve schedule resilience with recent complete-data fallback

### DIFF
--- a/api/schedule.js
+++ b/api/schedule.js
@@ -72,6 +72,40 @@ function getLastComplete(key) {
   return entry;
 }
 
+function getRecentCompleteForHubDir(hub, dir, requestedTs) {
+  const reqHub = String(hub || '').toUpperCase();
+  const reqDir = String(dir || '').toLowerCase();
+  let best = null;
+
+  for (const [key, entry] of lastCompleteCache.entries()) {
+    if (!entry || (Date.now() - entry.time > COMPLETE_CACHE_MAX_AGE)) {
+      lastCompleteCache.delete(key);
+      continue;
+    }
+
+    const parts = key.split(':');
+    if (parts.length !== 4 || parts[0] !== 'agg') continue;
+    const [, keyHub, keyDir, keyTsRaw] = parts;
+    if (keyHub.toUpperCase() !== reqHub || keyDir !== reqDir) continue;
+
+    const keyTs = parseInt(keyTsRaw, 10);
+    if (Number.isNaN(keyTs)) continue;
+
+    // Prefer same-day complete snapshot first, then closest timestamp.
+    const sameDay = Math.abs(keyTs - requestedTs) < 86400;
+    const tsDistance = Math.abs(keyTs - requestedTs);
+
+    if (!best ||
+      (sameDay && !best.sameDay) ||
+      (sameDay === best.sameDay && tsDistance < best.tsDistance) ||
+      (sameDay === best.sameDay && tsDistance === best.tsDistance && entry.time > best.entry.time)) {
+      best = { entry, keyTs, sameDay, tsDistance };
+    }
+  }
+
+  return best;
+}
+
 function cacheSet(key, data, ttlMs) {
   if (cache.size >= MAX_CACHE_SIZE) {
     const firstKey = cache.keys().next().value;
@@ -645,6 +679,24 @@ export default async function handler(req, res) {
       });
     }
 
+    // Broader fallback: use the most recent complete dataset for the same hub/dir
+    // (helps when a new day has no fresh cache yet and upstream briefly fails).
+    const recentComplete = getRecentCompleteForHubDir(hub, dir, ts);
+    if (recentComplete) {
+      triggerBackgroundRefresh(hub, dir, ts, aggKey, ttl);
+      const dataAge = Math.round((Date.now() - recentComplete.entry.time) / 1000);
+      const fallbackDeltaMin = Math.round(Math.abs(ts - recentComplete.keyTs) / 60);
+      res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
+      return res.status(200).json({ ...recentComplete.entry.data, cached: true, stale: true, degraded: true,
+        meta: {
+          ...recentComplete.entry.data.meta,
+          dataAge,
+          fallbackTimestamp: recentComplete.keyTs,
+          fallbackDeltaMin
+        }
+      });
+    }
+
     // Dedup concurrent aggregation requests
     if (pendingAggs.has(aggKey)) {
       const result = await pendingAggs.get(aggKey);
@@ -672,6 +724,21 @@ export default async function handler(req, res) {
           res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
           return res.status(200).json({ ...lc.data, cached: true, stale: true, degraded: true,
             meta: { ...lc.data.meta, dataAge }
+          });
+        }
+
+        const recentComplete = getRecentCompleteForHubDir(hub, dir, ts);
+        if (recentComplete) {
+          const dataAge = Math.round((Date.now() - recentComplete.entry.time) / 1000);
+          const fallbackDeltaMin = Math.round(Math.abs(ts - recentComplete.keyTs) / 60);
+          res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
+          return res.status(200).json({ ...recentComplete.entry.data, cached: true, stale: true, degraded: true,
+            meta: {
+              ...recentComplete.entry.data.meta,
+              dataAge,
+              fallbackTimestamp: recentComplete.keyTs,
+              fallbackDeltaMin
+            }
           });
         }
       }

--- a/public/index.html
+++ b/public/index.html
@@ -4148,7 +4148,12 @@ async function loadScheduleData() {
       let msg = '';
       if (result.degraded && meta.dataAge) {
         const ageMin = Math.round(meta.dataAge / 60);
-        msg = `Showing cached complete data from ${ageMin}m ago while refreshing.`;
+        if (meta.fallbackDeltaMin) {
+          const fallbackHours = Math.round(meta.fallbackDeltaMin / 60);
+          msg = `Showing cached complete data from ${ageMin}m ago (${fallbackHours}h from selected day) while refreshing.`;
+        } else {
+          msg = `Showing cached complete data from ${ageMin}m ago while refreshing.`;
+        }
       } else if (meta.partialReason === 'deadline_exceeded') {
         msg = 'The request timed out before all pages were fetched.';
       } else if (meta.partialReason === 'first_page_failed') {


### PR DESCRIPTION
### Motivation
- Prevent the schedule view from hard-failing when FR24 page 1 or upstream fetches transiently fail and no exact-day complete cache exists (results in "upstream data source is not responding / 0% loaded").
- Serve the best available complete dataset for the same hub + direction to keep the UI populated while background refresh retries continue.

### Description
- Added `getRecentCompleteForHubDir(hub, dir, requestedTs)` to `api/schedule.js` which scans `lastCompleteCache` and selects the most appropriate recent complete snapshot for the same hub/dir, preferring same-day snapshots and then closest timestamps.
- Used this broader fallback before dedup/aggregation and after a partial fresh aggregation to return a degraded but complete payload when an exact-key complete snapshot is missing (keeps previous exact-key fallback intact).
- Included fallback metadata fields `fallbackTimestamp` and `fallbackDeltaMin` in the degraded payload `meta` so callers can surface how far the fallback data is from the requested day.
- Updated `public/index.html` schedule UI message to show the distance (hours) from the selected day when fallback data is being used.

### Testing
- Ran `npm test` (Vitest): all test files passed (5 test files, 82 tests) and the test run completed successfully.
- Attempted `npm test -- --runInBand` which failed due to Vitest not recognizing `--runInBand`, this was a command misuse and not a test regression.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af698f1740832fbbc27ffc103ed328)