### PR TITLE
perf: Sprint 2 — strip hubFlights, fix layout gap, add CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Tests
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] - 2026-03-12
+
+### Changed
+- Strip `hubFlights` from IRROPS API response — reduces payload from ~4.6MB to ~100KB (schedule tab fetches its own data)
+
+### Fixed
+- Weather tab layout gap when hub cards are loading — added min-height to `.hub-cards` container
+
+### Added
+- CI/CD test workflow — `npm test` runs automatically on pushes to main and pull requests
+
 ## [1.3.1] - 2026-03-12
 
 ### Fixed

--- a/api/irrops.ts
+++ b/api/irrops.ts
@@ -127,7 +127,6 @@ export function computeMetrics(flightsByHub: Record<string, any[]>) {
     diversions,
     worstDelays: worstDelays.slice(0, 8),
     hubMetrics,
-    hubFlights: flightsByHub,
     generatedAt: new Date().toISOString()
   };
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "scripts": {
     "dev": "astro dev",
     "build": "vite build --config vite.dashboard.config.js && astro build",

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -258,7 +258,7 @@ tbody td{padding:5px 8px;white-space:nowrap}
 .wx-section-header{text-transform:uppercase;letter-spacing:.8px}
 .scroll-hint-arrow{animation:bounce 1.5s ease-in-out infinite;font-size:14px}
 @keyframes bounce{0%,100%{transform:translateY(0)}50%{transform:translateY(5px)}}
-.hub-cards{display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:14px;padding:16px}
+.hub-cards{display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:14px;padding:16px;min-height:200px}
 .hub-card{background:var(--ua-panel);border:1px solid var(--ua-border);border-radius:6px;overflow:hidden;transition:border-color .2s}
 .hub-card:hover{border-color:var(--ua-accent)}
 .hub-card-top{padding:12px 14px 8px;display:flex;align-items:center;justify-content:space-between}

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -3943,22 +3943,6 @@ async function _doFetchIrropsFromAPI() {
 }
 
 function renderIrropsFromAPI(data) {
-  // Hydrate schedule cache from IRROPS hub flights (avoids 7 separate schedule calls)
-  if (data.hubFlights) {
-    const hubs = ['ORD','DEN','IAH','EWR','SFO','IAD','LAX','NRT','GUM'];
-    hubs.forEach(hub => {
-      const flights = data.hubFlights[hub];
-      if (!flights || !flights.length) return;
-      const hubKey = `${hub}-departures-0`;
-      if (!schedRawByHub[hubKey]) {
-        schedRawByHub[hubKey] = flights;
-        // NOTE: Do NOT populate schedCache here — irrops only fetches 5 pages
-        // per hub, which misses international flights on later pages. Let the
-        // schedule API do a full fetch when the user opens the Schedule tab.
-      }
-    });
-  }
-
   // Store IRROPS hub data globally for delay risk engine
   if (data.hubMetrics) {
     for (const [hub, m] of Object.entries(data.hubMetrics)) {

--- a/tests/irrops.test.js
+++ b/tests/irrops.test.js
@@ -177,6 +177,14 @@ describe('computeMetrics', () => {
     const result = computeMetrics({});
     expect(result.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
+
+  it('does not include hubFlights in response', () => {
+    const t = 1700000000;
+    const result = computeMetrics({
+      ORD: [makeFlight('ORD', { schedDep: t, realDep: t, status: 'landed' })],
+    });
+    expect(result).not.toHaveProperty('hubFlights');
+  });
 });
 
 // ═══ DELAY RISK ENGINE v3 TESTS ═══


### PR DESCRIPTION
## Summary
- **P1**: Strip `hubFlights` from IRROPS API response — reduces payload from ~4.6MB to ~100KB. Schedule tab already fetches its own data when opened.
- **B7**: Fix weather tab layout gap when hub cards are loading — `min-height: 200px` on `.hub-cards` prevents content shift.
- **F12**: Add CI/CD test workflow — `npm test` runs on pushes to main and on PRs.

## Pre-Landing Review
No issues found.

## Eval Results
No prompt-related files changed — evals skipped.

## Test plan
- [x] All Vitest tests pass (139 tests, 10 files)
- [ ] Deploy preview → verify `/api/irrops` response < 200KB in network tab
- [ ] Weather tab → no layout gap before hub cards load
- [ ] Schedule tab → still loads normally via own API call
- [ ] Push PR → verify test.yml workflow triggers and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)