### PR TITLE
fix: use service role key for waitlist API

### DIFF
--- a/api/_supabase.ts
+++ b/api/_supabase.ts
@@ -4,10 +4,13 @@
 import { createClient } from '@supabase/supabase-js';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
+// Use service role key for server-side API routes (bypasses RLS)
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
 
-if (!supabaseUrl || !supabaseAnonKey) {
+if (!supabaseUrl || !supabaseKey) {
   console.warn('Supabase env vars missing — waitlist writes will fail');
+} else if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
+  console.warn('SUPABASE_SERVICE_ROLE_KEY missing — falling back to anon key (RLS will apply)');
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = createClient(supabaseUrl, supabaseKey);


### PR DESCRIPTION
## Summary
- Waitlist email signup was returning 500 — the Supabase client used the anon key (subject to RLS), but the INSERT policy was never applied to the database
- Switched `api/_supabase.ts` to use `SUPABASE_SERVICE_ROLE_KEY` (already in Vercel env vars) which bypasses RLS — appropriate for server-side API routes
- Added a fallback warning log if the service role key is missing, so the failure mode is visible in Vercel logs

## Test plan
- [x] Verified fix with direct curl to Supabase REST API — insert succeeds with service role key
- [ ] After deploy: submit email via waitlist modal on theblueboard.co
- [ ] Verify duplicate email submission returns success (upsert)
- [ ] Verify invalid email returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)