### PR TITLE
fix: reduce partial schedule data + admin-only credit widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.5] - 2026-03-12
+
+### Fixed
+- Reduced frequent partial schedule data — lowered batch size (6→3) and increased delays to avoid FR24 rate limiting
+- Rate-limited pages no longer abort the entire fetch loop — pauses 2s and continues with remaining pages
+- Increased cron warmer inter-hub delay (1s→3s) to reduce FR24 burst pressure
+
+### Changed
+- Credit usage widget is now admin-only — visit `?admin` to enable, `?admin=off` to disable
+
 ## [1.3.4] - 2026-03-12
 
 ### Changed

--- a/api/cron/warm-schedules.ts
+++ b/api/cron/warm-schedules.ts
@@ -60,8 +60,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const { key, result } = await warmOne(hub, 'departures', todayTs.ts, todayTs.label);
     results[key] = result;
     if (result.status === 'ok') warmed++; else failed++;
-    // Brief pause between hubs to avoid overwhelming FR24
-    await new Promise(r => setTimeout(r, 1000));
+    // Pause between hubs to avoid FR24 rate limiting
+    await new Promise(r => setTimeout(r, 3000));
   }
 
   // Phase 1.5: warm Starlink data cache (single fast request)
@@ -86,7 +86,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const { key, result } = await warmOne(hub, 'departures', tomorrowTs.ts, tomorrowTs.label);
     results[key] = result;
     if (result.status === 'ok') warmed++; else failed++;
-    await new Promise(r => setTimeout(r, 1000));
+    await new Promise(r => setTimeout(r, 3000));
   }
 
   console.log(`Cron warm-schedules: ${warmed} warmed, ${failed} failed`, results);

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -14,7 +14,7 @@ const lastCompleteCache = new Map<string, { data: any; time: number }>();
 const lastCompleteByHubDir = new Map<string, { data: any; time: number; sourceKey: string }>();
 const MAX_COMPLETE_CACHE_SIZE = 50;
 const COMPLETE_CACHE_MAX_AGE = 1800000; // 30 minutes
-const BATCH_DELAY = 250; // 250ms pause between parallel batches
+const BATCH_DELAY = 500; // 500ms pause between parallel batches
 const STALE_GRACE = 120000; // serve stale data for up to 2min past expiry
 
 // Busy hubs get more time to fetch all pages (capped at 55s for Vercel's 60s maxDuration)
@@ -683,7 +683,7 @@ async function fetchAllPages(hub: string, dir: string, ts: number, timeoutMs?: n
   let pagesScanned = 0;
   const failedPages: number[] = [];
   const rateLimitedPages: number[] = [];
-  const BATCH_SIZE = 6;
+  const BATCH_SIZE = 3;
   const MAX_PAGES = 50;
 
   function processPage(sched: any): boolean {
@@ -761,7 +761,11 @@ async function fetchAllPages(hub: string, dir: string, ts: number, timeoutMs?: n
         if (!sched.data || sched.data.length === 0) { batchDone = true; break; }
         if (processPage(sched)) { batchDone = true; break; }
       }
-      if (hitRateLimit) { partial = true; break; }
+      if (hitRateLimit && batchDone) break;
+      if (hitRateLimit) {
+        // Don't abort entire loop — pause and continue with remaining pages
+        await new Promise(r => setTimeout(r, 2000));
+      }
       if (batchDone) break;
 
       pageNum = batchEnd + 1;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "scripts": {
     "dev": "astro dev",
     "build": "vite build --config vite.dashboard.config.js && astro build",

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -5612,7 +5612,14 @@ async function initApp() {
 }
 
 // ═══ FR24 CREDIT USAGE WIDGET ═══
+// Admin-only: visit theblueboard.co?admin to enable, ?admin=off to disable
 function initCreditWidget() {
+  var params = new URLSearchParams(location.search);
+  if (params.has('admin')) {
+    if (params.get('admin') === 'off') { localStorage.removeItem('bb_admin'); return; }
+    localStorage.setItem('bb_admin', '1');
+  }
+  if (!localStorage.getItem('bb_admin')) return;
   function render(data) {
     var existing = document.getElementById('fr24-credit-widget');
     if (existing) existing.remove();


### PR DESCRIPTION
## Summary
- Reduce `BATCH_SIZE` 6→3 and `BATCH_DELAY` 250→500ms to stay under FR24's undocumented rate limits
- On rate-limit hit, pause 2s and continue fetching remaining pages instead of aborting the entire loop (a single 429 on page 5 was previously abandoning pages 6-15)
- Increase cron warmer inter-hub delay 1s→3s to reduce burst pressure on FR24
- Gate credit widget behind `localStorage` admin flag — visit `?admin` to enable, `?admin=off` to disable

## Root Cause
`BATCH_SIZE=6` concurrent requests per batch was too aggressive for FR24's unauthenticated endpoint. Combined with the cron warmer hitting 9 hubs back-to-back with only 1s gaps, FR24 was frequently returning 429s. The old code treated any rate-limited page as a hard abort, so even 1 throttled response out of 6 marked the entire result as partial.

## Test plan
- [x] All 146 tests pass
- [x] Credit widget hidden for non-admin visitors

🤖 Generated with [Claude Code](https://claude.com/claude-code)