### PR TITLE
Harden FR24 official schedule fallback handling

### DIFF
--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -365,6 +365,18 @@ function normalizeSummaryFlight(f: any) {
 
 const OFFICIAL_API_PAGE_SIZE = 10000; // FR24 API allows up to 20,000 per request; use 10k to get most hubs in a single page
 
+function parseRetryAfterMs(headerValue: string | null): number {
+  if (!headerValue) return 0;
+  const numeric = Number.parseInt(headerValue, 10);
+  if (Number.isFinite(numeric) && numeric > 0) return numeric * 1000;
+
+  const retryAt = Date.parse(headerValue);
+  if (Number.isFinite(retryAt)) {
+    return Math.max(0, retryAt - Date.now());
+  }
+  return 0;
+}
+
 async function fetchViaOfficialAPI(hub: string, dir: string, ts: number, timeoutMs?: number) {
   const logHub = String(hub);
   const token = process.env.FR24_API_TOKEN;
@@ -395,6 +407,9 @@ async function fetchViaOfficialAPI(hub: string, dir: string, ts: number, timeout
   let page = 1;
   let totalPages = 1;
   let retried1 = false;
+  let officialPartial = false;
+  let partialReason: string | null = null;
+  let pagesFailed = 0;
   const MAX_OFFICIAL_PAGES = 50;
 
   while (page <= MAX_OFFICIAL_PAGES) {
@@ -434,6 +449,13 @@ async function fetchViaOfficialAPI(hub: string, dir: string, ts: number, timeout
       if (!resp.ok) {
         const body = await resp.text().catch(() => '');
         console.error(`Official FR24 API returned ${resp.status} for ${logHub} (page ${page}): ${body.slice(0, 200)}`);
+
+        if ([429, 503].includes(resp.status) && Date.now() < deadline - 2500) {
+          const retryAfterMs = parseRetryAfterMs(resp.headers.get('retry-after'));
+          const waitMs = Math.max(1200, Math.min(retryAfterMs || 4000, 8000));
+          await new Promise(r => setTimeout(r, waitMs));
+        }
+
         if (page === 1) {
           // Retry page 1 once after a brief pause before giving up
           if (Date.now() < deadline - 5000 && !retried1) {
@@ -444,6 +466,9 @@ async function fetchViaOfficialAPI(hub: string, dir: string, ts: number, timeout
           }
           return null;
         }
+        pagesFailed++;
+        officialPartial = true;
+        partialReason = 'upstream_http_error';
         break;
       }
 
@@ -485,12 +510,18 @@ async function fetchViaOfficialAPI(hub: string, dir: string, ts: number, timeout
         }
         return null;
       }
+      pagesFailed++;
+      officialPartial = true;
+      partialReason = e.name === 'AbortError' ? 'upstream_timeout' : 'upstream_fetch_error';
       break;
     }
   }
 
   totalPages = page;
-  const officialPartial = page > 1 && Date.now() > deadline - 1000;
+  if (page > 1 && Date.now() > deadline - 1000) {
+    officialPartial = true;
+    partialReason = partialReason || 'deadline_exceeded';
+  }
 
   if (!allRawFlights.length) {
     console.log(`Official FR24 API returned 0 flights for ${logHub} ${dir}`);
@@ -505,12 +536,12 @@ async function fetchViaOfficialAPI(hub: string, dir: string, ts: number, timeout
       hub: logHub,
       dir,
       meta: {
-        partialReason: null,
+        partialReason,
         pagesRequested: totalPages,
-        pagesSucceeded: totalPages,
-        pagesFailed: 0,
+        pagesSucceeded: Math.max(0, totalPages - pagesFailed),
+        pagesFailed,
         missingPages: [] as number[],
-        completeness: 1,
+        completeness: officialPartial ? 0.9 : 1,
         elapsedMs: Date.now() - startTime,
         source: 'official-api'
       }
@@ -549,10 +580,10 @@ async function fetchViaOfficialAPI(hub: string, dir: string, ts: number, timeout
     hub: logHub,
     dir,
     meta: {
-      partialReason: officialPartial ? 'deadline_exceeded' : null,
+      partialReason,
       pagesRequested: totalPages,
-      pagesSucceeded: totalPages,
-      pagesFailed: 0,
+      pagesSucceeded: Math.max(0, totalPages - pagesFailed),
+      pagesFailed,
       missingPages: [] as number[],
       completeness: officialPartial ? 0.9 : 1,
       elapsedMs,

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -122,4 +122,50 @@ describe('schedule API', () => {
     expect(flight.time.scheduled.arrival).toBe(1741660800);
     expect(flight.time.estimated.departure).toBe(1741654200);
   });
+
+  it('marks response partial when official API fails after first page', async () => {
+    process.env.FR24_API_TOKEN = 'test-token-12345678';
+
+    const firstPageFlights = Array.from({ length: 10000 }, (_, i) => ({
+      flight_icao: `UAL${2000 + i}`,
+      flight_iata: `UA${2000 + i}`,
+      status: 'scheduled',
+      orig_iata: 'IAH',
+      dest_iata: 'DEN',
+      scheduled_departure: 1741653600,
+      scheduled_arrival: 1741660800,
+    }));
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes('page=1')) {
+        return {
+          ok: true,
+          json: async () => ({ data: firstPageFlights }),
+        };
+      }
+      return {
+        ok: false,
+        status: 503,
+        text: async () => 'service unavailable',
+        headers: { get: () => '1' }
+      };
+    });
+
+    const ts = Math.floor(Date.now() / 1000) - 10800;
+    const req = {
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'IAH', dir: 'departures', timestamp: String(ts) }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.partial).toBe(true);
+    expect(res.body.meta.partialReason).toBe('upstream_http_error');
+    expect(res.body.meta.pagesFailed).toBe(1);
+    expect(res.body.meta.pagesSucceeded).toBe(1);
+  });
 });


### PR DESCRIPTION
### Motivation
- The FR24 official schedule endpoint can throttle or fail mid-pagination, and the service previously returned a full/complete response even when later pages failed. 
- Improve resilience by honoring upstream `Retry-After` behavior and surface accurate partial/metadata so callers and caches can make informed decisions.

### Description
- Add `parseRetryAfterMs` to parse `Retry-After` (seconds or HTTP-date) and implement a bounded wait before retrying on `429`/`503` responses. 
- Track mid-pagination degradation via `officialPartial`, `partialReason`, and `pagesFailed`, and set `partial` when later pages fail or fetches/timeouts occur. 
- Populate response metadata (`meta.partialReason`, `meta.pagesSucceeded`, `meta.pagesFailed`, `meta.completeness`) to reflect upstream degradation instead of reporting full completeness. 
- Add a regression test that simulates a successful page 1 followed by a `503` on page 2 and asserts `partial: true` and the updated metadata are returned.

### Testing
- Ran the full test suite with `npm test` (Vitest) and all tests passed: 10 files, 136 tests succeeded. 
- Ran the targeted schedule test with `npx vitest run tests/schedule.test.js -t "marks response partial"` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1aaf826f0832fac94306aa2b2a2d2)