### PR TITLE
fix: security hardening on database, API, and LLM endpoints

### DIFF
--- a/api/cron/sync-starlink.ts
+++ b/api/cron/sync-starlink.ts
@@ -7,8 +7,8 @@ import type { VercelRequest, VercelResponse } from '../types.js';
 const UPSTREAM_URL = 'https://unitedstarlinktracker.com/api/data';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
-  // Verify cron secret in production
-  if (process.env.CRON_SECRET && req.headers['authorization'] !== `Bearer ${process.env.CRON_SECRET}`) {
+  // Verify cron secret — reject if missing or mismatched
+  if (req.headers['authorization'] !== `Bearer ${process.env.CRON_SECRET}`) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
 

--- a/api/delay-explain.ts
+++ b/api/delay-explain.ts
@@ -32,6 +32,12 @@ interface DelayContext {
   connection?: string;
 }
 
+// Sanitize context fields: truncate to max length, strip instruction-like patterns
+function sanitize(val: string | undefined, maxLen: number): string {
+  if (!val || typeof val !== 'string') return '';
+  return val.slice(0, maxLen).replace(/(\bignore\b.*\binstructions?\b|\bsystem\b.*\bprompt\b|\bforget\b.*\babove\b|\bact as\b|\byou are now\b)/gi, '[filtered]');
+}
+
 function getCacheKey(ctx: DelayContext): string {
   const inboundKey = ctx.inbound ? ctx.inbound.slice(0, 100) : '';
   const weatherKey = (ctx.weather || '').slice(0, 40) + '|' + (ctx.destWeather || '').slice(0, 40);
@@ -70,21 +76,28 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     // Build context prompt with aircraft journey chain
+    // All fields sanitized to mitigate prompt injection via crafted POST bodies
+    const flight = sanitize(ctx.flight, 20);
+    const route = sanitize(ctx.route, 20);
+    const status = sanitize(ctx.status, 30);
+    const riskLabel = sanitize(ctx.riskLabel, 20);
+    const riskScore = typeof ctx.riskScore === 'number' ? Math.max(0, Math.min(100, ctx.riskScore)) : 0;
+
     const lines = [
-      `Flight: ${ctx.flight} (${ctx.route || 'unknown route'})`,
-      `Status: ${ctx.status || 'scheduled'}`,
-      `Risk Level: ${ctx.riskLabel || 'LOW'} (score ${ctx.riskScore || 0}/100)`,
+      `Flight: ${flight} (${route || 'unknown route'})`,
+      `Status: ${status || 'scheduled'}`,
+      `Risk Level: ${riskLabel || 'LOW'} (score ${riskScore}/100)`,
     ];
-    if (ctx.factors && ctx.factors.length > 0) {
-      lines.push(`Contributing factors: ${ctx.factors.join('; ')}`);
+    if (ctx.factors && Array.isArray(ctx.factors)) {
+      lines.push(`Contributing factors: ${ctx.factors.map(f => sanitize(f, 80)).join('; ')}`);
     }
-    if (ctx.otp) lines.push(`Hub on-time performance: ${ctx.otp}%`);
-    if (ctx.weather) lines.push(`Origin weather: ${ctx.weather}`);
-    if (ctx.destWeather) lines.push(`Destination weather: ${ctx.destWeather}`);
-    if (ctx.irops) lines.push(`Hub disruption status: ${ctx.irops}`);
-    if (ctx.hubTime) lines.push(`Current local time at hub: ${ctx.hubTime}`);
-    if (ctx.connection) lines.push(`Passenger connection: ${ctx.connection}`);
-    if (ctx.inbound) lines.push(`Aircraft journey: ${ctx.inbound}`);
+    if (ctx.otp) lines.push(`Hub on-time performance: ${sanitize(ctx.otp, 10)}%`);
+    if (ctx.weather) lines.push(`Origin weather: ${sanitize(ctx.weather, 200)}`);
+    if (ctx.destWeather) lines.push(`Destination weather: ${sanitize(ctx.destWeather, 200)}`);
+    if (ctx.irops) lines.push(`Hub disruption status: ${sanitize(ctx.irops, 200)}`);
+    if (ctx.hubTime) lines.push(`Current local time at hub: ${sanitize(ctx.hubTime, 30)}`);
+    if (ctx.connection) lines.push(`Passenger connection: ${sanitize(ctx.connection, 100)}`);
+    if (ctx.inbound) lines.push(`Aircraft journey: ${sanitize(ctx.inbound, 300)}`);
 
     const message = await getClient().messages.create({
       model: 'claude-haiku-4-5',

--- a/api/fr24-usage.ts
+++ b/api/fr24-usage.ts
@@ -3,9 +3,11 @@
 // Returns current billing period credit consumption from FR24's usage API.
 
 import type { VercelRequest, VercelResponse } from './types.js';
+import { createRateLimiter } from './_rate-limit.js';
 
 const FR24_BASE = 'https://fr24api.flightradar24.com';
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const isRateLimited = createRateLimiter('fr24-usage', 10);
 
 let usageCache: { data: any; ts: number } | null = null;
 
@@ -25,6 +27,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   if (req.method === 'OPTIONS') return res.status(204).end();
   if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' });
+
+  if (isRateLimited(req)) {
+    return res.status(429).json({ error: 'Too many requests — try again later' });
+  }
 
   if (!process.env.FR24_API_TOKEN) {
     return res.status(200).json({ data: null, error: 'No FR24 API token configured' });
@@ -51,8 +57,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     clearTimeout(timeout);
 
     if (!resp.ok) {
-      const text = await resp.text().catch(() => '');
-      return res.status(resp.status).json({ error: `FR24 API returned ${resp.status}`, detail: text });
+      console.error(`FR24 usage API returned ${resp.status}`);
+      return res.status(502).json({ error: 'Upstream API error' });
     }
 
     const data = await resp.json();
@@ -61,6 +67,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate=60');
     return res.status(200).json({ ...data, cached: false });
   } catch (e: any) {
-    return res.status(500).json({ error: 'Failed to fetch FR24 usage', detail: e.message });
+    console.error('FR24 usage fetch error:', e.message);
+    return res.status(500).json({ error: 'Failed to fetch usage data' });
   }
 }

--- a/sql/001_waitlist.sql
+++ b/sql/001_waitlist.sql
@@ -7,3 +7,10 @@ CREATE TABLE waitlist (
 );
 
 CREATE INDEX idx_waitlist_email ON waitlist(email);
+
+-- Row Level Security: anon key can only INSERT, not read
+ALTER TABLE waitlist ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "anon_insert_only" ON waitlist
+  FOR INSERT TO anon
+  WITH CHECK (true);

--- a/sql/002_waitlist_rls.sql
+++ b/sql/002_waitlist_rls.sql
@@ -1,0 +1,11 @@
+-- Enable Row Level Security on waitlist table
+-- Without RLS, anyone with the Supabase anon key can SELECT all rows
+ALTER TABLE waitlist ENABLE ROW LEVEL SECURITY;
+
+-- Allow anonymous inserts (for the waitlist signup flow)
+CREATE POLICY "anon_insert_only" ON waitlist
+  FOR INSERT TO anon
+  WITH CHECK (true);
+
+-- No SELECT/UPDATE/DELETE policies for anon = no reads via public API
+-- Server-side access uses the service_role key which bypasses RLS

--- a/vercel.json
+++ b/vercel.json
@@ -24,7 +24,7 @@
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://unpkg.com https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://*.basemaps.cartocdn.com https://*.tile.openstreetmap.org https://mesonet.agron.iastate.edu https://theblueboard.co; connect-src 'self' https://theblueboard.co https://va.vercel-scripts.com https://vitals.vercel-insights.com https://*.supabase.co; frame-ancestors 'none'" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://unpkg.com https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://*.basemaps.cartocdn.com https://*.tile.openstreetmap.org https://mesonet.agron.iastate.edu https://theblueboard.co; connect-src 'self' https://theblueboard.co https://va.vercel-scripts.com https://vitals.vercel-insights.com; frame-ancestors 'none'" }
       ]
     },
     {


### PR DESCRIPTION
## Summary
Security audit of recent PRs (#82–#91) identified 5 vulnerabilities. All fixed and tested.

**Critical**: Waitlist table missing RLS allowed anon Supabase key to SELECT all email addresses. Added insert-only policy.
**Moderate**: Wildcard CSP for Supabase in vercel.json removed (client has no direct access).
**Low**: `/api/fr24-usage` lacked rate limiting and exposed error details. Added rate limit + sanitized errors.
**Low**: `/api/delay-explain` susceptible to prompt injection. Added input sanitization with pattern filtering.
**Bonus**: Cron auth in `sync-starlink` could bypass if env unset. Made unconditional like `warm-schedules`.

All 165 tests passing. See `sql/002_waitlist_rls.sql` for live Supabase migration.