### PR TITLE
Fix upstream field mapping and add fleet stats chips

### DIFF
--- a/api/cron/sync-starlink.ts
+++ b/api/cron/sync-starlink.ts
@@ -28,25 +28,47 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     const upstream = await resp.json() as {
       totalCount: number;
-      starlinkPlanes: Array<{ tail_number: string; aircraft_type: string; fleet: string; operator: string }>;
+      starlinkPlanes: Array<{ TailNumber: string; Aircraft: string; fleet: string; OperatedBy: string }>;
       lastUpdated: string;
-      fleetStats: { mainline: number; express: number; total: number };
-      flightsByTail: Record<string, Array<{ flight_number: string; origin: string; destination: string; departure_time: string }>>;
+      fleetStats: { mainline: { total: number; starlink: number }; express: { total: number; starlink: number }; combined: { total: number; starlink: number } };
+      flightsByTail: Record<string, Array<{ flight_number: string; departure_airport: string; arrival_airport: string; departure_time: string }>>;
     };
 
     // Transform to our format: keep backwards-compatible starlink.json shape + extras
+    // Upstream uses: TailNumber, Aircraft (=type), fleet ("express"/"mainline"), OperatedBy
     const aircraft = (upstream.starlinkPlanes || []).map(p => ({
-      tail: p.tail_number,
-      fleet: p.fleet || 'Express',
-      type: p.aircraft_type || 'Unknown',
-      operator: p.operator || 'United Airlines',
+      tail: p.TailNumber,
+      fleet: (p.fleet || 'express').charAt(0).toUpperCase() + (p.fleet || 'express').slice(1),
+      type: p.Aircraft || 'Unknown',
+      operator: p.OperatedBy || 'United Airlines',
     }));
+
+    // Normalize fleet stats to simple counts
+    const fs = upstream.fleetStats;
+    const fleetStats = fs ? {
+      mainline: fs.mainline?.starlink ?? 0,
+      express: fs.express?.starlink ?? 0,
+      total: fs.combined?.starlink ?? aircraft.length,
+      mainlineTotal: fs.mainline?.total ?? 0,
+      expressTotal: fs.express?.total ?? 0,
+    } : null;
+
+    // Normalize flight fields (upstream uses departure_airport/arrival_airport)
+    const flightsByTail: Record<string, Array<{ flight_number: string; origin: string; destination: string; departure_time: string }>> = {};
+    for (const [tail, flights] of Object.entries(upstream.flightsByTail || {})) {
+      flightsByTail[tail] = flights.map((f: any) => ({
+        flight_number: f.flight_number,
+        origin: f.departure_airport || f.origin || '',
+        destination: f.arrival_airport || f.destination || '',
+        departure_time: f.departure_time || '',
+      }));
+    }
 
     const enriched = {
       aircraft,
       totalCount: upstream.totalCount || aircraft.length,
-      fleetStats: upstream.fleetStats || null,
-      flightsByTail: upstream.flightsByTail || {},
+      fleetStats,
+      flightsByTail,
       lastUpdated: upstream.lastUpdated || new Date().toISOString(),
       syncedAt: new Date().toISOString(),
     };

--- a/api/cron/warm-schedules.ts
+++ b/api/cron/warm-schedules.ts
@@ -68,6 +68,22 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     await new Promise(r => setTimeout(r, 1000));
   }
 
+  // Phase 1.5: warm Starlink data cache (single fast request)
+  try {
+    const slController = new AbortController();
+    const slTimeout = setTimeout(() => slController.abort(), 20000);
+    const slResp = await fetch(`${BASE_URL}/api/starlink-data`, {
+      signal: slController.signal,
+      headers: { 'User-Agent': 'BlueBoard-CronWarmer/1.0' },
+    });
+    clearTimeout(slTimeout);
+    results['starlink-data'] = { status: slResp.ok ? 'ok' : `http_${slResp.status}` };
+    if (slResp.ok) warmed++; else failed++;
+  } catch (e: any) {
+    results['starlink-data'] = { status: 'error', message: e.message };
+    failed++;
+  }
+
   // Phase 2: warm tomorrow for all hubs (if time permits — cron has 300s max)
   for (const hub of HUBS) {
     const tomorrowTs = TIMESTAMPS(hub)[1];

--- a/api/starlink-data.ts
+++ b/api/starlink-data.ts
@@ -10,7 +10,7 @@ const CACHE_TTL = 4 * 60 * 60 * 1000; // 4 hours
 interface StarlinkCache {
   aircraft: Array<{ tail: string; fleet: string; type: string; operator: string }>;
   totalCount: number;
-  fleetStats: { mainline: number; express: number; total: number } | null;
+  fleetStats: { mainline: number; express: number; total: number; mainlineTotal: number; expressTotal: number } | null;
   flightsByTail: Record<string, Array<{ flight_number: string; origin: string; destination: string; departure_time: string }>>;
   lastUpdated: string;
   syncedAt: string;
@@ -32,18 +32,40 @@ async function fetchUpstream(): Promise<StarlinkCache> {
   if (!resp.ok) throw new Error(`Upstream ${resp.status}`);
 
   const upstream = await resp.json() as any;
+  // Upstream uses: TailNumber, Aircraft (=type), fleet ("express"/"mainline"), OperatedBy
   const aircraft = (upstream.starlinkPlanes || []).map((p: any) => ({
-    tail: p.tail_number,
-    fleet: p.fleet || 'Express',
-    type: p.aircraft_type || 'Unknown',
-    operator: p.operator || 'United Airlines',
+    tail: p.TailNumber,
+    fleet: (p.fleet || 'express').charAt(0).toUpperCase() + (p.fleet || 'express').slice(1),
+    type: p.Aircraft || 'Unknown',
+    operator: p.OperatedBy || 'United Airlines',
   }));
+
+  // Normalize fleet stats to simple counts
+  const fs = upstream.fleetStats;
+  const fleetStats = fs ? {
+    mainline: fs.mainline?.starlink ?? 0,
+    express: fs.express?.starlink ?? 0,
+    total: fs.combined?.starlink ?? aircraft.length,
+    mainlineTotal: fs.mainline?.total ?? 0,
+    expressTotal: fs.express?.total ?? 0,
+  } : null;
+
+  // Normalize flight fields (upstream uses departure_airport/arrival_airport)
+  const flightsByTail: Record<string, any[]> = {};
+  for (const [tail, flights] of Object.entries(upstream.flightsByTail || {} as Record<string, any[]>)) {
+    flightsByTail[tail] = (flights as any[]).map((f: any) => ({
+      flight_number: f.flight_number,
+      origin: f.departure_airport || f.origin || '',
+      destination: f.arrival_airport || f.destination || '',
+      departure_time: f.departure_time || '',
+    }));
+  }
 
   return {
     aircraft,
     totalCount: upstream.totalCount || aircraft.length,
-    fleetStats: upstream.fleetStats || null,
-    flightsByTail: upstream.flightsByTail || {},
+    fleetStats,
+    flightsByTail,
     lastUpdated: upstream.lastUpdated || new Date().toISOString(),
     syncedAt: new Date().toISOString(),
   };

--- a/public/index.html
+++ b/public/index.html
@@ -589,6 +589,7 @@
   <div class="card">
     <h3>⚡ Starlink Tracker — <span id="starlink-count">258</span> Aircraft</h3>
     <div style="font-size:10px;color:var(--ua-muted);margin-bottom:8px">Starlink data via <a href="https://unitedstarlinktracker.com" target="_blank" rel="noopener noreferrer" style="color:var(--ua-green)">unitedstarlinktracker.com</a> · <span id="starlink-updated" style="color:var(--ua-green)">live</span></div>
+    <div id="starlink-fleet-stats" style="display:none;gap:8px;flex-wrap:wrap;margin-bottom:8px"></div>
     <div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:8px">
       <input type="text" id="starlink-search" aria-label="Search Starlink aircraft" placeholder="Search tail..." style="background:var(--bg-card);color:var(--ua-text);border:1px solid var(--ua-border);padding:4px 8px;font-family:var(--mono);font-size:10px;border-radius:3px;width:120px">
       <select id="starlink-filter-fleet" aria-label="Starlink fleet filter" style="background:var(--bg-card);color:var(--ua-text);border:1px solid var(--ua-border);padding:4px 6px;font-family:var(--mono);font-size:10px;border-radius:3px"><option value="">All Fleets</option><option value="Mainline">Mainline</option><option value="Express">Express</option></select>

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -1680,6 +1680,21 @@ function initFleetTab() {
   document.getElementById('starlink-progress').style.width = (mainlineStarlink / FLEET_DB.length * 100) + '%';
   document.getElementById('starlink-pct').textContent = Math.round(mainlineStarlink / FLEET_DB.length * 100) + '% (' + mainlineStarlink + '/' + FLEET_DB.length + ')';
 
+  // Render fleet stats chips if live data available
+  if (STARLINK_FLEET_STATS) {
+    const statsEl = document.getElementById('starlink-fleet-stats');
+    if (statsEl) {
+      const fs = STARLINK_FLEET_STATS;
+      const chipStyle = 'display:inline-flex;flex-direction:column;align-items:center;padding:6px 12px;border-radius:4px;font-size:10px';
+      statsEl.style.display = 'flex';
+      statsEl.innerHTML =
+        `<div style="${chipStyle};background:rgba(34,197,94,.1);border:1px solid rgba(34,197,94,.2)"><span style="font-size:16px;font-weight:700;color:var(--ua-green)">${fs.total}</span><span style="color:var(--ua-muted)">Total</span></div>` +
+        `<div style="${chipStyle};background:rgba(0,93,170,.1);border:1px solid rgba(0,93,170,.2)"><span style="font-size:16px;font-weight:700;color:var(--ua-accent)">${fs.mainline}</span><span style="color:var(--ua-muted)">Mainline</span></div>` +
+        `<div style="${chipStyle};background:rgba(168,85,247,.1);border:1px solid rgba(168,85,247,.2)"><span style="font-size:16px;font-weight:700;color:#a855f7">${fs.express}</span><span style="color:var(--ua-muted)">Express</span></div>` +
+        (fs.mainlineTotal ? `<div style="${chipStyle};background:rgba(100,116,139,.08);border:1px solid rgba(100,116,139,.15)"><span style="font-size:16px;font-weight:700;color:var(--ua-text)">${Math.round(fs.mainline / fs.mainlineTotal * 100)}%</span><span style="color:var(--ua-muted)">Mainline Fleet</span></div>` : '');
+    }
+  }
+
   // Update Starlink tracker freshness indicator
   if (STARLINK_LAST_UPDATED) {
     const updatedEl = document.getElementById('starlink-updated');


### PR DESCRIPTION
- Fix field name mismatch: upstream uses TailNumber, Aircraft, fleet (lowercase), OperatedBy — not tail_number/aircraft_type/operator
- Fix fleetStats shape: upstream returns nested objects with {total, starlink, percentage} per fleet, not flat numbers
- Normalize flight fields (departure_airport → origin)
- Add fleet stats summary chips (Total / Mainline / Express / %) to Starlink tracker section when live data is available
- Pre-warm Starlink data cache in the schedule cron warmer

https://claude.ai/code/session_01UtY5ojsJsrXWVFEccrNHpv