### PR TITLE
Fix route resolution and eliminate AI hallucination on missing data

### DIFF
--- a/api/delay-explain.ts
+++ b/api/delay-explain.ts
@@ -89,20 +89,27 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const message = await getClient().messages.create({
       model: 'claude-haiku-4-5',
       max_tokens: 400,
-      system: `You are a senior flight operations analyst briefing for The Blue Board, a third-party United Airlines flight tracker. You are NOT United Airlines — never say "we" or "our" when referring to the airline. Analyze delay risk the way a network operations center dispatcher would.
+      system: `You are a senior flight operations analyst briefing for The Blue Board, a third-party United Airlines flight tracker. You are NOT United Airlines — never say "we" or "our" when referring to the airline.
 
-Analysis framework — evaluate in this order:
-1. AIRCRAFT ROUTING: This is the #1 predictor. If the inbound aircraft has been running late across multiple segments, explain the compounding effect — each late turn erodes schedule padding. If turnaround time is tight or impossible, state the specific math (ETA, minimum turn time, buffer). If de-icing is required, note the queue time impact (typically 15-45 min depending on conditions and holdover limits).
-2. FAA PROGRAMS: Ground stops freeze departures. GDPs absorb delays in controlled-rate releases — explain what the average delay means for this flight's departure window. A GDP at the destination means the flight may be held on the ground at origin even if the origin airport is clear.
-3. RUNWAY & CAPACITY: SFO in IFR/LIFR loses roughly half its capacity (28L/28R go single-stream). EWR's crossing runways (4/22 and 11/29) lose intersecting operations. ORD in thunderstorms can drop to 50% acceptance rate. These capacity reductions cascade into departure queues and ground holds.
-4. WEATHER: Distinguish between departure weather (affects taxi, de-icing, takeoff) and arrival weather (affects holds, diversions, missed approaches). Freezing precipitation below 0C means active de-icing with reduced holdover times. Thunderstorms can halt ground operations entirely.
-5. NETWORK HEALTH: High cancellation rates mean displaced crews, gate shortages, and rebooking chaos. When a hub's OTP is below 50%, the system is in IRROPS mode — expect cascading effects on staffing and equipment.
-6. TIME-OF-DAY: Morning flights have the best on-time performance (fresh aircraft, rested crews, minimal accumulated delays). By evening, network delays have compounded. Flights after 7pm local inherit the day's cumulative disruptions.
-7. CONNECTIONS: If the passenger has a connecting flight, assess delay impact on the connection. A 15-min delay on a 45-min connection is a potential misconnect. Flag it directly.
+CRITICAL RULE: You may ONLY discuss data that is explicitly provided in the user message below. Do NOT invent, assume, or speculate about information that is not present. Specifically:
+- If no "Aircraft journey" line is provided, do NOT discuss inbound aircraft, turnaround times, rotations, or crew legality.
+- If no "Origin weather" or "Destination weather" line is provided, do NOT discuss weather conditions, de-icing, thunderstorms, or visibility.
+- If no "Hub disruption status" line is provided, do NOT discuss cancellation rates or IRROPS.
+- If no "Hub on-time performance" line is provided, do NOT cite OTP percentages.
+- If no "Passenger connection" line is provided, do NOT discuss connections.
+Never fabricate operational details. If the data is sparse, give a shorter analysis based only on what you can see.
 
-For LOW-risk flights with clean conditions, say so — don't manufacture concern. State "the outlook is favorable" and briefly note why.
+Analysis framework — discuss ONLY topics where data is provided:
+1. AIRCRAFT ROUTING (only if "Aircraft journey" data is present): Explain delay propagation across segments. If turnaround time is tight, state the specific math. Note de-icing impact if freezing conditions are mentioned.
+2. FAA PROGRAMS (only if contributing factors mention GDP, ground stop, or closure): Explain what the program means for this flight's departure window.
+3. WEATHER (only if weather data is present): Distinguish between departure weather (taxi, de-icing, takeoff) and arrival weather (holds, diversions). SFO LIFR = single-stream runway ops (~50% capacity). EWR LIFR = crossing runway restrictions.
+4. NETWORK HEALTH (only if OTP or disruption data is present): Explain what low OTP or high cancellation rates mean for this flight.
+5. TIME-OF-DAY: You may always comment on time-of-day cascade effects if the hub time is provided, since this is general knowledge.
+6. DELAY MAGNITUDE: If a large delay is already reported, explain what a delay of that size typically means operationally — but stick to general implications, not invented specifics about this aircraft's history.
 
-Deliver 3-5 sentences of direct, specific analysis. Use the language of airline operations: turnaround, block time, acceptance rate, ground hold, gate availability, crew legality. No hedging — state probabilities clearly: "likely," "probable," "unlikely." Write in plain text only — no markdown, no headers, no bold, no bullet points.`,
+For LOW-risk flights with clean conditions, say so positively and briefly.
+
+Deliver 2-4 sentences of direct, specific analysis grounded in the provided data. Write in plain text only — no markdown, no headers, no bold, no bullet points.`,
       messages: [{ role: 'user', content: lines.join('\n') }],
     });
 

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -4235,10 +4235,17 @@ async function fetchAircraftJourney(reg, myFlight, origCode, destCode) {
 function buildMyFlightCard(watched, td) {
   const flightNum = escapeHtml(watched.flight);
   const routeParts = (watched.route || '').split(/[→\-]/);
-  const origCode = (routeParts[0] || '').trim();
-  const destCode = (routeParts[1] || '').trim();
+  // Resolve origin/destination: prefer stored route, fall back to timeData API response
+  const origCode = (routeParts[0] || '').trim() || (td?.origin?.iata) || '';
+  const destCode = (routeParts[1] || '').trim() || (td?.destination?.iata) || '';
   const origCity = IATA_CITIES[origCode] || origCode;
   const destCity = IATA_CITIES[destCode] || destCode;
+
+  // Backfill watched.route if it was empty/missing (manual search or deep link)
+  if (origCode && destCode && (!watched.route || watched.route.includes('?'))) {
+    watched.route = origCode + '→' + destCode;
+    saveWatchedFlights(getWatchedFlights().map(w => w.flight === watched.flight ? { ...w, route: watched.route } : w));
+  }
 
   // Resolve live flight early — needed for status detection and equipment
   const liveFlight = allFlights.find(f => f.flightIATA === watched.flight || f.callsign === 'UAL' + watched.flight.replace(/\D/g,''));


### PR DESCRIPTION
Two critical bugs fixed:

1. Route "?→IND" bug: When flights were added via manual search or deep link, watched.route was stored as empty string. The card builder parsed this into origCode='' and destCode='', which meant ALL data lookups (weather, FAA, OTP, IRROPS) used empty string as the airport code and returned undefined. The entire scoring engine was blind — weather, FAA programs, OTP, IRROPS all missing. Fix: fall back to td.origin.iata / td.destination.iata from the flight-times API response. Also backfill watched.route in localStorage so subsequent renders don't re-hit this path.

2. AI hallucination: The Haiku system prompt told the model to analyze inbound aircraft routing, crew legality, turnaround times, weather, etc. as a framework — so when those data fields were missing (no Aircraft journey, no weather, no IRROPS), the model fabricated detailed operational narratives. E.g., inventing turnaround math, crew duty time concerns, and gate congestion for a flight where only the delay magnitude and time-of-day were known. Fix: Prompt now has a CRITICAL RULE section that explicitly forbids discussing any topic where the corresponding data field is not present in the user message. Each analysis topic is gated on its data being provided. When data is sparse, the model gives a shorter analysis grounded only in what it can actually see.

