### PR TITLE
Fix on-time metrics to require real departure times

### DIFF
--- a/api/irrops.ts
+++ b/api/irrops.ts
@@ -72,21 +72,18 @@ export function computeMetrics(flightsByHub: Record<string, any[]>) {
 
       const hasOperated = status === 'departed' || status === 'en-route' || status === 'landed' || status === 'diverted';
       const realDep = fl.time?.real?.departure;
-      const estDep = fl.time?.estimated?.departure;
-      if (!hasOperated && !realDep) continue;
+      if (!hasOperated || !realDep) continue;
 
-      const actDep = realDep || (hasOperated ? estDep : null);
-      if (!actDep) continue;
+      const schedT = fl.time?.scheduled?.departure;
+      if (!schedT) continue;
 
       hubMetrics[hub].operated++;
-      const schedT = fl.time?.scheduled?.departure || 0;
-      if (schedT && actDep > schedT) {
-        const delayMin = Math.round((actDep - schedT) / 60);
+      if (realDep <= schedT + 1800) {
+        hubMetrics[hub].onTime++;
+      } else {
+        const delayMin = Math.round((realDep - schedT) / 60);
         if (delayMin > 30) hubMetrics[hub].delayed30++;
         if (delayMin > 60) hubMetrics[hub].delayed60++;
-        if (delayMin <= 30) hubMetrics[hub].onTime++;
-      } else {
-        hubMetrics[hub].onTime++;
       }
     }
   }
@@ -100,7 +97,7 @@ export function computeMetrics(flightsByHub: Record<string, any[]>) {
     if (status === 'diverted') diversions++;
 
     const schedT = fl.time?.scheduled?.departure || 0;
-    const actT = fl.time?.real?.departure || fl.time?.estimated?.departure || 0;
+    const actT = fl.time?.real?.departure || 0;
     if (schedT && actT && actT > schedT) {
       const delayMin = Math.round((actT - schedT) / 60);
       if (delayMin > 30) delayed30++;

--- a/tests/irrops.test.js
+++ b/tests/irrops.test.js
@@ -141,6 +141,38 @@ describe('computeMetrics', () => {
     expect(result.worstDelays[7].delay).toBe(40);
   });
 
+  it('does not count flights with only estimated departure as on-time', () => {
+    const t = 1700000000;
+    const flights = [
+      makeFlight('ORD', { schedDep: t, realDep: null, estDep: t, status: 'departed' }),
+      makeFlight('ORD', { schedDep: t, realDep: null, estDep: t + 100, status: 'en-route' }),
+    ];
+    const result = computeMetrics({ ORD: flights });
+    expect(result.hubMetrics.ORD.operated).toBe(0);
+    expect(result.hubMetrics.ORD.onTime).toBe(0);
+  });
+
+  it('skips flights with missing scheduled departure', () => {
+    const t = 1700000000;
+    const flights = [
+      makeFlight('ORD', { schedDep: null, realDep: t, status: 'landed' }),
+    ];
+    const result = computeMetrics({ ORD: flights });
+    expect(result.hubMetrics.ORD.operated).toBe(0);
+    expect(result.hubMetrics.ORD.onTime).toBe(0);
+  });
+
+  it('global metrics ignore flights with only estimated departure', () => {
+    const t = 1700000000;
+    const flights = [
+      makeFlight('ORD', { schedDep: t, realDep: null, estDep: t + 7200, status: 'departed' }),
+    ];
+    const result = computeMetrics({ ORD: flights });
+    expect(result.delayed30).toBe(0);
+    expect(result.delayed60).toBe(0);
+    expect(result.worstDelays).toEqual([]);
+  });
+
   it('includes generatedAt ISO timestamp', () => {
     const result = computeMetrics({});
     expect(result.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);


### PR DESCRIPTION
## Summary
This PR fixes the on-time and delay metrics calculation to only count flights with actual (real) departure times, not estimated departures. This ensures metrics accurately reflect actual flight performance rather than predictions.

## Key Changes
- **Hub metrics**: Modified to require `realDep` (actual departure time) to exist before counting a flight as operated. Flights with only estimated departures are now excluded from on-time/delay calculations.
- **Global metrics**: Removed reliance on estimated departure times when calculating delayed30, delayed60, and worstDelays. Now only uses real departure times.
- **Validation**: Added explicit check that scheduled departure time exists before processing a flight, preventing flights with missing schedule data from skewing metrics.
- **Logic simplification**: Consolidated the on-time determination to a single condition (`realDep <= schedT + 1800`) rather than the previous multi-branch approach.

## Implementation Details
- Flights must have both a real departure time AND a scheduled departure time to be counted in metrics
- On-time threshold remains 30 minutes (1800 seconds) after scheduled departure
- Estimated departure times are no longer used as fallbacks in metric calculations
- Three new test cases validate the corrected behavior for edge cases (estimated-only departures, missing scheduled times, and global metric exclusions)

https://claude.ai/code/session_01PEBDUHaL4wqMGgwuMgQtZ9