### PR TITLE
Improve Schedule tab messaging for transient API failures

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4075,6 +4075,18 @@ async function fetchScheduleAggregated(hub, dir, timestamp) {
   }
 }
 
+function getScheduleLoadErrorMessage(err) {
+  const raw = (err && err.message ? String(err.message) : '').trim();
+  if (raw === 'Schedule request timed out') return raw;
+  const apiMatch = raw.match(/^Schedule API\s+(\d{3})$/);
+  if (!apiMatch) return raw || 'Unknown error';
+  const code = Number(apiMatch[1]);
+  if (code === 503 || code === 502) return `Schedule provider is temporarily unavailable (${code})`;
+  if (code === 429) return 'Schedule provider is rate-limited right now (429)';
+  if (code === 403) return 'Schedule provider access is temporarily restricted (403)';
+  return `Schedule service error (${code})`;
+}
+
 function classifySchedStatus(flight) {
   const s = flight.status;
   if (!s) return { text: 'Unknown', cls: 'unknown', key: 'unknown' };
@@ -4200,7 +4212,8 @@ async function loadScheduleData() {
     checkWatchedFlightChanges(allUAFlights);
   } catch (err) {
     console.error('Schedule load error:', err);
-    loadEl.innerHTML = `<div style="font-size:24px;margin-bottom:8px">⚠️</div>Error loading schedule: ${escapeHtml(err.message)}<br><span style="font-size:10px">Try again in a moment</span><br><button onclick="loadScheduleData()" style="margin-top:8px;padding:4px 12px;background:var(--ua-blue);color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:11px">↻ Retry</button>`;
+    const friendlyError = getScheduleLoadErrorMessage(err);
+    loadEl.innerHTML = `<div style="font-size:24px;margin-bottom:8px">⚠️</div>Error loading schedule: ${escapeHtml(friendlyError)}<br><span style="font-size:10px">Try again in a moment</span><br><button onclick="loadScheduleData()" style="margin-top:8px;padding:4px 12px;background:var(--ua-blue);color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:11px">↻ Retry</button>`;
   } finally {
     schedLoading = false;
     btn.disabled = false;


### PR DESCRIPTION
### Motivation
- Users were seeing raw upstream error text like `Schedule API 503` in the Schedule tab, which is confusing during transient outages or rate-limits, so surface clearer, actionable messages.

### Description
- Added `getScheduleLoadErrorMessage(err)` in `public/index.html` and switched the Schedule load error UI to use this helper to map timeouts and common HTTP responses (502/503/429/403) into friendlier messages while keeping the retry button and existing behavior intact.

### Testing
- Ran unit tests with `npm test` (Vitest) and all tests passed: `Test Files 6 passed`, `Tests 84 passed`.
- Started the dev server with `npm run dev` and verified UI behavior manually, and ran a Playwright script that mocked `/api/schedule` returning `503` to confirm the new friendly message is shown (screenshot captured).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af74a88388832f9d1120004375050b)