### PR TITLE
docs: add CRON_SECRET to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ FR24_API_TOKEN=your-token-here
 
 # Google Sheets Fleet Data
 FLEET_SHEET_ID=your-sheet-id-here
+
+# Vercel Cron Secret (required for cron job auth)
+CRON_SECRET=


### PR DESCRIPTION
The Vercel cron job at /api/cron/warm-schedules returns 401 because CRON_SECRET is not set in the Vercel environment. Document the required variable so developers know to configure it.

