### PR TITLE
Improve schedule tab resiliency for upstream 503 errors

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4063,8 +4063,17 @@ async function fetchScheduleAggregated(hub, dir, timestamp) {
   try {
     const resp = await fetch(url, { signal: controller.signal });
     clearTimeout(timeout);
-    if (!resp.ok) throw new Error(`Schedule API ${resp.status}`);
-    const data = await resp.json();
+    let data = null;
+    try {
+      data = await resp.json();
+    } catch (parseErr) {
+      data = null;
+    }
+    if (!resp.ok) {
+      const upstreamMsg = typeof data?.error === 'string' ? data.error : '';
+      const msg = upstreamMsg ? `${upstreamMsg} (${resp.status})` : `Schedule API ${resp.status}`;
+      throw new Error(msg);
+    }
     if (data.error) throw new Error(data.error);
     if (!data.partial) schedCache[cacheKey] = data;
     return data;
@@ -4073,6 +4082,20 @@ async function fetchScheduleAggregated(hub, dir, timestamp) {
     if (e.name === 'AbortError') throw new Error('Schedule request timed out');
     throw e;
   }
+}
+
+function formatScheduleLoadErrorMessage(err) {
+  const msg = String(err?.message || '').toLowerCase();
+  if (msg.includes('timed out') || msg.includes('timeout')) {
+    return 'Schedule data source timed out. Try again in a moment.';
+  }
+  if (msg.includes(' 503') || msg.includes('api 503') || msg.includes('service unavailable')) {
+    return 'Schedule provider is temporarily unavailable (503). Retrying shortly usually works.';
+  }
+  if (msg.includes(' 502') || msg.includes('upstream')) {
+    return 'Schedule provider is temporarily unavailable. Please try again in a moment.';
+  }
+  return 'Error loading schedule data. Please try again in a moment.';
 }
 
 function classifySchedStatus(flight) {
@@ -4200,7 +4223,18 @@ async function loadScheduleData() {
     checkWatchedFlightChanges(allUAFlights);
   } catch (err) {
     console.error('Schedule load error:', err);
-    loadEl.innerHTML = `<div style="font-size:24px;margin-bottom:8px">⚠️</div>Error loading schedule: ${escapeHtml(err.message)}<br><span style="font-size:10px">Try again in a moment</span><br><button onclick="loadScheduleData()" style="margin-top:8px;padding:4px 12px;background:var(--ua-blue);color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:11px">↻ Retry</button>`;
+    const friendlyMsg = formatScheduleLoadErrorMessage(err);
+    loadEl.innerHTML = `<div style="font-size:24px;margin-bottom:8px">⚠️</div>${escapeHtml(friendlyMsg)}<br><span style="font-size:10px">Technical details: ${escapeHtml(err?.message || 'unknown error')}</span><br><button onclick="loadScheduleData()" style="margin-top:8px;padding:4px 12px;background:var(--ua-blue);color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:11px">↻ Retry</button>`;
+
+    const hubKey = `${schedCurrentHub}-${schedCurrentDir}-${schedCurrentDay}`;
+    const fallbackFlights = schedRawByHub[hubKey];
+    if (Array.isArray(fallbackFlights) && fallbackFlights.length) {
+      schedAllFlights = fallbackFlights;
+      tableWrap.style.display = 'block';
+      renderScheduleTable();
+      renderScheduleStats();
+      loadEl.innerHTML = `<div style="padding:8px 12px;background:rgba(234,179,8,.12);border:1px solid rgba(234,179,8,.3);border-radius:4px;font-size:11px;color:#eab308;margin-bottom:8px">⚠️ ${escapeHtml(friendlyMsg)} Showing last loaded schedule snapshot (${fallbackFlights.length} flights). <button onclick="loadScheduleData()" style="background:none;border:none;color:var(--ua-accent);cursor:pointer;font-family:var(--font-ui);font-size:11px;text-decoration:underline">↻ Retry</button></div>`;
+    }
   } finally {
     schedLoading = false;
     btn.disabled = false;


### PR DESCRIPTION
### Motivation
- The Schedule tab showed raw upstream errors (e.g. `Schedule API 503`) and could fail hard when FR24 returned transient 502/503 responses or non-JSON payloads, leaving the tab unusable.
- Provide clearer, actionable messaging and make the UI resilient to transient upstream failures by surfacing last-known schedule snapshots.

### Description
- Made `fetchScheduleAggregated` JSON parsing defensive so non-JSON responses don't crash the client and included upstream error text when present instead of only `Schedule API <status>` (in `public/index.html`).
- Added `formatScheduleLoadErrorMessage()` to convert common failure modes (timeouts, 502/503, generic upstream failures) into friendlier user-facing strings.
- Updated `loadScheduleData()` error handling to show a friendly message with technical details, and to render the last successful snapshot from `schedRawByHub` for the current `hub/dir/day` when available so the tab remains usable.
- These changes are UI-side only and keep existing cache/fallback semantics intact.

### Testing
- Ran `npm test` which executed the Vitest suite and passed all tests (`6 files`, `84 tests` passed).
- Running `npm test -- --runInBand` failed because Vitest does not accept the `--runInBand` option in this environment.
- Attempted a Playwright-based page check which crashed the headless Chromium process (SIGSEGV) so no browser screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af74a88388832f9d1120004375050b)