### PR TITLE
Remove "COMMUNITY ·" from header tagline

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -155,7 +155,7 @@
 
 <!-- HEADER -->
 <div id="header">
-  <h1><a href="#" data-action="go-home" style="text-decoration:none;color:inherit;cursor:pointer"><span class="ua">THE BLUE BOARD</span></a> <span style="font-size:9px;color:var(--ua-muted);font-weight:400;letter-spacing:0.5px">COMMUNITY · FOR UNITED FLYERS, BY UNITED FLYERS</span></h1>
+  <h1><a href="#" data-action="go-home" style="text-decoration:none;color:inherit;cursor:pointer"><span class="ua">THE BLUE BOARD</span></a> <span style="font-size:9px;color:var(--ua-muted);font-weight:400;letter-spacing:0.5px">FOR UNITED FLYERS, BY UNITED FLYERS</span></h1>
   <div id="global-search-wrap" style="position:relative;flex:0 1 300px">
     <input type="text" id="global-search-input" aria-label="Global flight search" placeholder="Track a flight (UA 1234, N12345, ORD...)" style="width:100%;background:rgba(15,23,41,.8);border:1px solid var(--ua-border);color:var(--ua-text);padding:6px 10px;border-radius:4px;font-family:var(--mono);font-size:11px">
     <div id="global-search-results" style="position:absolute;top:34px;left:0;right:0;background:rgba(17,24,39,.95);border:1px solid var(--ua-border);border-radius:4px;max-height:300px;overflow-y:auto;display:none;z-index:9999;backdrop-filter:blur(8px)"></div>


### PR DESCRIPTION
## Summary
Updated the header tagline on the homepage to remove the word "COMMUNITY ·" from the subtitle, simplifying the messaging while maintaining the core identity statement.

## Changes
- Removed "COMMUNITY · " from the header tagline in `public/index.html`
- Updated tagline from "COMMUNITY · FOR UNITED FLYERS, BY UNITED FLYERS" to "FOR UNITED FLYERS, BY UNITED FLYERS"

## Details
This is a minor text update to the main page header that streamlines the tagline while preserving the essential message about the community being for and by United flyers.

https://claude.ai/code/session_01PL1SfzbvAapC9nqBZbqRHq