### PR TITLE
Fix flight schedule: broken FR24 pagination, missing hub timeouts, re…

### DIFF
--- a/api/flight-times.ts
+++ b/api/flight-times.ts
@@ -160,7 +160,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (!rawFlight) return res.status(400).json({ success: false, error: 'Missing flight parameter' });
 
   const flight = normalizeFlightNumber(rawFlight);
-  if (!/^UAL\d{1,4}[A-Z]?$/i.test(flight)) {
+  if (!/^UAL\d{1,5}[A-Z]?$/i.test(flight)) {
     return res.status(400).json({ success: false, error: 'Invalid flight number' });
   }
 

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -18,7 +18,7 @@ const BATCH_DELAY = 500; // 500ms pause between parallel batches (was 300)
 const STALE_GRACE = 120000; // serve stale data for up to 2min past expiry
 
 // Busy hubs get more time to fetch all pages (capped at 55s for Vercel's 60s maxDuration)
-const HUB_TIMEOUT_MS: Record<string, number> = { ORD: 55000, EWR: 55000, IAH: 55000, SFO: 55000 };
+const HUB_TIMEOUT_MS: Record<string, number> = { ORD: 55000, EWR: 55000, IAH: 55000, SFO: 55000, LAX: 55000, DEN: 55000, IAD: 55000 };
 
 // Global concurrency limiter for FR24 outbound requests
 const MAX_CONCURRENT_FR24 = 6;
@@ -308,7 +308,7 @@ function normalizeSummaryFlight(f: any) {
   };
 }
 
-const OFFICIAL_API_PAGE_SIZE = 100;
+const OFFICIAL_API_PAGE_SIZE = 20; // FR24 API caps at ~20 per page regardless of limit param
 
 async function fetchViaOfficialAPI(hub: string, dir: string, ts: number, timeoutMs?: number) {
   const logHub = String(hub);


### PR DESCRIPTION
…strictive flight regex

1. Fix OFFICIAL_API_PAGE_SIZE from 100 to 20 — the FR24 API caps responses at ~20 per page regardless of the limit parameter. With PAGE_SIZE=100, the pagination break condition (flights.length < 100) fires after the first page (20 < 100), returning only ~20 raw flights. For LAX departures this meant only ~3 UA flights after direction filtering. Now pagination correctly continues until the API returns fewer than 20 results.

2. Add LAX, DEN, IAD to HUB_TIMEOUT_MS — these busy hubs were missing from the timeout config, getting only 45s default instead of 55s. This gave the Official API only ~18s (40% of 45s) vs ~22s with proper timeout.

3. Expand flight-times regex from \d{1,4} to \d{1,5} — United uses some 5-digit flight numbers for codeshares/regionals, which were rejected with 400 errors, generating the api/flight-times log errors.

https://claude.ai/code/session_01HE4wX8qS4BS4VKydYbB69b