### PR TITLE
Switch license from MIT to Functional Source License (FSL-1.1-MIT)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,102 @@
-MIT License
+# Functional Source License, Version 1.1, MIT Future License
 
-Copyright (c) 2026 Jonah Berg
+## Abbreviation
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+FSL-1.1-MIT
+
+## Notice
+
+Copyright 2026 Jonah Berg
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the MIT license that is effective on the second anniversary of the date we make
+the Software available. On or after that date, you may use the Software under
+the MIT license, in which case the following will apply:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ All flight data is provided for informational purposes only and may be delayed, 
 
 ## License
 
-MIT — see [LICENSE](LICENSE) for details.
+[FSL-1.1-MIT](https://fsl.software/) — see [LICENSE](LICENSE) for details.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "the-blue-board",
   "description": "The Blue Board — Unofficial United Airlines operations dashboard",
   "author": "Jonah Berg (https://github.com/notjbg)",
-  "license": "MIT",
+  "license": "FSL-1.1-MIT",
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary

This PR updates the project's licensing from MIT to the Functional Source License 1.1 with a future MIT license grant (FSL-1.1-MIT). This is a dual-licensing approach that provides commercial protections while guaranteeing the software will become MIT-licensed after two years.

## Key Changes

- **LICENSE file**: Replaced MIT license with comprehensive FSL-1.1-MIT terms that:
  - Permit use for internal use, non-commercial education, non-commercial research, and professional services
  - Restrict "Competing Uses" (commercial products/services that substitute for the Software)
  - Include an irrevocable grant to use the software under MIT license on the second anniversary
  - Maintain patent protections and trademark restrictions

- **package.json**: Updated license field from `"MIT"` to `"FSL-1.1-MIT"`

- **README.md**: Updated license reference to point to FSL-1.1-MIT with link to fsl.software

## Notable Details

The FSL-1.1-MIT license provides a time-limited commercial restriction while guaranteeing eventual open-source freedom. After two years from the software's availability date, users automatically gain the right to use the software under the standard MIT license without restrictions.

https://claude.ai/code/session_01BM8ga92rb34Lzd2vQ3Wans