### PR TITLE
Replace static Starlink data with live API + add flight predictions

### DIFF
--- a/api/cron/sync-starlink.ts
+++ b/api/cron/sync-starlink.ts
@@ -1,0 +1,67 @@
+// Vercel Cron Job: syncs Starlink aircraft data from unitedstarlinktracker.com
+// Writes enriched data (aircraft list, fleet stats, flights) to /tmp for edge caching
+// Config in vercel.json: { "path": "/api/cron/sync-starlink", "schedule": "0 */4 * * *" }
+
+import type { VercelRequest, VercelResponse } from '../types.js';
+
+const UPSTREAM_URL = 'https://unitedstarlinktracker.com/api/data';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  // Verify cron secret in production
+  if (process.env.CRON_SECRET && req.headers['authorization'] !== `Bearer ${process.env.CRON_SECRET}`) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 25000);
+
+    const resp = await fetch(UPSTREAM_URL, {
+      signal: controller.signal,
+      headers: { 'User-Agent': 'BlueBoard-StarlinkSync/1.0' },
+    });
+    clearTimeout(timeout);
+
+    if (!resp.ok) {
+      return res.status(502).json({ error: `Upstream returned ${resp.status}` });
+    }
+
+    const upstream = await resp.json() as {
+      totalCount: number;
+      starlinkPlanes: Array<{ tail_number: string; aircraft_type: string; fleet: string; operator: string }>;
+      lastUpdated: string;
+      fleetStats: { mainline: number; express: number; total: number };
+      flightsByTail: Record<string, Array<{ flight_number: string; origin: string; destination: string; departure_time: string }>>;
+    };
+
+    // Transform to our format: keep backwards-compatible starlink.json shape + extras
+    const aircraft = (upstream.starlinkPlanes || []).map(p => ({
+      tail: p.tail_number,
+      fleet: p.fleet || 'Express',
+      type: p.aircraft_type || 'Unknown',
+      operator: p.operator || 'United Airlines',
+    }));
+
+    const enriched = {
+      aircraft,
+      totalCount: upstream.totalCount || aircraft.length,
+      fleetStats: upstream.fleetStats || null,
+      flightsByTail: upstream.flightsByTail || {},
+      lastUpdated: upstream.lastUpdated || new Date().toISOString(),
+      syncedAt: new Date().toISOString(),
+    };
+
+    // Store in global for the /api/starlink-data endpoint to serve
+    (globalThis as any).__starlinkCache = enriched;
+
+    return res.status(200).json({
+      status: 'ok',
+      aircraft_count: aircraft.length,
+      fleet_stats: upstream.fleetStats,
+      synced_at: enriched.syncedAt,
+    });
+  } catch (err: any) {
+    console.error('Starlink sync error:', err);
+    return res.status(500).json({ error: err.message || 'Sync failed' });
+  }
+}

--- a/api/predict-flight.ts
+++ b/api/predict-flight.ts
@@ -1,0 +1,67 @@
+// Proxy endpoint for Starlink flight prediction
+// Calls upstream unitedstarlinktracker.com/api/predict-flight
+
+import type { VercelRequest, VercelResponse } from './types.js';
+
+const UPSTREAM_URL = 'https://unitedstarlinktracker.com/api/predict-flight';
+
+// Simple in-memory cache: predictions don't change frequently
+const cache = new Map<string, { data: any; ts: number }>();
+const CACHE_TTL = 30 * 60 * 1000; // 30 minutes
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const flightNumber = (req.query.flight_number as string || '').trim();
+  if (!flightNumber) {
+    return res.status(400).json({ error: 'Missing flight_number parameter' });
+  }
+
+  // Normalize: ensure UA prefix
+  const normalized = flightNumber.toUpperCase().startsWith('UA')
+    ? flightNumber.toUpperCase()
+    : 'UA' + flightNumber.replace(/^UAL/i, '');
+
+  try {
+    // Check cache
+    const cached = cache.get(normalized);
+    if (cached && Date.now() - cached.ts < CACHE_TTL) {
+      res.setHeader('Cache-Control', 'public, s-maxage=1800, stale-while-revalidate=300');
+      return res.status(200).json(cached.data);
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10000);
+
+    const resp = await fetch(`${UPSTREAM_URL}?flight_number=${encodeURIComponent(normalized)}`, {
+      signal: controller.signal,
+      headers: { 'User-Agent': 'BlueBoard-PredictFlight/1.0' },
+    });
+    clearTimeout(timeout);
+
+    if (!resp.ok) {
+      return res.status(resp.status).json({ error: `Upstream returned ${resp.status}` });
+    }
+
+    const data = await resp.json();
+
+    // Cache it
+    cache.set(normalized, { data, ts: Date.now() });
+
+    // Evict old entries periodically
+    if (cache.size > 500) {
+      const now = Date.now();
+      for (const [key, val] of cache) {
+        if (now - val.ts > CACHE_TTL) cache.delete(key);
+      }
+    }
+
+    res.setHeader('Cache-Control', 'public, s-maxage=1800, stale-while-revalidate=300');
+    return res.status(200).json(data);
+  } catch (err: any) {
+    console.error('Predict-flight error:', err);
+    return res.status(502).json({ error: 'Prediction service unavailable' });
+  }
+}

--- a/api/starlink-data.ts
+++ b/api/starlink-data.ts
@@ -1,0 +1,86 @@
+// Serves enriched Starlink aircraft data
+// Primary: serves cached data from cron sync
+// Fallback: fetches directly from upstream if cache is empty
+
+import type { VercelRequest, VercelResponse } from './types.js';
+
+const UPSTREAM_URL = 'https://unitedstarlinktracker.com/api/data';
+const CACHE_TTL = 4 * 60 * 60 * 1000; // 4 hours
+
+interface StarlinkCache {
+  aircraft: Array<{ tail: string; fleet: string; type: string; operator: string }>;
+  totalCount: number;
+  fleetStats: { mainline: number; express: number; total: number } | null;
+  flightsByTail: Record<string, Array<{ flight_number: string; origin: string; destination: string; departure_time: string }>>;
+  lastUpdated: string;
+  syncedAt: string;
+}
+
+let inMemoryCache: StarlinkCache | null = null;
+let lastFetch = 0;
+
+async function fetchUpstream(): Promise<StarlinkCache> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15000);
+
+  const resp = await fetch(UPSTREAM_URL, {
+    signal: controller.signal,
+    headers: { 'User-Agent': 'BlueBoard-StarlinkData/1.0' },
+  });
+  clearTimeout(timeout);
+
+  if (!resp.ok) throw new Error(`Upstream ${resp.status}`);
+
+  const upstream = await resp.json() as any;
+  const aircraft = (upstream.starlinkPlanes || []).map((p: any) => ({
+    tail: p.tail_number,
+    fleet: p.fleet || 'Express',
+    type: p.aircraft_type || 'Unknown',
+    operator: p.operator || 'United Airlines',
+  }));
+
+  return {
+    aircraft,
+    totalCount: upstream.totalCount || aircraft.length,
+    fleetStats: upstream.fleetStats || null,
+    flightsByTail: upstream.flightsByTail || {},
+    lastUpdated: upstream.lastUpdated || new Date().toISOString(),
+    syncedAt: new Date().toISOString(),
+  };
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    // Check cron-populated global cache first
+    const cronCache = (globalThis as any).__starlinkCache as StarlinkCache | undefined;
+    if (cronCache) {
+      res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=600');
+      return res.status(200).json(cronCache);
+    }
+
+    // Fall back to in-memory cache with TTL
+    if (inMemoryCache && Date.now() - lastFetch < CACHE_TTL) {
+      res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=600');
+      return res.status(200).json(inMemoryCache);
+    }
+
+    // Fetch fresh
+    inMemoryCache = await fetchUpstream();
+    lastFetch = Date.now();
+
+    res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=600');
+    return res.status(200).json(inMemoryCache);
+  } catch (err: any) {
+    // If we have stale cache, serve it rather than failing
+    if (inMemoryCache) {
+      res.setHeader('Cache-Control', 'public, s-maxage=300');
+      return res.status(200).json(inMemoryCache);
+    }
+    console.error('Starlink data error:', err);
+    return res.status(502).json({ error: 'Failed to fetch Starlink data' });
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -588,7 +588,7 @@
   </div>
   <div class="card">
     <h3>⚡ Starlink Tracker — <span id="starlink-count">258</span> Aircraft</h3>
-    <div style="font-size:10px;color:var(--ua-muted);margin-bottom:8px">Starlink data via <a href="https://unitedstarlinktracker.com" target="_blank" rel="noopener noreferrer" style="color:var(--ua-green)">unitedstarlinktracker.com</a>, updated daily</div>
+    <div style="font-size:10px;color:var(--ua-muted);margin-bottom:8px">Starlink data via <a href="https://unitedstarlinktracker.com" target="_blank" rel="noopener noreferrer" style="color:var(--ua-green)">unitedstarlinktracker.com</a> · <span id="starlink-updated" style="color:var(--ua-green)">live</span></div>
     <div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:8px">
       <input type="text" id="starlink-search" aria-label="Search Starlink aircraft" placeholder="Search tail..." style="background:var(--bg-card);color:var(--ua-text);border:1px solid var(--ua-border);padding:4px 8px;font-family:var(--mono);font-size:10px;border-radius:3px;width:120px">
       <select id="starlink-filter-fleet" aria-label="Starlink fleet filter" style="background:var(--bg-card);color:var(--ua-text);border:1px solid var(--ua-border);padding:4px 6px;font-family:var(--mono);font-size:10px;border-radius:3px"><option value="">All Fleets</option><option value="Mainline">Mainline</option><option value="Express">Express</option></select>
@@ -598,7 +598,7 @@
     </div>
     <div class="fleet-table-wrap" style="max-height:400px">
       <table id="starlink-table">
-        <thead><tr><th data-starlink-sort="tail" style="cursor:pointer">Tail ↕</th><th data-starlink-sort="fleet" style="cursor:pointer">Fleet ↕</th><th data-starlink-sort="type" style="cursor:pointer">Type ↕</th><th data-starlink-sort="operator" style="cursor:pointer">Operator ↕</th></tr></thead>
+        <thead><tr><th data-starlink-sort="tail" style="cursor:pointer">Tail ↕</th><th data-starlink-sort="fleet" style="cursor:pointer">Fleet ↕</th><th data-starlink-sort="type" style="cursor:pointer">Type ↕</th><th data-starlink-sort="operator" style="cursor:pointer">Operator ↕</th><th id="starlink-next-flight-th" style="display:none">Next Flight</th></tr></thead>
         <tbody id="starlink-tbody"></tbody>
       </table>
     </div>
@@ -692,8 +692,8 @@
   <div class="source-item">
     <div class="source-icon">⚡</div>
     <div>
-      <div class="source-name">Starlink Tracker — @martinamps <span class="freshness fresh-daily">DAILY</span></div>
-      <div class="source-desc">258 Starlink-equipped United aircraft. Community-maintained tracker.</div>
+      <div class="source-name">Starlink Tracker — @martinamps <span class="freshness fresh-daily">LIVE</span></div>
+      <div class="source-desc">Starlink-equipped United aircraft with live fleet stats &amp; predictions. Community-maintained tracker.</div>
       <a class="source-link" href="https://github.com/martinamps/ua-starlink-tracker" target="_blank" rel="noopener noreferrer">github.com/martinamps/ua-starlink-tracker →</a>
       <a class="source-link" href="https://unitedstarlinktracker.com" target="_blank" rel="noopener noreferrer" style="margin-left:12px">unitedstarlinktracker.com →</a>
     </div>

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -31,19 +31,43 @@ function escapeHtml(str) {
 let FLEET_DB = [];
 let STARLINK_DB = [];
 let STARLINK_TAILS = new Set();
+let STARLINK_FLIGHTS_BY_TAIL = {};  // upcoming flights keyed by tail number
+let STARLINK_FLEET_STATS = null;    // { mainline, express, total }
+let STARLINK_LAST_UPDATED = null;   // ISO timestamp from upstream
 
 // Build registration lookup
 const FLEET_BY_REG = {};
 
 async function loadFleetData() {
   try {
-    const [fleetRes, starlinkRes] = await Promise.all([
-      fetch('/data/fleet.json'),
-      fetch('/data/starlink.json')
-    ]);
-    if (!fleetRes.ok || !starlinkRes.ok) throw new Error('Fleet data load failed');
+    // Fetch fleet data and try live Starlink API (fall back to static file)
+    const fleetRes = await fetch('/data/fleet.json');
+    if (!fleetRes.ok) throw new Error('Fleet data load failed');
     FLEET_DB = await fleetRes.json();
-    STARLINK_DB = await starlinkRes.json();
+
+    // Try live API first for always-current Starlink data
+    let starlinkLoaded = false;
+    try {
+      const liveRes = await fetch('/api/starlink-data');
+      if (liveRes.ok) {
+        const liveData = await liveRes.json();
+        STARLINK_DB = liveData.aircraft || [];
+        STARLINK_FLIGHTS_BY_TAIL = liveData.flightsByTail || {};
+        STARLINK_FLEET_STATS = liveData.fleetStats || null;
+        STARLINK_LAST_UPDATED = liveData.lastUpdated || null;
+        starlinkLoaded = true;
+      }
+    } catch (e) {
+      console.warn('Live Starlink API unavailable, falling back to static file');
+    }
+
+    // Fallback to static file
+    if (!starlinkLoaded) {
+      const starlinkRes = await fetch('/data/starlink.json');
+      if (starlinkRes.ok) {
+        STARLINK_DB = await starlinkRes.json();
+      }
+    }
   } catch (err) {
     console.error('Fleet data load error:', err);
     FLEET_DB = [];
@@ -1102,7 +1126,11 @@ function showFlightPopup(f, marker) {
     html += `<div class="popup-aircraft">`;
     html += `<div class="popup-aircraft-type">${escapeHtml(aircraft.t)} <span class="ac-reg-link" data-action="aircraft-detail" data-reg="${escapeHtml(aircraft.r)}" style="font-size:10px">${escapeHtml(aircraft.r)}</span></div>`;
     html += `<div style="font-size:10px;color:var(--ua-muted)">${escapeHtml(aircraft.c || '')} | ${escapeHtml(aircraft.w || '')} | ${escapeHtml(aircraft.i || '')}</div>`;
-    if (isStarlink) html += `<span class="starlink-badge">⚡ STARLINK</span> `;
+    if (isStarlink) {
+      html += `<span class="starlink-badge">⚡ STARLINK CONFIRMED</span> `;
+    } else if (flightNum && flightNum !== 'N/A') {
+      html += `<span class="starlink-badge starlink-predict" data-flight="${escapeHtml(flightNum)}" style="background:rgba(100,116,139,.15);color:var(--ua-muted)">⚡ Checking…</span> `;
+    }
     const popupSpecial = isSpecialAircraft(aircraft.r);
     if (popupSpecial) html += `<span class="special-badge">⭐ ${escapeHtml(popupSpecial.name)}</span> `;
     if (aircraft.seats && Object.keys(aircraft.seats).length > 0) {
@@ -1258,6 +1286,9 @@ function showFlightPopup(f, marker) {
       });
   })();
 
+  // Async fetch Starlink probability for non-confirmed flights
+  fetchStarlinkPredictions();
+
   // Draw great circle route lines with traveled/remaining segments + endpoint markers
   {
     let oApt = null, dApt = null;
@@ -1329,6 +1360,47 @@ function normalizeLonContinuity(pts) {
 // Legacy wrapper — no longer splits; just returns a single continuous segment
 function splitAtAntimeridian(pts) {
   return [normalizeLonContinuity(pts)];
+}
+
+// ═══ STARLINK PREDICTION ═══
+const starlinkPredictionCache = new Map();
+
+function fetchStarlinkPredictions() {
+  document.querySelectorAll('.starlink-predict').forEach(el => {
+    const flight = el.getAttribute('data-flight');
+    if (!flight || flight === 'N/A') { el.style.display = 'none'; return; }
+
+    // Check cache first
+    const cached = starlinkPredictionCache.get(flight);
+    if (cached) {
+      applyStarlinkPrediction(el, cached);
+      return;
+    }
+
+    fetch('/api/predict-flight?flight_number=' + encodeURIComponent(flight))
+      .then(r => r.ok ? r.json() : null)
+      .then(data => {
+        if (!data || data.probability === undefined) {
+          el.style.display = 'none';
+          return;
+        }
+        starlinkPredictionCache.set(flight, data);
+        applyStarlinkPrediction(el, data);
+      })
+      .catch(() => { el.style.display = 'none'; });
+  });
+}
+
+function applyStarlinkPrediction(el, data) {
+  const pct = Math.round(data.probability * 100);
+  if (pct < 5) { el.style.display = 'none'; return; }
+
+  const color = pct >= 75 ? 'var(--ua-green)' : pct >= 40 ? 'var(--ua-yellow)' : 'var(--ua-muted)';
+  const bgColor = pct >= 75 ? 'rgba(34,197,94,.2)' : pct >= 40 ? 'rgba(234,179,8,.15)' : 'rgba(100,116,139,.15)';
+  el.style.background = bgColor;
+  el.style.color = color;
+  el.textContent = '⚡ Starlink ~' + pct + '%';
+  el.title = 'Confidence: ' + (data.confidence || 'unknown') + ' (' + (data.n_observations || 0) + ' observations)';
 }
 
 // ═══ STATS ═══
@@ -1603,10 +1675,19 @@ function initFleetTab() {
     </div>`
   ).join('');
 
-  // Starlink progress
-  const mainlineStarlink = STARLINK_DB.filter(s => s.fleet === 'Mainline').length;
+  // Starlink progress — use live fleet stats if available
+  const mainlineStarlink = STARLINK_FLEET_STATS ? STARLINK_FLEET_STATS.mainline : STARLINK_DB.filter(s => s.fleet === 'Mainline').length;
   document.getElementById('starlink-progress').style.width = (mainlineStarlink / FLEET_DB.length * 100) + '%';
   document.getElementById('starlink-pct').textContent = Math.round(mainlineStarlink / FLEET_DB.length * 100) + '% (' + mainlineStarlink + '/' + FLEET_DB.length + ')';
+
+  // Update Starlink tracker freshness indicator
+  if (STARLINK_LAST_UPDATED) {
+    const updatedEl = document.getElementById('starlink-updated');
+    if (updatedEl) {
+      const ago = Math.round((Date.now() - new Date(STARLINK_LAST_UPDATED).getTime()) / 60000);
+      updatedEl.textContent = ago < 60 ? `Updated ${ago}m ago` : ago < 1440 ? `Updated ${Math.round(ago/60)}h ago` : `Updated ${Math.round(ago/1440)}d ago`;
+    }
+  }
 
   // Populate filters
   const wifiTypes = [...new Set(FLEET_DB.map(a => a.w).filter(Boolean))].sort();
@@ -1951,9 +2032,24 @@ function renderStarlinkTable() {
   document.getElementById('starlink-filtered-count').textContent = filtered.length < STARLINK_DB.length ? `${filtered.length} of ${STARLINK_DB.length}` : '';
   document.getElementById('starlink-count').textContent = STARLINK_DB.length;
 
-  document.getElementById('starlink-tbody').innerHTML = filtered.map(s =>
-    `<tr><td style="font-weight:700;color:var(--ua-green)">${escapeHtml(s.tail)}</td><td>${escapeHtml(s.fleet)}</td><td>${escapeHtml(s.type)}</td><td style="font-size:10px">${escapeHtml(s.operator)}</td></tr>`
-  ).join('');
+  const hasFlights = Object.keys(STARLINK_FLIGHTS_BY_TAIL).length > 0;
+  document.getElementById('starlink-tbody').innerHTML = filtered.map(s => {
+    let nextFlightHtml = '';
+    if (hasFlights) {
+      const flights = STARLINK_FLIGHTS_BY_TAIL[s.tail];
+      if (flights && flights.length > 0) {
+        const next = flights[0];
+        nextFlightHtml = `<td style="font-size:9px">${escapeHtml(next.flight_number || '')} ${escapeHtml((next.origin || '') + '→' + (next.destination || ''))}</td>`;
+      } else {
+        nextFlightHtml = '<td style="font-size:9px;color:var(--ua-muted)">—</td>';
+      }
+    }
+    return `<tr><td style="font-weight:700;color:var(--ua-green)">${escapeHtml(s.tail)}</td><td>${escapeHtml(s.fleet)}</td><td>${escapeHtml(s.type)}</td><td style="font-size:10px">${escapeHtml(s.operator)}</td>${nextFlightHtml}</tr>`;
+  }).join('');
+
+  // Toggle next-flight column header visibility
+  const nextFlightHeader = document.getElementById('starlink-next-flight-th');
+  if (nextFlightHeader) nextFlightHeader.style.display = hasFlights ? '' : 'none';
 }
 
 // ═══ FLEET DATA REFRESH ═══
@@ -3872,6 +3968,7 @@ async function renderMyFlights() {
 
   container.innerHTML = flights.map((w, i) => buildMyFlightCard(w, timeData[i])).join('');
   detectAndRenderConnections(flights, timeData);
+  fetchStarlinkPredictions();
 
   // Async: fetch aircraft journey chains for watched flights (non-blocking)
   flights.forEach((w, i) => {
@@ -4120,7 +4217,7 @@ function buildMyFlightCard(watched, td) {
     const seatStr = ac.seats ? Object.entries(ac.seats).map(([cls,cnt]) => cnt + cls).join('/') : (ac.c || '');
     equipHtml = `<div class="mf-grid">
       <div><span class="mf-label">Aircraft</span><div class="mf-value">${escapeHtml(ac.t)} <span class="ac-reg-link" data-action="aircraft-detail" data-reg="${escapeHtml(reg)}" style="font-size:10px">${escapeHtml(reg)}</span></div></div>
-      <div><span class="mf-label">Config</span><div class="mf-value">${escapeHtml(seatStr)}${isStar ? ' <span class="starlink-badge">⚡ Starlink</span>' : ''}</div></div>
+      <div><span class="mf-label">Config</span><div class="mf-value">${escapeHtml(seatStr)}${isStar ? ' <span class="starlink-badge">⚡ Starlink Confirmed</span>' : ` <span class="starlink-badge starlink-predict" data-flight="${escapeHtml(flightNum)}" style="background:rgba(100,116,139,.15);color:var(--ua-muted)">⚡ Checking…</span>`}</div></div>
     </div>`;
   } else if (td && td.aircraft) {
     equipHtml = `<div><span class="mf-label">Aircraft</span><div class="mf-value">${escapeHtml(td.aircraft)}</div></div>`;

--- a/vercel.json
+++ b/vercel.json
@@ -4,10 +4,14 @@
         "api/irrops.ts": { "maxDuration": 90 },
         "api/schedule.ts": { "maxDuration": 60 },
         "api/cron/warm-schedules.ts": { "maxDuration": 300 },
-        "api/delay-explain.ts": { "maxDuration": 15 }
+        "api/delay-explain.ts": { "maxDuration": 15 },
+        "api/cron/sync-starlink.ts": { "maxDuration": 30 },
+        "api/starlink-data.ts": { "maxDuration": 20 },
+        "api/predict-flight.ts": { "maxDuration": 15 }
     },
     "crons": [
-        { "path": "/api/cron/warm-schedules", "schedule": "*/15 * * * *" }
+        { "path": "/api/cron/warm-schedules", "schedule": "*/15 * * * *" },
+        { "path": "/api/cron/sync-starlink", "schedule": "0 */4 * * *" }
     ],
   "buildCommand": "npm run build",
   "outputDirectory": "dist",


### PR DESCRIPTION
- Add /api/starlink-data endpoint that fetches live data from unitedstarlinktracker.com/api/data with in-memory caching and graceful fallback to static starlink.json
- Add /api/cron/sync-starlink Vercel cron job (every 4 hours) to keep Starlink aircraft data fresh
- Add /api/predict-flight proxy endpoint for Starlink probability predictions with 30-minute cache
- Update loadFleetData() to try live API first, enriching the dashboard with fleet stats, upcoming flights per tail, and last-updated timestamps
- Add Starlink probability badges to flight popups and My Flights modal: "Starlink Confirmed" for known aircraft, "~X% likely" via prediction API for unknown aircraft
- Add "Next Flight" column to Starlink tracker table when flight data is available from upstream
- Show live freshness indicator on Starlink tracker section
