### PR TITLE
Fix schedule timestamp parsing from FR24 official API responses

### DIFF
--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -264,6 +264,10 @@ function icaoFlightToIata(icaoFlight: string): string {
 function toUnix(val: any): number | null {
   if (!val) return null;
   if (typeof val === 'number') return val > 1e12 ? Math.floor(val / 1000) : val;
+  if (typeof val === 'string') {
+    const num = Number(val);
+    if (Number.isFinite(num)) return num > 1e12 ? Math.floor(num / 1000) : Math.floor(num);
+  }
   const ms = Date.parse(val);
   return isNaN(ms) ? null : Math.floor(ms / 1000);
 }

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -85,4 +85,41 @@ describe('schedule API', () => {
     expect(res.body.meta.source).toBe('official-api');
     expect(res.body.meta.partialReason).toBe(null);
   });
+
+  it('parses numeric-string timestamps from official API so schedule times are populated', async () => {
+    process.env.FR24_API_TOKEN = 'test-token-12345678';
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{
+          flight_icao: 'UAL2118',
+          flight_iata: 'UA2118',
+          status: 'scheduled',
+          orig_iata: 'ORD',
+          dest_iata: 'DEN',
+          scheduled_departure: '1741653600',
+          scheduled_arrival: '1741660800',
+          estimated_departure: '1741654200'
+        }]
+      }),
+    });
+
+    const ts = Math.floor(Date.now() / 1000) - 7200;
+    const req = {
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'ORD', dir: 'departures', timestamp: String(ts) }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.total).toBe(1);
+    const flight = res.body.flights[0];
+    expect(flight.time.scheduled.departure).toBe(1741653600);
+    expect(flight.time.scheduled.arrival).toBe(1741660800);
+    expect(flight.time.estimated.departure).toBe(1741654200);
+  });
 });


### PR DESCRIPTION
### Motivation
- The official FR24 API sometimes returns epoch timestamps as numeric strings (e.g. `"1741653600"`), which `Date.parse()` does not interpret as epoch seconds and therefore produced `null` normalized times. 
- That caused schedule rows to render with missing/blank time columns even when upstream data was present.

### Description
- Update `toUnix()` in `api/schedule.ts` to detect numeric strings and convert them to unix seconds before falling back to `Date.parse()` so stringified epoch values are normalized correctly. 
- Add a regression test in `tests/schedule.test.js` that mocks the official FR24 API returning numeric-string `scheduled_*`/`estimated_*` fields and asserts normalized `flight.time.scheduled.*` and `flight.time.estimated.*` values. 
- The change is limited to parsing/normalization logic and test coverage; no UI code was modified.

### Testing
- Ran the schedule test suite with `npm test -- tests/schedule.test.js`, which completed successfully with all tests passing (3 tests). 
- The new regression test verifies that numeric-string timestamps are parsed to integer unix seconds and prevents the previously observed blank schedule times.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0f48bfe98832fbea17c25360dd10e)