### PR TITLE
Optimize cron warming and add CDN/visibility tracking

### DIFF
--- a/api/cron/warm-schedules.ts
+++ b/api/cron/warm-schedules.ts
@@ -23,11 +23,12 @@ async function warmOne(hub: string, dir: string, timestamp: number, label: strin
       headers: { 'User-Agent': 'BlueBoard-CronWarmer/1.0' }
     });
     clearTimeout(timeout);
+    const cdnStatus = resp.headers.get('x-vercel-cache') || 'unknown';
     if (resp.ok) {
       const data = await resp.json() as any;
-      return { key, result: { status: 'ok', flights: data.total || 0, partial: data.partial || false, cached: data.cached || false } };
+      return { key, result: { status: 'ok', flights: data.total || 0, partial: data.partial || false, cached: data.cached || false, cdn: cdnStatus } };
     }
-    return { key, result: { status: `http_${resp.status}` } };
+    return { key, result: { status: `http_${resp.status}`, cdn: cdnStatus } };
   } catch (e: any) {
     return { key, result: { status: 'error', message: e.message } };
   }
@@ -44,7 +45,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   let failed = 0;
 
   // Warm today first for ALL hubs (most important), then tomorrow.
-  // For each hub, fetch departures & arrivals in parallel to cut time in half.
+  // Only warm departures — arrivals are less viewed and load on-demand.
   const TIMESTAMPS = (hub: string) => {
     const todayTs = getStartOfDayForHub(hub);
     return [
@@ -53,17 +54,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     ];
   };
 
-  // Phase 1: warm today for all hubs (departures + arrivals in parallel per hub)
+  // Phase 1: warm today departures for all hubs
   for (const hub of HUBS) {
     const todayTs = TIMESTAMPS(hub)[0];
-    const batch = await Promise.all([
-      warmOne(hub, 'departures', todayTs.ts, todayTs.label),
-      warmOne(hub, 'arrivals', todayTs.ts, todayTs.label),
-    ]);
-    for (const { key, result } of batch) {
-      results[key] = result;
-      if (result.status === 'ok') warmed++; else failed++;
-    }
+    const { key, result } = await warmOne(hub, 'departures', todayTs.ts, todayTs.label);
+    results[key] = result;
+    if (result.status === 'ok') warmed++; else failed++;
     // Brief pause between hubs to avoid overwhelming FR24
     await new Promise(r => setTimeout(r, 1000));
   }
@@ -84,17 +80,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     failed++;
   }
 
-  // Phase 2: warm tomorrow for all hubs (if time permits — cron has 300s max)
+  // Phase 2: warm tomorrow departures for all hubs (if time permits — cron has 300s max)
   for (const hub of HUBS) {
     const tomorrowTs = TIMESTAMPS(hub)[1];
-    const batch = await Promise.all([
-      warmOne(hub, 'departures', tomorrowTs.ts, tomorrowTs.label),
-      warmOne(hub, 'arrivals', tomorrowTs.ts, tomorrowTs.label),
-    ]);
-    for (const { key, result } of batch) {
-      results[key] = result;
-      if (result.status === 'ok') warmed++; else failed++;
-    }
+    const { key, result } = await warmOne(hub, 'departures', tomorrowTs.ts, tomorrowTs.label);
+    results[key] = result;
+    if (result.status === 'ok') warmed++; else failed++;
     await new Promise(r => setTimeout(r, 1000));
   }
 

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -789,7 +789,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const isOld = (now - ts) > 86400;
     const ttl = isOld ? 600000 : 900000;
     const cdnMaxAge = isOld ? 3600 : 900;
-    const swr = 300;
+    const swr = 600;
 
     // Single page mode (backward compat)
     if (page !== undefined) {

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -825,11 +825,27 @@ function initMap() {
   // Hub markers
   drawHubs();
   refreshFlights();
-  refreshTimer = setInterval(() => {
-    countdown--;
-    document.getElementById('countdown').textContent = 'Next refresh: ' + countdown + 's';
-    if (countdown <= 0) { refreshFlights(); countdown = 30; }
-  }, 1000);
+  function startRefreshTimer() {
+    if (refreshTimer) clearInterval(refreshTimer);
+    countdown = 30;
+    refreshTimer = setInterval(() => {
+      countdown--;
+      document.getElementById('countdown').textContent = 'Next refresh: ' + countdown + 's';
+      if (countdown <= 0) { refreshFlights(); countdown = 30; }
+    }, 1000);
+  }
+  startRefreshTimer();
+
+  // Pause polling when tab is hidden to save API credits
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) {
+      if (refreshTimer) { clearInterval(refreshTimer); refreshTimer = null; }
+      document.getElementById('countdown').textContent = 'Paused (tab hidden)';
+    } else {
+      refreshFlights();
+      startRefreshTimer();
+    }
+  });
 }
 
 function drawHubs() {
@@ -2823,6 +2839,11 @@ function updateSchedDayLabels() {
 }
 
 async function preloadScheduleData() {
+  // Skip if we already preloaded recently (survives soft navigations / refreshes)
+  const PRELOAD_TTL = 10 * 60 * 1000; // 10 minutes
+  const lastPreload = parseInt(sessionStorage.getItem('bb_sched_preload_ts') || '0', 10);
+  if (Date.now() - lastPreload < PRELOAD_TTL) return;
+
   // Fetch hubs sequentially to avoid overwhelming FR24 with concurrent aggregations
   const preloadHubs = ['ORD','DEN','EWR'];
   const timestamp = getSchedDayTimestamp(0); // today
@@ -2838,6 +2859,7 @@ async function preloadScheduleData() {
     } catch (e) { /* preload is best-effort */ }
   }
   if (loaded > 0) {
+    sessionStorage.setItem('bb_sched_preload_ts', String(Date.now()));
     updateHubHealth();
     updateIrrops();
   }


### PR DESCRIPTION
## Summary
This PR optimizes the schedule warming cron job to focus only on departures (which are more frequently viewed), adds CDN cache status tracking to warming results, and improves the dashboard's API efficiency by pausing polling when the tab is hidden and caching preloaded schedule data.

## Key Changes

- **Cron warming optimization**: Removed parallel arrivals warming from both Phase 1 (today) and Phase 2 (tomorrow) since arrivals are less viewed and load on-demand. This reduces API load and cron execution time.

- **CDN cache tracking**: Added `x-vercel-cache` header extraction to warming responses, capturing CDN cache status ('HIT', 'MISS', etc.) in both success and error cases for better observability.

- **Dashboard visibility-aware polling**: Implemented `visibilitychange` listener to pause the refresh timer when the tab is hidden and resume when it becomes visible again. This reduces unnecessary API calls and saves credits when users aren't actively viewing the dashboard.

- **Schedule preload caching**: Added a 10-minute TTL check using `sessionStorage` to prevent redundant preloading of schedule data across soft navigations and page refreshes, reducing FR24 API pressure.

- **Cache-Control tuning**: Increased SWR (stale-while-revalidate) from 300s to 600s for schedule endpoints to allow longer serving of stale content while revalidating in the background.

## Implementation Details

- The `warmOne()` function now captures CDN status before checking response status, ensuring it's available in all result paths
- The refresh timer is now wrapped in a `startRefreshTimer()` function to allow clean restart after visibility changes
- Preload timestamp is stored in `sessionStorage` (survives soft navigations) rather than memory to persist across page reloads

https://claude.ai/code/session_01Xzn8dDgRzDTB3rpkWXJL2M