### PR TITLE
Fix inconsistent hub health by aggregating per-hub totals

### DIFF
--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -3640,13 +3640,17 @@ function updateHubHealth() {
   const bar = document.getElementById('hub-health-bar');
   const hubs = ['ORD','DEN','IAH','EWR','SFO','IAD','LAX','NRT','GUM'];
   let hasData = false;
+  const totalsByHub = {};
+  hubs.forEach(hub => { totalsByHub[hub] = { onTime: 0, operated: 0 }; });
 
-  // Gather OTP from all loaded schedule data
+  // Gather OTP from all loaded schedule data.
+  // Multiple keys can exist per hub (arrivals/departures + day), so aggregate
+  // instead of letting whichever key is iterated last overwrite the hub value.
   for (const key of Object.keys(schedRawByHub)) {
     const flights = schedRawByHub[key];
     if (!flights || !flights.length) continue;
     const hub = key.split('-')[0];
-    let onTime = 0, operated = 0;
+    if (!totalsByHub[hub]) continue;
     flights.forEach(fl => {
       const status = classifySchedStatus(fl);
       const hasOp = status.key === 'departed' || status.key === 'enroute' || status.key === 'landed';
@@ -3654,16 +3658,20 @@ function updateHubHealth() {
       const schedT = fl.time?.scheduled?.departure || fl.time?.scheduled?.arrival;
       const realT = fl.time?.real?.departure || fl.time?.real?.arrival;
       if (!realT || !schedT) return; // skip flights without real timestamps
-      operated++;
-      if (realT <= schedT + 1800) onTime++;
+      totalsByHub[hub].operated++;
+      if (realT <= schedT + 1800) totalsByHub[hub].onTime++;
     });
+  }
+
+  hubs.forEach(hub => {
+    const { onTime, operated } = totalsByHub[hub];
     if (operated >= 5) {
       hubHealthData[hub] = Math.round((onTime / operated) * 100);
       hasData = true;
     } else {
       delete hubHealthData[hub]; // clear stale data when sample too small
     }
-  }
+  });
 
   if (!hasData) {
     bar.innerHTML = '<span class="hh-label">Hub Health</span><span class="hh-explainer">ON-TIME %</span><span class="hh-info">?<span class="hh-tooltip">% of operated flights departing within 30 min of schedule. 🟢 &gt;70% · 🟡 50–70% · 🔴 &lt;50%</span></span><span style="color:var(--ua-muted)">Load schedule data for hub health</span>';


### PR DESCRIPTION
### Motivation
- Hub health percentages could be inconsistent because multiple schedule buckets (departures/arrivals and day variants) for the same hub were processed separately and the last-iterated bucket could overwrite previous calculations.  

### Description
- Update `updateHubHealth()` in `src/dashboard/main.js` to aggregate `onTime` and `operated` totals into a per-hub accumulator (`totalsByHub`) before computing percentages.  
- Replace the previous per-key overwrite logic with a single per-hub computation so all loaded schedule buckets for a hub are combined.  
- Preserve the existing minimum sample-size guard (`operated >= 5`) and stale-data clearing behavior.  
- Add a short inline comment explaining why aggregation is required (multiple keys per hub).  

### Testing
- Ran `npm test` which invokes `vitest`; the test suite completed successfully with all tests passing (`10 files, 136 tests passed`).  
- An attempted `npm test -- --runInBand` failed because the repo's `vitest` CLI does not recognize the `--runInBand` flag (reported by the test runner).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1ad582b5c832faf8a3e7852839afd)