### PR TITLE
feat: scrape-first FR24 routing with circuit breaker (v1.3.4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,8 @@ FR24_API_TOKEN=your-token-here
 # Google Sheets Fleet Data
 FLEET_SHEET_ID=your-sheet-id-here
 
+# FR24 schedule source routing: 'scrape' (default) | 'official' | 'scrape-only'
+SCHEDULE_SOURCE_PRIORITY=scrape
+
 # Vercel Cron Secret (required for cron job auth)
 CRON_SECRET=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.4] - 2026-03-12
+
+### Changed
+- Inverted FR24 schedule routing — scraping is now primary, official API is fallback-of-last-resort (projected ~96-99% credit savings)
+- Added `SCHEDULE_SOURCE_PRIORITY` env var for one-click rollback (`scrape` default, `official`, `scrape-only`)
+
+### Added
+- Circuit breaker on official API fallback — trips after 5 fallbacks in 15 minutes to prevent credit burn during sustained scraping outages
+- `/api/fr24-usage` endpoint — proxies FR24 credit consumption data with 5-minute cache
+- FR24 credit usage widget in dashboard footer — shows remaining credits with color-coded progress bar (green/yellow/red)
+- 6 new schedule tests covering scrape-first routing, fallback, circuit breaker, and scrape-only mode
+
 ## [1.3.3] - 2026-03-12
 
 ### Fixed

--- a/api/fr24-usage.ts
+++ b/api/fr24-usage.ts
@@ -1,0 +1,66 @@
+// FR24 Official API — Credit Usage Monitoring Endpoint
+// Usage: GET /api/fr24-usage
+// Returns current billing period credit consumption from FR24's usage API.
+
+import type { VercelRequest, VercelResponse } from './types.js';
+
+const FR24_BASE = 'https://fr24api.flightradar24.com';
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+let usageCache: { data: any; ts: number } | null = null;
+
+function corsHeaders(req: VercelRequest): Record<string, string> {
+  const origin = req.headers?.origin || '';
+  const allowed = origin === 'https://theblueboard.co' || /^http:\/\/localhost(:\d+)?$/.test(origin as string);
+  return {
+    'Access-Control-Allow-Origin': allowed ? (origin as string) : 'https://theblueboard.co',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+  };
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const cors = corsHeaders(req);
+  for (const [k, v] of Object.entries(cors)) res.setHeader(k, v);
+
+  if (req.method === 'OPTIONS') return res.status(204).end();
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' });
+
+  if (!process.env.FR24_API_TOKEN) {
+    return res.status(200).json({ data: null, error: 'No FR24 API token configured' });
+  }
+
+  // Return cached if fresh
+  if (usageCache && Date.now() - usageCache.ts < CACHE_TTL_MS) {
+    return res.status(200).json({ ...usageCache.data, cached: true });
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10000);
+
+    const resp = await fetch(`${FR24_BASE}/api/usage`, {
+      signal: controller.signal,
+      headers: {
+        'Authorization': `Bearer ${process.env.FR24_API_TOKEN}`,
+        'Accept': 'application/json',
+        'Accept-Version': 'v1',
+        'User-Agent': 'TheBlueBoardDashboard/1.0 (https://theblueboard.co)',
+      },
+    });
+    clearTimeout(timeout);
+
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => '');
+      return res.status(resp.status).json({ error: `FR24 API returned ${resp.status}`, detail: text });
+    }
+
+    const data = await resp.json();
+    usageCache = { data, ts: Date.now() };
+
+    res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate=60');
+    return res.status(200).json({ ...data, cached: false });
+  } catch (e: any) {
+    return res.status(500).json({ error: 'Failed to fetch FR24 usage', detail: e.message });
+  }
+}

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -628,13 +628,42 @@ function triggerBackgroundRefresh(hub: string, dir: string, ts: number, aggKey: 
   pendingAggs.set(aggKey, promise);
 }
 
+// ── Circuit breaker: stop falling back to official API during sustained scraping outages ──
+const fallbackLog: number[] = [];
+const FALLBACK_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+const MAX_FALLBACKS_PER_WINDOW = 5;
+
+export function shouldAttemptOfficialFallback(): boolean {
+  const now = Date.now();
+  while (fallbackLog.length && fallbackLog[0] < now - FALLBACK_WINDOW_MS) fallbackLog.shift();
+  if (fallbackLog.length >= MAX_FALLBACKS_PER_WINDOW) {
+    console.warn(`Circuit breaker tripped: ${fallbackLog.length} official API fallbacks in 15min, skipping`);
+    return false;
+  }
+  return true;
+}
+
+export function recordFallback(): void {
+  fallbackLog.push(Date.now());
+}
+
+export function resetFallbackBreaker(): void {
+  fallbackLog.length = 0;
+}
+
 async function fetchAllPages(hub: string, dir: string, ts: number, timeoutMs?: number, overallDeadline?: number) {
   const logHub = String(hub);
   const now = Date.now();
   const effectiveDeadline = overallDeadline || (now + (timeoutMs || HUB_TIMEOUT_MS[logHub.toUpperCase()] || 45000));
 
-  // Try official FR24 API first
-  if (process.env.FR24_API_TOKEN) {
+  // ── Source routing decision tree ──
+  const srcPriority = (process.env.SCHEDULE_SOURCE_PRIORITY || 'scrape').toLowerCase();
+
+  if (!['scrape', 'official', 'scrape-only'].includes(srcPriority)) {
+    console.warn(`Unrecognized SCHEDULE_SOURCE_PRIORITY: '${srcPriority}', using scrape-only`);
+  }
+
+  if (srcPriority === 'official' && process.env.FR24_API_TOKEN) {
     try {
       const officialTimeout = Math.min(Math.floor((effectiveDeadline - Date.now()) * 0.7), 45000);
       const officialResult = await fetchViaOfficialAPI(logHub, dir, ts, officialTimeout);
@@ -644,7 +673,7 @@ async function fetchAllPages(hub: string, dir: string, ts: number, timeoutMs?: n
     }
   }
 
-  // Fallback: scrape unauthenticated FR24 endpoint (paginated)
+  // Primary path: scrape unauthenticated FR24 endpoint (paginated)
   const deadline = effectiveDeadline;
   const dayEnd = ts + 86400;
   const allUAFlights: any[] = [];
@@ -676,8 +705,23 @@ async function fetchAllPages(hub: string, dir: string, ts: number, timeoutMs?: n
   const startTime = Date.now();
   const firstPage = await fetchOnePage(logHub, dir, ts, 1, deadline);
   if (!firstPage || firstPage._rateLimited) {
+    // Scraping failed on first page — try official API fallback if in scrape-first mode
+    if (srcPriority === 'scrape' && process.env.FR24_API_TOKEN && shouldAttemptOfficialFallback()) {
+      console.log(`Scraping failed on first page for ${logHub} ${dir}, trying official API fallback`);
+      recordFallback();
+      try {
+        const remaining = Math.max(2000, effectiveDeadline - Date.now() - 1000);
+        const officialResult = await fetchViaOfficialAPI(logHub, dir, ts, Math.min(remaining, 30000));
+        if (officialResult && officialResult.total > 0) {
+          officialResult.meta = { ...officialResult.meta, fallbackFrom: 'scraping' };
+          return officialResult;
+        }
+      } catch (e: any) {
+        console.error(`Official API fallback also failed for ${logHub}:`, e.message);
+      }
+    }
     return { flights: [], total: 0, totalFetched: 0, pagesScanned: 0, totalPages: 1, cached: false, partial: true, hub: logHub, dir,
-      meta: { partialReason: 'first_page_failed', pagesRequested: 1, pagesSucceeded: 0, pagesFailed: 1, missingPages: [1], completeness: 0, elapsedMs: Date.now() - startTime }
+      meta: { partialReason: 'first_page_failed', pagesRequested: 1, pagesSucceeded: 0, pagesFailed: 1, missingPages: [1], completeness: 0, elapsedMs: Date.now() - startTime, source: 'scraping' as const }
     };
   }
   totalPages = firstPage.page?.total || 1;
@@ -785,7 +829,7 @@ async function fetchAllPages(hub: string, dir: string, ts: number, timeoutMs?: n
     else partialReason = 'unknown';
   }
 
-  return {
+  const scrapeResult = {
     flights: allUAFlights,
     total: allUAFlights.length,
     totalFetched,
@@ -802,9 +846,29 @@ async function fetchAllPages(hub: string, dir: string, ts: number, timeoutMs?: n
       pagesFailed: allFailedPages.length,
       missingPages: allFailedPages,
       completeness: pagesRequested > 0 ? Math.round(((pagesScanned - allFailedPages.length) / pagesRequested) * 100) / 100 : 1,
-      elapsedMs
+      elapsedMs,
+      source: 'scraping' as const
     }
   };
+
+  // Scrape-first fallback: if scraping failed completely, try official API (with circuit breaker)
+  if (srcPriority === 'scrape' && scrapeResult.total === 0 && scrapeResult.partial
+      && process.env.FR24_API_TOKEN && shouldAttemptOfficialFallback()) {
+    console.log(`Scraping returned 0 flights for ${logHub} ${dir}, trying official API fallback`);
+    recordFallback();
+    try {
+      const remaining = Math.max(2000, effectiveDeadline - Date.now() - 1000);
+      const officialResult = await fetchViaOfficialAPI(logHub, dir, ts, Math.min(remaining, 30000));
+      if (officialResult && officialResult.total > 0) {
+        officialResult.meta = { ...officialResult.meta, fallbackFrom: 'scraping' };
+        return officialResult;
+      }
+    } catch (e: any) {
+      console.error(`Official API fallback also failed for ${logHub}:`, e.message);
+    }
+  }
+
+  return scrapeResult;
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "scripts": {
     "dev": "astro dev",
     "build": "vite build --config vite.dashboard.config.js && astro build",

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -596,6 +596,14 @@ table,thead th,tbody td,.stat-val,.metric-val,.big-number,.ticker,.ticker-item,.
 .shimmer-loader *{visibility:hidden}
 .irrops-empty,.popup-times-loading{background:linear-gradient(90deg,var(--ua-panel) 25%,rgba(30,41,59,.6) 50%,var(--ua-panel) 75%);background-size:200% 100%;animation:shimmerSlide 1.5s ease-in-out infinite;border-radius:4px}
 
+/* ═══ FR24 CREDIT USAGE WIDGET ═══ */
+#fr24-credit-widget{position:fixed;bottom:8px;right:8px;background:var(--ua-panel);border:1px solid var(--ua-border);border-radius:6px;padding:8px 12px;font-family:var(--font-mono);font-size:11px;color:var(--ua-muted);z-index:900;min-width:200px;opacity:.85;transition:opacity .2s}
+#fr24-credit-widget:hover{opacity:1}
+.credit-widget-label{margin-bottom:4px}
+.credit-widget-bar-bg{height:6px;background:var(--ua-border);border-radius:3px;overflow:hidden}
+.credit-widget-bar{height:100%;border-radius:3px;transition:width .5s ease}
+@media(max-width:768px){#fr24-credit-widget{display:none}}
+
 /* ═══ MOBILE SCROLL FADE MASKS ═══ */
 @media(max-width:768px){
   #stats-bar{-webkit-mask-image:linear-gradient(to right,transparent,#000 16px,#000 calc(100% - 24px),transparent);mask-image:linear-gradient(to right,transparent,#000 16px,#000 calc(100% - 24px),transparent)}

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -5608,6 +5608,47 @@ async function initApp() {
   // Background preload: fetch top 3 hubs on idle so Schedule tab is fast without hammering mobile
   const idlePreload = () => { preloadScheduleData(); fetchIrropsFromAPI(); preloadWeatherAndFAA(); };
   if ('requestIdleCallback' in window) requestIdleCallback(idlePreload); else setTimeout(idlePreload, 5000);
+  initCreditWidget();
+}
+
+// ═══ FR24 CREDIT USAGE WIDGET ═══
+function initCreditWidget() {
+  function render(data) {
+    var existing = document.getElementById('fr24-credit-widget');
+    if (existing) existing.remove();
+    if (!data || !data.data) return;
+    var rows = data.data;
+    var totalCredits = 0;
+    for (var i = 0; i < rows.length; i++) totalCredits += (rows[i].credits || 0);
+    var limit = 60000; // Explorer tier
+    var remaining = Math.max(0, limit - totalCredits);
+    var pct = Math.round((remaining / limit) * 100);
+    var color = pct > 50 ? 'var(--ua-green)' : pct > 20 ? 'var(--ua-yellow)' : 'var(--ua-red)';
+
+    var w = document.createElement('div');
+    w.id = 'fr24-credit-widget';
+
+    var label = document.createElement('div');
+    label.className = 'credit-widget-label';
+    label.textContent = 'FR24 API: ' + remaining.toLocaleString() + ' / ' + limit.toLocaleString() + ' credits remaining';
+    w.appendChild(label);
+
+    var barBg = document.createElement('div');
+    barBg.className = 'credit-widget-bar-bg';
+    var bar = document.createElement('div');
+    bar.className = 'credit-widget-bar';
+    bar.style.width = pct + '%';
+    bar.style.background = color;
+    barBg.appendChild(bar);
+    w.appendChild(barBg);
+
+    document.body.appendChild(w);
+  }
+  function load() {
+    fetch('/api/fr24-usage').then(function(r) { return r.json(); }).then(render).catch(function() {});
+  }
+  load();
+  setInterval(load, 5 * 60 * 1000);
 }
 
 // Both Leaflet and dashboard are deferred — Leaflet loads first (script order preserved).

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import handler from '../api/schedule.js';
+import handler, { shouldAttemptOfficialFallback, recordFallback, resetFallbackBreaker } from '../api/schedule.js';
 
 function createRes() {
   return {
@@ -27,6 +27,8 @@ describe('schedule API', () => {
 
   afterEach(() => {
     delete process.env.FR24_API_TOKEN;
+    delete process.env.SCHEDULE_SOURCE_PRIORITY;
+    resetFallbackBreaker();
   });
 
   it('treats missing schedule block on page 1 as empty data instead of upstream failure', async () => {
@@ -62,6 +64,7 @@ describe('schedule API', () => {
 
   it('returns valid empty result when official API returns 0 flights', async () => {
     process.env.FR24_API_TOKEN = 'test-token-12345678';
+    process.env.SCHEDULE_SOURCE_PRIORITY = 'official';
 
     vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: true,
@@ -88,6 +91,7 @@ describe('schedule API', () => {
 
   it('parses numeric-string timestamps from official API so schedule times are populated', async () => {
     process.env.FR24_API_TOKEN = 'test-token-12345678';
+    process.env.SCHEDULE_SOURCE_PRIORITY = 'official';
 
     vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: true,
@@ -125,6 +129,7 @@ describe('schedule API', () => {
 
   it('marks response partial when official API fails after first page', async () => {
     process.env.FR24_API_TOKEN = 'test-token-12345678';
+    process.env.SCHEDULE_SOURCE_PRIORITY = 'official';
 
     const firstPageFlights = Array.from({ length: 10000 }, (_, i) => ({
       flight_icao: `UAL${2000 + i}`,
@@ -171,6 +176,7 @@ describe('schedule API', () => {
 
   it('rejects sparse official API data and falls back to scraping', async () => {
     process.env.FR24_API_TOKEN = 'test-token-12345678';
+    process.env.SCHEDULE_SOURCE_PRIORITY = 'official';
 
     // Official API returns flights with no scheduled times (sparse)
     const sparseFlights = Array.from({ length: 10 }, (_, i) => ({
@@ -242,6 +248,7 @@ describe('schedule API', () => {
 
   it('filters individual sparse flights but keeps good ones from official API', async () => {
     process.env.FR24_API_TOKEN = 'test-token-12345678';
+    process.env.SCHEDULE_SOURCE_PRIORITY = 'official';
 
     const mixedFlights = [
       // Good flights with scheduled times
@@ -284,5 +291,242 @@ describe('schedule API', () => {
     expect(res.body.meta.source).toBe('official-api');
     expect(res.body.total).toBe(8); // only good flights
     expect(res.body.meta.sparseFiltered).toBe(2);
+  });
+
+  // ═══ NEW: Scrape-first routing tests ═══
+
+  it('scrape-first: scraping succeeds, official API never called', async () => {
+    process.env.FR24_API_TOKEN = 'test-token-12345678';
+    // Default SCHEDULE_SOURCE_PRIORITY is 'scrape'
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes('fr24api.flightradar24.com')) {
+        throw new Error('Official API should not be called');
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          result: {
+            response: {
+              airport: {
+                pluginData: {
+                  schedule: {
+                    departures: {
+                      page: { current: 1, total: 1 },
+                      data: [{
+                        flight: {
+                          airline: { code: { iata: 'UA' } },
+                          identification: { number: { default: 'UA100' } },
+                          time: { scheduled: { departure: 1741653600, arrival: 1741660800 } },
+                          airport: {
+                            origin: { code: { iata: 'ORD' } },
+                            destination: { code: { iata: 'LAX' } }
+                          }
+                        }
+                      }]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }),
+      };
+    });
+
+    const ts = Math.floor(Date.now() / 1000) - 21600;
+    const req = {
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'ORD', dir: 'departures', timestamp: String(ts) }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.meta.source).toBe('scraping');
+    // Verify no calls went to the official API
+    for (const call of fetchSpy.mock.calls) {
+      expect(String(call[0])).not.toContain('fr24api.flightradar24.com');
+    }
+  });
+
+  it('scrape-first: scraping fails, falls back to official API', async () => {
+    process.env.FR24_API_TOKEN = 'test-token-12345678';
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes('fr24api.flightradar24.com')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: [{
+              flight_icao: 'UAL200',
+              flight_iata: 'UA200',
+              status: 'scheduled',
+              orig_iata: 'LAX',
+              dest_iata: 'SFO',
+              scheduled_departure: 1741653600,
+              scheduled_arrival: 1741660800,
+            }]
+          }),
+        };
+      }
+      // Scraping returns 403
+      return { ok: false, status: 403, text: async () => 'Forbidden', headers: { get: () => null } };
+    });
+
+    const ts = Math.floor(Date.now() / 1000) - 25200;
+    const req = {
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'LAX', dir: 'departures', timestamp: String(ts) }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.meta.source).toBe('official-api');
+    expect(res.body.meta.fallbackFrom).toBe('scraping');
+  });
+
+  it('circuit breaker trips after repeated fallbacks', () => {
+    // Record 5 fallbacks — breaker should trip
+    for (let i = 0; i < 5; i++) recordFallback();
+    expect(shouldAttemptOfficialFallback()).toBe(false);
+
+    // Reset and verify breaker is open again
+    resetFallbackBreaker();
+    expect(shouldAttemptOfficialFallback()).toBe(true);
+  });
+
+  it('scrape-first: empty schedule (not partial) does not trigger fallback', async () => {
+    process.env.FR24_API_TOKEN = 'test-token-12345678';
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes('fr24api.flightradar24.com')) {
+        throw new Error('Official API should not be called');
+      }
+      // Scraping returns valid but empty schedule (no UA flights)
+      return {
+        ok: true,
+        json: async () => ({
+          result: {
+            response: {
+              airport: {
+                pluginData: {
+                  schedule: {
+                    departures: {
+                      page: { current: 1, total: 1 },
+                      data: []
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }),
+      };
+    });
+
+    const ts = Math.floor(Date.now() / 1000) - 28800;
+    const req = {
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'DEN', dir: 'departures', timestamp: String(ts) }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.total).toBe(0);
+    expect(res.body.partial).toBe(false);
+    // Official API should never have been called
+    for (const call of fetchSpy.mock.calls) {
+      expect(String(call[0])).not.toContain('fr24api.flightradar24.com');
+    }
+  });
+
+  it('scrape-only mode: official API never called even on failure', async () => {
+    process.env.FR24_API_TOKEN = 'test-token-12345678';
+    process.env.SCHEDULE_SOURCE_PRIORITY = 'scrape-only';
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes('fr24api.flightradar24.com')) {
+        throw new Error('Official API should not be called in scrape-only mode');
+      }
+      // Scraping fails
+      return { ok: false, status: 500, text: async () => 'Error', headers: { get: () => null } };
+    });
+
+    const ts = Math.floor(Date.now() / 1000) - 32400;
+    const req = {
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'IAD', dir: 'departures', timestamp: String(ts) }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.partial).toBe(true);
+    // Official API should never have been called
+    for (const call of fetchSpy.mock.calls) {
+      expect(String(call[0])).not.toContain('fr24api.flightradar24.com');
+    }
+  });
+
+  it('meta.source is scraping on default successful scrape', async () => {
+    // No FR24_API_TOKEN — simplest case
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        result: {
+          response: {
+            airport: {
+              pluginData: {
+                schedule: {
+                  departures: {
+                    page: { current: 1, total: 1 },
+                    data: [{
+                      flight: {
+                        airline: { code: { iata: 'UA' } },
+                        identification: { number: { default: 'UA300' } },
+                        time: { scheduled: { departure: 1741653600, arrival: 1741660800 } },
+                        airport: {
+                          origin: { code: { iata: 'SFO' } },
+                          destination: { code: { iata: 'ORD' } }
+                        }
+                      }
+                    }]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }),
+    });
+
+    const ts = Math.floor(Date.now() / 1000) - 36000;
+    const req = {
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'SFO', dir: 'departures', timestamp: String(ts) }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.total).toBe(1);
+    expect(res.body.meta.source).toBe('scraping');
   });
 });


### PR DESCRIPTION
## Summary
- Inverted FR24 schedule routing — scraping is now primary, official API is fallback-of-last-resort (projected ~96-99% credit savings, from ~25k/day to <500/day)
- Added circuit breaker on official API fallback — trips after 5 fallbacks in 15 minutes to prevent credit burn during sustained scraping outages
- New `/api/fr24-usage` endpoint — proxies FR24 credit consumption data with 5-minute cache
- FR24 credit usage widget in dashboard footer — shows remaining credits with color-coded progress bar (green/yellow/red)
- `SCHEDULE_SOURCE_PRIORITY` env var for one-click rollback (`scrape` default, `official`, `scrape-only`)
- 6 new schedule tests covering scrape-first routing, fallback, circuit breaker, and scrape-only mode

## Pre-Landing Review
Pre-Landing Review: 1 issue (0 critical, 1 informational)

**Issues** (non-blocking):
- [api/schedule.ts:713+855] Duplicated fallback block — official-API-fallback logic is copy-pasted in two places (first-page-failed early return and end-of-scraping fallback). Consider extracting a helper if fallback conditions change.

## Eval Results
No prompt-related files changed — evals skipped.

## Test plan
- [x] All Vitest tests pass (146 tests, 10 files, 0 failures)
- [x] 6 new tests: scrape-first success, scrape-first fallback, circuit breaker, empty-not-partial, scrape-only, meta.source tracking
- [x] All 6 existing schedule tests preserved with SCHEDULE_SOURCE_PRIORITY=official

🤖 Generated with [Claude Code](https://claude.com/claude-code)