### PR TITLE
Add gate/terminal fallback for all United hubs, not just LAX

### DIFF
--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -20,6 +20,45 @@ const STALE_GRACE = 120000; // serve stale data for up to 2min past expiry
 // Busy hubs get more time to fetch all pages (capped at 55s for Vercel's 60s maxDuration)
 const HUB_TIMEOUT_MS: Record<string, number> = { ORD: 55000, EWR: 55000, IAH: 55000, SFO: 55000, LAX: 55000, DEN: 55000, IAD: 55000, NRT: 55000, GUM: 55000 };
 
+// Known United Airlines terminal assignments at each hub (used when API doesn't provide terminal data)
+const UNITED_HUB_TERMINALS: Record<string, { domestic: string; international: string }> = {
+  ORD: { domestic: '1', international: '1' },       // Terminal 1 (Concourses B & C); Express uses T2
+  DEN: { domestic: 'B', international: 'B' },       // Concourse B
+  EWR: { domestic: 'C', international: 'C' },       // Terminal C (primary); some flights use Terminal A
+  IAH: { domestic: 'C', international: 'E' },       // Terminal C (domestic), Terminal E (international)
+  SFO: { domestic: '3', international: 'G' },       // Terminal 3 (domestic), International Terminal G
+  LAX: { domestic: '7', international: '7' },       // Terminals 7 & 8
+  IAD: { domestic: 'C', international: 'D' },       // Concourse C (domestic), Concourse D (international)
+  NRT: { domestic: '1', international: '1' },       // Terminal 1
+  GUM: { domestic: '1', international: '1' },       // Single terminal
+};
+
+// US airport IATA codes (3-letter codes starting from common US airports)
+// Used to determine if a route is domestic or international for terminal assignment
+const US_AIRPORTS = new Set([
+  // United hubs
+  'ORD','DEN','EWR','IAH','SFO','LAX','IAD','GUM',
+  // Major US airports
+  'ATL','JFK','LGA','DFW','CLT','MIA','FLL','TPA','MCO','SEA','MSP','DTW','PHL','BOS',
+  'DCA','BWI','SAN','PHX','SLC','AUS','SAT','HOU','DAL','MDW','OAK','SJC','SMF','PDX',
+  'MCI','MSY','STL','IND','CLE','CVG','CMH','PIT','RDU','BNA','MKE','OMA','RSW',
+  // Hawaii (treated as domestic for terminal purposes)
+  'HNL','OGG','LIH','KOA',
+]);
+
+function isInternationalRoute(origIata: string, destIata: string): boolean {
+  if (!origIata || !destIata) return false;
+  const origUS = US_AIRPORTS.has(origIata.toUpperCase());
+  const destUS = US_AIRPORTS.has(destIata.toUpperCase());
+  return !(origUS && destUS);
+}
+
+function getHubTerminal(iata: string, isIntl: boolean): string {
+  const hub = UNITED_HUB_TERMINALS[iata.toUpperCase()];
+  if (!hub) return '';
+  return isIntl ? hub.international : hub.domestic;
+}
+
 // Global concurrency limiter for FR24 outbound requests
 const MAX_CONCURRENT_FR24 = 6;
 let activeFR24 = 0;
@@ -292,6 +331,17 @@ function normalizeSummaryFlight(f: any) {
   const acType = f.aircraft?.type || f.aircraft_type || f.type || '';
   const acReg = f.aircraft?.registration || f.registration || '';
 
+  // Extract gate/terminal from API response if available (try multiple field name conventions)
+  const origGate = f.origin?.gate || f.orig_gate || f.departure_gate || '';
+  const origTerminal = f.origin?.terminal || f.orig_terminal || f.departure_terminal || '';
+  const destGate = f.destination?.gate || f.dest_gate || f.arrival_gate || '';
+  const destTerminal = f.destination?.terminal || f.dest_terminal || f.arrival_terminal || '';
+
+  // Fall back to known United hub terminal if API didn't provide terminal data
+  const isIntl = isInternationalRoute(origIata, destIata);
+  const fallbackOrigTerminal = origTerminal || getHubTerminal(origIata, isIntl);
+  const fallbackDestTerminal = destTerminal || getHubTerminal(destIata, isIntl);
+
   return {
     identification: { number: { default: flightNum }, callsign },
     airline: { code: { iata: 'UA' } },
@@ -302,8 +352,8 @@ function normalizeSummaryFlight(f: any) {
       estimated: { departure: estDep, arrival: estArr }
     },
     airport: {
-      origin: { code: { iata: origIata }, name: origName, info: { gate: '', terminal: '' } },
-      destination: { code: { iata: destIata }, name: destName, info: { gate: '', terminal: '' } }
+      origin: { code: { iata: origIata }, name: origName, info: { gate: origGate, terminal: fallbackOrigTerminal } },
+      destination: { code: { iata: destIata }, name: destName, info: { gate: destGate, terminal: fallbackDestTerminal } }
     },
     aircraft: { model: { code: acType, text: '' }, registration: acReg }
   };

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -246,6 +246,24 @@ const TERMINAL_WALK_TIMES = {
   SFO:{default:12},IAD:{default:10},LAX:{'7-8':5,'7-B':15,'8-B':12,default:10},NRT:{default:15},GUM:{default:5}
 };
 const INTL_AIRPORTS = new Set(['NRT','GUM','HND','LHR','FRA','CDG','AMS','ZRH','FCO','MAD','BCN','DUB','IST','TLV','MUC','EDI','BRU','LIS','CPH','ARN','HEL','OSL','SIN','HKG','SYD','PEK','ICN','TPE','BKK','DEL','MEL','AKL','PVG','CAN','BOM','NAN','PPT','KIX','CTU','XIY','CKG','SNN','MAN','GLA']);
+// Known United Airlines terminals at each hub (fallback when API doesn't provide terminal data)
+const UNITED_HUB_TERMINALS = {
+  ORD:{domestic:'1',international:'1'},       // Terminal 1 (B & C); Express uses T2
+  DEN:{domestic:'B',international:'B'},       // Concourse B
+  EWR:{domestic:'C',international:'C'},       // Terminal C (primary)
+  IAH:{domestic:'C',international:'E'},       // Terminal C (domestic), Terminal E (international)
+  SFO:{domestic:'3',international:'G'},       // Terminal 3 (domestic), International Terminal G
+  LAX:{domestic:'7',international:'7'},       // Terminals 7 & 8
+  IAD:{domestic:'C',international:'D'},       // Concourse C (domestic), Concourse D (international)
+  NRT:{domestic:'1',international:'1'},       // Terminal 1
+  GUM:{domestic:'1',international:'1'},       // Single terminal
+};
+function getUnitedTerminal(iata, origIata, destIata) {
+  const hub = UNITED_HUB_TERMINALS[iata];
+  if (!hub) return '';
+  const isIntl = INTL_AIRPORTS.has(origIata) || INTL_AIRPORTS.has(destIata);
+  return isIntl ? hub.international : hub.domestic;
+}
 
 // ═══ UA ROUTE LOOKUP TABLE ═══
 // Static mapping of UA flight numbers to known city pairs (fallback for missing FR24 route data)
@@ -3173,9 +3191,16 @@ function renderScheduleTable() {
     const acShort = acText ? acText.replace(/Boeing |Airbus |Embraer /g, '').substring(0, 20) : '';
     const reg = fl.aircraft?.registration || '—';
 
-    const gate = schedCurrentDir === 'departures'
-      ? (orig?.info?.gate ? orig.info.gate : (orig?.info?.terminal ? `T${orig.info.terminal}` : '—'))
-      : (dest?.info?.gate ? dest.info.gate : (dest?.info?.terminal ? `T${dest.info.terminal}` : '—'));
+    const oIata = orig?.code?.iata || '';
+    const dIata = dest?.code?.iata || '';
+    let gate;
+    if (schedCurrentDir === 'departures') {
+      const t = orig?.info?.terminal || getUnitedTerminal(oIata, oIata, dIata);
+      gate = orig?.info?.gate ? orig.info.gate : (t ? `T${t}` : '—');
+    } else {
+      const t = dest?.info?.terminal || getUnitedTerminal(dIata, oIata, dIata);
+      gate = dest?.info?.gate ? dest.info.gate : (t ? `T${t}` : '—');
+    }
 
     const status = classifySchedStatus(fl);
 
@@ -4320,8 +4345,12 @@ function buildMyFlightCard(watched, td) {
   // Gate info
   let gateHtml = '';
   if (td && td.success !== false) {
-    const oGate = td.origin?.gate ? `T${td.origin.terminal || '?'} Gate ${td.origin.gate}` : (td.origin?.terminal ? `T${td.origin.terminal}` : '—');
-    const dGate = td.destination?.gate ? `T${td.destination.terminal || '?'} Gate ${td.destination.gate}` : (td.destination?.terminal ? `T${td.destination.terminal}` : '—');
+    const oIata = td.origin?.iata || '';
+    const dIata = td.destination?.iata || '';
+    const oTerm = td.origin?.terminal || getUnitedTerminal(oIata, oIata, dIata);
+    const dTerm = td.destination?.terminal || getUnitedTerminal(dIata, oIata, dIata);
+    const oGate = td.origin?.gate ? `T${oTerm || '?'} Gate ${td.origin.gate}` : (oTerm ? `T${oTerm}` : '—');
+    const dGate = td.destination?.gate ? `T${dTerm || '?'} Gate ${td.destination.gate}` : (dTerm ? `T${dTerm}` : '—');
     gateHtml = `<div class="mf-grid">
       <div><span class="mf-label">Origin Gate</span><div class="mf-value">${escapeHtml(oGate)}</div></div>
       <div><span class="mf-label">Dest Gate</span><div class="mf-value">${escapeHtml(dGate)}</div></div>
@@ -4945,8 +4974,8 @@ function computeConnectionRisk(conn) {
   const mctKey = (isDomIn ? 'd' : 'i') + (isDomOut ? 'd' : 'i');
   const mct = MIN_CONNECTION_TIMES[hub]?.[mctKey] || 60;
 
-  const inTerminal = inTd.destination?.terminal || '?';
-  const outTerminal = outTd.origin?.terminal || '?';
+  const inTerminal = inTd.destination?.terminal || getUnitedTerminal(hub, inTd.origin?.iata || '', hub) || '?';
+  const outTerminal = outTd.origin?.terminal || getUnitedTerminal(hub, hub, outTd.destination?.iata || '') || '?';
   const walkKey = [inTerminal, outTerminal].sort().join('-');
   const walkTime = inTerminal === outTerminal ? 5 : (TERMINAL_WALK_TIMES[hub]?.[walkKey] || TERMINAL_WALK_TIMES[hub]?.default || 10);
 


### PR DESCRIPTION
The FR24 official API flight-summary endpoint does not return gate or terminal data. Previously this left the gate column blank ('—') for all airports. This adds known United terminal mappings for every hub (ORD, DEN, EWR, IAH, SFO, LAX, IAD, NRT, GUM) with domestic/international awareness so the schedule table, My Flights modal, and connection risk calculator all show the correct terminal.

Changes:
- api/schedule.ts: Add UNITED_HUB_TERMINALS mapping with domestic/intl terminal assignments, US_AIRPORTS set for route classification, and helper functions. normalizeSummaryFlight now populates terminal info from hub mapping when API doesn't provide it, and tries multiple field name conventions for extracting gate/terminal from API responses.
- src/dashboard/main.js: Add client-side UNITED_HUB_TERMINALS mapping with getUnitedTerminal() helper. Update schedule table gate column, My Flights gate display, and connection risk terminal lookup to use fallback terminals when API data is missing.
