### PR TITLE
fix: Sprint 1 quick wins — onboarding, ticker, offline banner, search UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-03-12
+
+### Fixed
+- Onboarding overlay no longer blocks tab interaction — tabs are clickable while the welcome modal is visible
+- Alerts ticker no longer shows "0 mainline aircraft" before fleet data loads
+- Offline banner no longer flashes briefly on page load for connected users
+
+### Changed
+- Search "no results" message now distinguishes flight numbers ("not currently airborne") from tail numbers ("not found in live feed")
+
 ## [1.3] - 2026-03-10
 
 ### Added

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -478,9 +478,9 @@ tbody td{padding:5px 8px;white-space:nowrap}
 .sched-load-more:disabled{opacity:.4;cursor:default}
 
 /* Onboarding Overlay */
-#onboarding-overlay{position:fixed;inset:0;background:rgba(10,14,20,.85);z-index:10000;display:flex;align-items:center;justify-content:center;opacity:0;animation:obFadeIn .4s ease forwards;backdrop-filter:blur(4px)}
+#onboarding-overlay{position:fixed;inset:0;background:rgba(10,14,20,.85);z-index:10000;display:flex;align-items:center;justify-content:center;opacity:0;animation:obFadeIn .4s ease forwards;backdrop-filter:blur(4px);pointer-events:none}
 #onboarding-overlay.ob-hidden{opacity:0;pointer-events:none;transition:opacity .3s ease}
-#onboarding-card{background:var(--ua-panel);border:1px solid var(--ua-border);border-radius:12px;max-width:480px;width:90%;padding:32px;text-align:center;box-shadow:0 0 60px rgba(0,93,170,.15)}
+#onboarding-card{pointer-events:auto;background:var(--ua-panel);border:1px solid var(--ua-border);border-radius:12px;max-width:480px;width:90%;padding:32px;text-align:center;box-shadow:0 0 60px rgba(0,93,170,.15)}
 #onboarding-card h2{font-size:20px;color:#fff;margin-bottom:6px;letter-spacing:.5px}
 .onboarding-subtitle{color:var(--ua-muted);font-size:12px;margin-bottom:24px}
 .onboarding-features{text-align:left;display:flex;flex-direction:column;gap:12px;margin-bottom:24px}

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -1607,8 +1607,11 @@ function updateTicker() {
 
   if (allFlights.length > 0) {
     items.push({ text: `${airborne} United flights airborne`, cls: 'info' });
-    items.push({ text: `Fleet: ${FLEET_DB.length} mainline aircraft`, cls: 'info' });
-    items.push({ text: `${STARLINK_TAILS.size} Starlink-equipped aircraft (incl. United Express)`, cls: 'info' });
+    // Show fleet counts only after fleet data has loaded — avoids misleading "0 aircraft" on initial render
+    if (FLEET_DB.length > 0) {
+      items.push({ text: `Fleet: ${FLEET_DB.length} mainline aircraft`, cls: 'info' });
+      items.push({ text: `${STARLINK_TAILS.size} Starlink-equipped aircraft (incl. United Express)`, cls: 'info' });
+    }
   }
 
   // Check for emergency squawks
@@ -3397,6 +3400,8 @@ function renderScheduleStats(filtered) {
 }
 
 // ═══ OFFLINE DETECTION ═══
+// Only show offline banner on actual 'offline' event — never proactively on load
+// (navigator.onLine can be unreliable during service worker registration, causing a false flash)
 function updateOnlineStatus() {
   const banner = document.getElementById('offline-banner');
   if (!navigator.onLine) {
@@ -3407,7 +3412,6 @@ function updateOnlineStatus() {
 }
 window.addEventListener('online', updateOnlineStatus);
 window.addEventListener('offline', updateOnlineStatus);
-updateOnlineStatus();
 
 // ═══ GLOBAL SEARCH ═══
 document.getElementById('global-search-input').addEventListener('input', debounce(function() {
@@ -3449,7 +3453,17 @@ document.getElementById('global-search-input').addEventListener('input', debounc
   const fr24Option = looksLikeFlight ? `<div class="search-result" style="border-top:1px solid var(--ua-border);color:var(--ua-accent);font-size:10px" data-action="lookup-fr24" data-query="${escapeHtml(normalizedQ)}" data-close-global="1">🔍 Look up ${escapeHtml(normalizedQ.startsWith('UA') || normalizedQ.startsWith('UAL') ? normalizedQ : 'UA' + normalizedQ)} via FlightRadar24...</div>` : '';
 
   if (matches.length === 0) {
-    results.innerHTML = '<div style="padding:10px 12px;color:var(--ua-muted);font-size:10px">No results for "' + escapeHtml(q) + '"</div>' + fr24Option;
+    // Contextual "no results" message based on query format — all user input passed through escapeHtml()
+    const tailPattern = /^N\d{3,5}[A-Z]{0,2}$/i;
+    let noResultMsg;
+    if (looksLikeFlight) {
+      noResultMsg = escapeHtml(normalizedQ.startsWith('UA') || normalizedQ.startsWith('UAL') ? normalizedQ : 'UA' + normalizedQ) + ' is not currently airborne';
+    } else if (tailPattern.test(normalizedQ)) {
+      noResultMsg = escapeHtml(normalizedQ) + ' not found in live feed';
+    } else {
+      noResultMsg = 'No results for "' + escapeHtml(q) + '"';
+    }
+    results.innerHTML = '<div style="padding:10px 12px;color:var(--ua-muted);font-size:10px">' + noResultMsg + '</div>' + fr24Option;
   } else {
     results.innerHTML = matches.slice(0, 20).map(m => {
       if (m.type === 'live') return `<div class="search-result" data-action="focus-flight" data-icao24="${escapeHtml(m.icao24)}" data-close-global="1">${escapeHtml(m.label)}</div>`;
@@ -5613,6 +5627,7 @@ async function initApp() {
   var acDeepLink = new URLSearchParams(location.search).get('aircraft');
   const loadFleetAndInit = async () => {
     await loadFleetData();
+    updateTicker(); // Re-render ticker now that fleet data is available (avoids 30s gap with missing fleet counts)
     initFleetTab();
     var onboardingEl = document.getElementById('onboarding-overlay');
     if (acDeepLink && FLEET_DB.length > 0 && (!onboardingEl || onboardingEl.style.display === 'none')) setTimeout(function() { showAircraftDetail(acDeepLink); }, 500);


### PR DESCRIPTION
## Summary
- **B1**: Onboarding overlay no longer blocks tab interaction — `pointer-events: none` on overlay, `auto` on card
- **B2**: Alerts ticker hides fleet counts until fleet data loads (no more "0 mainline aircraft" flash)
- **B3**: Offline banner no longer flashes on page load — only shown on actual `offline` event
- **U3**: Search "no results" now shows contextual messages: "not currently airborne" for flight numbers, "not found in live feed" for tail numbers

## Pre-Landing Review
Pre-Landing Review: No issues found.

## Eval Results
No prompt-related files changed — evals skipped.

## Test plan
- [x] All Vitest tests pass (138 tests, 10 files, 0 failures)
- [x] Pre-landing review passed with no critical or informational issues
- [x] CSS change verified: `pointer-events` on overlay/card only
- [x] All `innerHTML` assignments use `escapeHtml()` for user input

🤖 Generated with [Claude Code](https://claude.com/claude-code)