### PR TITLE
Scope FR24 feed cache and in-flight dedupe by airline

### DIFF
--- a/api/fr24-feed.ts
+++ b/api/fr24-feed.ts
@@ -4,8 +4,8 @@ import { CacheStore } from './_cache.js';
 
 const isRateLimited = createRateLimiter('fr24-feed', 30);
 
-const feedCache = new CacheStore('fr24-feed', { maxSize: 1, defaultTTL: 15_000 });
-let feedFetching: Promise<any> | null = null;
+const feedCache = new CacheStore('fr24-feed', { maxSize: 50, defaultTTL: 15_000 });
+const feedFetching = new Map<string, Promise<any>>();
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'GET') {
@@ -22,22 +22,25 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   try {
-    const airline = (req.query.airline as string) || 'UAL';
+    const airlineRaw = ((req.query.airline as string) || 'UAL').trim();
     // Validate airline: 2-4 letter ICAO code
-    if (!/^[A-Z0-9]{2,4}$/i.test(airline)) {
+    if (!/^[A-Z0-9]{2,4}$/i.test(airlineRaw)) {
       return res.status(400).json({ error: 'Invalid airline code' });
     }
+    const airline = airlineRaw.toUpperCase();
+    const cacheKey = `feed:${airline}`;
 
     // Return cached if fresh
-    const hit = feedCache.get('feed');
+    const hit = feedCache.get(cacheKey);
     if (hit) {
       res.setHeader('Cache-Control', 's-maxage=15, stale-while-revalidate=30');
       return res.status(200).json(hit);
     }
 
     // Dedup: if already fetching, wait for that
-    if (feedFetching) {
-      const data = await feedFetching;
+    const inflight = feedFetching.get(cacheKey);
+    if (inflight) {
+      const data = await inflight;
       res.setHeader('Cache-Control', 's-maxage=15, stale-while-revalidate=30');
       return res.status(200).json(data);
     }
@@ -58,13 +61,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     };
 
     try {
-      feedFetching = doFetch();
-      const data = await feedFetching;
-      feedCache.set('feed', data);
+      const inflightRequest = doFetch();
+      feedFetching.set(cacheKey, inflightRequest);
+      const data = await inflightRequest;
+      feedCache.set(cacheKey, data);
       res.setHeader('Cache-Control', 's-maxage=15, stale-while-revalidate=30');
       return res.status(200).json(data);
     } finally {
-      feedFetching = null;
+      feedFetching.delete(cacheKey);
     }
   } catch (e: any) {
     console.error('FR24 feed error:', e);

--- a/tests/fr24-feed.test.js
+++ b/tests/fr24-feed.test.js
@@ -92,6 +92,45 @@ describe('fr24-feed API', () => {
     expect(res.headers['Cache-Control']).toContain('s-maxage=15');
   });
 
+
+  it('isolates cache entries by airline', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const airline = new URL(url).searchParams.get('airline');
+      return {
+        ok: true,
+        json: async () => ({ airline, full_count: airline === 'DAL' ? 10 : 20 }),
+      };
+    });
+
+    const dalFirst = createRes();
+    await handler({
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { airline: 'dal' },
+    }, dalFirst);
+
+    const aalFirst = createRes();
+    await handler({
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { airline: 'AAL' },
+    }, aalFirst);
+
+    const dalSecond = createRes();
+    await handler({
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { airline: 'DAL' },
+    }, dalSecond);
+
+    expect(dalFirst.statusCode).toBe(200);
+    expect(aalFirst.statusCode).toBe(200);
+    expect(dalSecond.statusCode).toBe(200);
+    expect(dalFirst.body).toEqual({ airline: 'DAL', full_count: 10 });
+    expect(aalFirst.body).toEqual({ airline: 'AAL', full_count: 20 });
+    expect(dalSecond.body).toEqual({ airline: 'DAL', full_count: 10 });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
   it('returns cached data on subsequent requests', async () => {
     // Previous test populated the cache — this request should hit it
     const res = createRes();


### PR DESCRIPTION
### Motivation
- Prevent different-airline requests from interfering with each other by scoping cache and in-flight dedupe to the airline.
- Normalize incoming `airline` values to avoid cache fragmentation from case/whitespace variations.

### Description
- Normalize `airline` by trimming and uppercasing after validation (`airlineRaw -> airline`).
- Replace single shared cache key (`feed`) with per-airline keys using `feed:${airline}` and increase cache `maxSize` to 50.
- Replace global `feedFetching` promise with a per-airline `Map<string, Promise<any>>` to dedupe only same-airline concurrent fetches and avoid cross-airline blocking.
- Add a regression test `isolates cache entries by airline` that requests `DAL` and `AAL`, asserts per-airline responses, and verifies only two upstream fetches occurred.

### Testing
- Ran `npm test -- tests/fr24-feed.test.js` and the test suite passed: all tests succeeded (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1a97d5838832f8dd6cd86ae46c954)