### PR TITLE
Align flight API IP extraction with shared limiter precedence

### DIFF
--- a/api/flight-times.ts
+++ b/api/flight-times.ts
@@ -20,10 +20,12 @@ function setCache(key: string, data: any): void {
 
 // Rate limiting: 5 req/min per IP
 const rateLimitByIp = new Map<string, number[]>();
-function getClientIp(req: VercelRequest): string {
+export function getClientIp(req: VercelRequest): string {
+  const realIp = req.headers?.['x-real-ip'];
+  if (realIp) return Array.isArray(realIp) ? realIp[0] : realIp;
   const xff = req.headers?.['x-forwarded-for'];
   const raw = Array.isArray(xff) ? xff[0] : (typeof xff === 'string' ? xff : '');
-  return raw.split(',')[0]?.trim() || (req.headers?.['x-real-ip'] as string) || 'unknown';
+  return raw.split(',')[0]?.trim() || 'unknown';
 }
 let lastRateLimitCleanup = Date.now();
 function isRateLimited(req: VercelRequest): boolean {

--- a/api/fr24-flight.ts
+++ b/api/fr24-flight.ts
@@ -36,10 +36,12 @@ const globalLog: number[] = [];
 const MAX_PER_IP = 10;
 const MAX_GLOBAL = 60;
 let lastCleanup = Date.now();
-function getClientIp(req: VercelRequest): string {
+export function getClientIp(req: VercelRequest): string {
+  const realIp = req.headers?.['x-real-ip'];
+  if (realIp) return Array.isArray(realIp) ? realIp[0] : realIp;
   const xff = req.headers?.['x-forwarded-for'];
   const raw = Array.isArray(xff) ? xff[0] : (typeof xff === 'string' ? xff : '');
-  return raw.split(',')[0]?.trim() || (req.headers?.['x-real-ip'] as string) || 'unknown';
+  return raw.split(',')[0]?.trim() || 'unknown';
 }
 function isRateLimited(req: VercelRequest): boolean {
   const now = Date.now();

--- a/tests/flight-times.test.js
+++ b/tests/flight-times.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   normalizeFlightNumber,
   epochToISO,
+  getClientIp,
 } from '../api/flight-times.js';
 
 describe('normalizeFlightNumber (FlightAware)', () => {
@@ -58,5 +59,27 @@ describe('epochToISO', () => {
   it('handles recent timestamps', () => {
     const result = epochToISO(1700000000);
     expect(result).toMatch(/^2023-11-14T/);
+  });
+});
+
+
+describe('getClientIp (FlightAware)', () => {
+  it('prefers x-real-ip over x-forwarded-for', () => {
+    const req = {
+      headers: {
+        'x-real-ip': '100.0.0.1',
+        'x-forwarded-for': '200.0.0.1, 201.0.0.1',
+      },
+    };
+    expect(getClientIp(req)).toBe('100.0.0.1');
+  });
+
+  it('falls back to first x-forwarded-for value when x-real-ip is missing', () => {
+    const req = { headers: { 'x-forwarded-for': '200.0.0.1, 201.0.0.1' } };
+    expect(getClientIp(req)).toBe('200.0.0.1');
+  });
+
+  it('returns unknown when both headers are missing', () => {
+    expect(getClientIp({ headers: {} })).toBe('unknown');
   });
 });

--- a/tests/fr24-flight.test.js
+++ b/tests/fr24-flight.test.js
@@ -3,6 +3,7 @@ import {
   normalizeFlightNumber,
   normalizeLiveResponse,
   normalizeSummaryResponse,
+  getClientIp,
 } from '../api/fr24-flight.js';
 
 describe('normalizeFlightNumber (FR24)', () => {
@@ -180,5 +181,27 @@ describe('normalizeSummaryResponse', () => {
     expect(result.aircraft.type).toBe('A320');
     expect(result.aircraft.reg).toBe('N54321');
     expect(result.flightId).toBe('fallback1');
+  });
+});
+
+
+describe('getClientIp (FR24)', () => {
+  it('prefers x-real-ip over x-forwarded-for', () => {
+    const req = {
+      headers: {
+        'x-real-ip': '100.0.0.1',
+        'x-forwarded-for': '200.0.0.1, 201.0.0.1',
+      },
+    };
+    expect(getClientIp(req)).toBe('100.0.0.1');
+  });
+
+  it('falls back to first x-forwarded-for value when x-real-ip is missing', () => {
+    const req = { headers: { 'x-forwarded-for': '200.0.0.1, 201.0.0.1' } };
+    expect(getClientIp(req)).toBe('200.0.0.1');
+  });
+
+  it('returns unknown when both headers are missing', () => {
+    expect(getClientIp({ headers: {} })).toBe('unknown');
   });
 });


### PR DESCRIPTION
### Motivation
- Ensure IP extraction in flight endpoints matches the shared limiter logic which prefers `x-real-ip` (set by the Vercel edge) to avoid using spoofable `x-forwarded-for` values.
- Make `getClientIp` behavior consistent across `fr24-flight` and `flight-times` so rate limiting and logging use the same source of truth.

### Description
- Updated `getClientIp` in `api/fr24-flight.ts` to check `x-real-ip` first, then fall back to the first entry in `x-forwarded-for`, and finally return `'unknown'` if neither header is present, and exported the function for testing.
- Applied the same `getClientIp` change and export to `api/flight-times.ts` to mirror the shared limiter precedence.
- Added unit tests to `tests/fr24-flight.test.js` and `tests/flight-times.test.js` that import `getClientIp` and assert `x-real-ip` precedence, correct fallback to the first `x-forwarded-for` value, and `'unknown'` when headers are absent.

### Testing
- Ran `npm test -- tests/fr24-flight.test.js tests/flight-times.test.js` which executed the updated test suites under `vitest` and all tests passed.
- Result: 2 test files ran, 32 tests total, and all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1a995a868832f958e6f43812ed000)