### PR TITLE
Make FR24 feed cache and dedupe airline-aware

### DIFF
--- a/api/fr24-feed.ts
+++ b/api/fr24-feed.ts
@@ -5,7 +5,7 @@ import { CacheStore } from './_cache.js';
 const isRateLimited = createRateLimiter('fr24-feed', 30);
 
 const feedCache = new CacheStore('fr24-feed', { maxSize: 1, defaultTTL: 15_000 });
-let feedFetching: Promise<any> | null = null;
+const feedFetching = new Map<string, Promise<any>>();
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'GET') {
@@ -28,16 +28,20 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return res.status(400).json({ error: 'Invalid airline code' });
     }
 
+    const normalizedAirline = airline.toUpperCase();
+    const cacheKey = `feed:${normalizedAirline}`;
+
     // Return cached if fresh
-    const hit = feedCache.get('feed');
+    const hit = feedCache.get(cacheKey);
     if (hit) {
       res.setHeader('Cache-Control', 's-maxage=15, stale-while-revalidate=30');
       return res.status(200).json(hit);
     }
 
     // Dedup: if already fetching, wait for that
-    if (feedFetching) {
-      const data = await feedFetching;
+    const inFlight = feedFetching.get(cacheKey);
+    if (inFlight) {
+      const data = await inFlight;
       res.setHeader('Cache-Control', 's-maxage=15, stale-while-revalidate=30');
       return res.status(200).json(data);
     }
@@ -45,7 +49,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const doFetch = async () => {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 15000);
-      const upstream = await fetch(`https://data-cloud.flightradar24.com/zones/fcgi/feed.js?airline=${encodeURIComponent(airline)}`, {
+      const upstream = await fetch(`https://data-cloud.flightradar24.com/zones/fcgi/feed.js?airline=${encodeURIComponent(normalizedAirline)}`, {
         signal: controller.signal,
         headers: {
           'User-Agent': 'TheBlueBoardDashboard/1.0 (https://theblueboard.co)',
@@ -58,13 +62,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     };
 
     try {
-      feedFetching = doFetch();
-      const data = await feedFetching;
-      feedCache.set('feed', data);
+      const inFlightRequest = doFetch();
+      feedFetching.set(cacheKey, inFlightRequest);
+      const data = await inFlightRequest;
+      feedCache.set(cacheKey, data);
       res.setHeader('Cache-Control', 's-maxage=15, stale-while-revalidate=30');
       return res.status(200).json(data);
     } finally {
-      feedFetching = null;
+      feedFetching.delete(cacheKey);
     }
   } catch (e: any) {
     console.error('FR24 feed error:', e);

--- a/tests/fr24-feed.test.js
+++ b/tests/fr24-feed.test.js
@@ -92,16 +92,68 @@ describe('fr24-feed API', () => {
     expect(res.headers['Cache-Control']).toContain('s-maxage=15');
   });
 
-  it('returns cached data on subsequent requests', async () => {
-    // Previous test populated the cache — this request should hit it
-    const res = createRes();
+
+  it('uses airline-specific cache keys to avoid cross-airline contamination', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const airline = new URL(url).searchParams.get('airline');
+      return {
+        ok: true,
+        json: async () => ({ airline, full_count: airline === 'DAL' ? 500 : 120 }),
+      };
+    });
+
+    const resUAL = createRes();
     await handler({
       method: 'GET',
       headers: { origin: 'http://localhost:3000' },
-      query: {},
-    }, res);
+      query: { airline: 'DAL' },
+    }, resUAL);
 
-    expect(res.statusCode).toBe(200);
-    expect(res.body.full_count).toBe(500);
+    const resAAL = createRes();
+    await handler({
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { airline: 'JBU' },
+    }, resAAL);
+
+    const resAALCached = createRes();
+    await handler({
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { airline: 'JBU' },
+    }, resAALCached);
+
+    expect(resUAL.statusCode).toBe(200);
+    expect(resUAL.body.airline).toBe('DAL');
+    expect(resAAL.statusCode).toBe(200);
+    expect(resAAL.body.airline).toBe('JBU');
+    expect(resAALCached.body.airline).toBe('JBU');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+  it('returns cached data on subsequent requests', async () => {
+    const mockData = { full_count: 500, version: 4, '2d5c8a': ['data'] };
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => mockData,
+    });
+
+    const firstRes = createRes();
+    await handler({
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { airline: 'UAL' },
+    }, firstRes);
+
+    const secondRes = createRes();
+    await handler({
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { airline: 'UAL' },
+    }, secondRes);
+
+    expect(firstRes.statusCode).toBe(200);
+    expect(secondRes.statusCode).toBe(200);
+    expect(secondRes.body.full_count).toBe(500);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent cache contamination between different airline queries by making cache keys parameter-aware instead of using a single shared `feed` key.
- Avoid cross-airline blocking by making in-flight deduplication scoped per-airline so concurrent different-airline requests can proceed independently.
- Preserve existing response caching semantics (TTL and `Cache-Control` headers) while adding per-airline isolation.

### Description
- Replace the single shared cache key with a normalized per-airline key built as ``feed:${airline.toUpperCase()}`` and use it for both `get` and `set` operations in `api/fr24-feed.ts`.
- Replace the single `feedFetching` promise with a `Map<string, Promise<any>>` and store in-flight requests per cache key so dedupe is airline-specific.
- Use the normalized airline code when calling the upstream FR24 endpoint (`airline=${encodeURIComponent(normalizedAirline)}`).
- Keep the original `Cache-Control` header (`s-maxage=15, stale-while-revalidate=30`) and TTL behavior from the `CacheStore` intact.
- Extend `tests/fr24-feed.test.js` with a test that verifies one airline request does not contaminate another and update the cache-hit test to explicitly exercise `airline`-scoped caching and dedupe.

### Testing
- Ran `npm test -- tests/fr24-feed.test.js` and all tests passed (`8 passed`).
- The updated test suite includes a new test that asserts two different airlines trigger separate fetches and that repeated requests for the same airline are deduplicated to a single upstream call.
- Existing upstream error and timeout tests were left unchanged and continue to pass under the new cache/dedupe behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1a9792868832f97089296a2810d7c)