### PR TITLE
update: improve donation CTA in waitlist modal

### DIFF
--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -5874,7 +5874,7 @@ function hideDisclaimer() {
     donateBtn.target = '_blank';
     donateBtn.rel = 'noopener noreferrer';
     donateBtn.style.cssText = 'display:inline-block;padding:10px 28px;background:rgba(255,255,255,0.08);border:1px solid var(--ua-accent);color:var(--ua-accent);border-radius:8px;font-size:14px;font-weight:600;font-family:var(--font-ui);text-decoration:none;transition:background .2s,color .2s;cursor:pointer';
-    donateBtn.textContent = 'Donate $5';
+    donateBtn.textContent = 'Donate';
     donateBtn.addEventListener('mouseenter', function() { donateBtn.style.background = 'var(--ua-accent)'; donateBtn.style.color = '#fff'; });
     donateBtn.addEventListener('mouseleave', function() { donateBtn.style.background = 'rgba(255,255,255,0.08)'; donateBtn.style.color = 'var(--ua-accent)'; });
     donateWrap.appendChild(donateBtn);

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -5862,19 +5862,23 @@ function hideDisclaimer() {
     badges.appendChild(badge2);
     content.appendChild(badges);
 
-    // Coffee link (secondary)
-    var coffeeWrap = document.createElement('div');
-    coffeeWrap.style.cssText = 'margin-top:20px;padding-top:16px;border-top:1px solid var(--ua-border);font-size:12px;color:var(--ua-muted);line-height:1.5';
-    var coffeeIcon = document.createTextNode('\u2615 Like what you see? Help cover the server costs \u2192 ');
-    coffeeWrap.appendChild(coffeeIcon);
-    var coffeeLink = document.createElement('a');
-    coffeeLink.href = 'https://buymeacoffee.com/notjbg';
-    coffeeLink.target = '_blank';
-    coffeeLink.rel = 'noopener noreferrer';
-    coffeeLink.style.cssText = 'color:var(--ua-accent);text-decoration:none;font-weight:600';
-    coffeeLink.textContent = 'Buy a coffee';
-    coffeeWrap.appendChild(coffeeLink);
-    content.appendChild(coffeeWrap);
+    // Donation CTA (prominent)
+    var donateWrap = document.createElement('div');
+    donateWrap.style.cssText = 'margin-top:20px;padding-top:16px;border-top:1px solid var(--ua-border);text-align:center';
+    var donateText = document.createElement('div');
+    donateText.style.cssText = 'font-size:14px;color:var(--ua-fg);line-height:1.5;margin-bottom:12px';
+    donateText.textContent = 'This site costs real money to run \u2014 API calls, hosting, and hours of dev time. It\u2019s free because one person pays for it.';
+    donateWrap.appendChild(donateText);
+    var donateBtn = document.createElement('a');
+    donateBtn.href = 'https://buymeacoffee.com/notjbg';
+    donateBtn.target = '_blank';
+    donateBtn.rel = 'noopener noreferrer';
+    donateBtn.style.cssText = 'display:inline-block;padding:10px 28px;background:rgba(255,255,255,0.08);border:1px solid var(--ua-accent);color:var(--ua-accent);border-radius:8px;font-size:14px;font-weight:600;font-family:var(--font-ui);text-decoration:none;transition:background .2s,color .2s;cursor:pointer';
+    donateBtn.textContent = '\u2615 Buy me a coffee';
+    donateBtn.addEventListener('mouseenter', function() { donateBtn.style.background = 'var(--ua-accent)'; donateBtn.style.color = '#fff'; });
+    donateBtn.addEventListener('mouseleave', function() { donateBtn.style.background = 'rgba(255,255,255,0.08)'; donateBtn.style.color = 'var(--ua-accent)'; });
+    donateWrap.appendChild(donateBtn);
+    content.appendChild(donateWrap);
 
     card.appendChild(content);
     backdrop.appendChild(card);

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -5867,14 +5867,14 @@ function hideDisclaimer() {
     donateWrap.style.cssText = 'margin-top:20px;padding-top:16px;border-top:1px solid var(--ua-border);text-align:center';
     var donateText = document.createElement('div');
     donateText.style.cssText = 'font-size:14px;color:var(--ua-fg);line-height:1.5;margin-bottom:12px';
-    donateText.textContent = 'This site costs real money to run \u2014 API calls, hosting, and hours of dev time. It\u2019s free because one person pays for it.';
+    donateText.textContent = 'Free. No ads. No paywalls. Just one United nerd who hates bad flight trackers. A $5 donation covers a full day of live flights, API calls, and everything that keeps this running.';
     donateWrap.appendChild(donateText);
     var donateBtn = document.createElement('a');
     donateBtn.href = 'https://buymeacoffee.com/notjbg';
     donateBtn.target = '_blank';
     donateBtn.rel = 'noopener noreferrer';
     donateBtn.style.cssText = 'display:inline-block;padding:10px 28px;background:rgba(255,255,255,0.08);border:1px solid var(--ua-accent);color:var(--ua-accent);border-radius:8px;font-size:14px;font-weight:600;font-family:var(--font-ui);text-decoration:none;transition:background .2s,color .2s;cursor:pointer';
-    donateBtn.textContent = '\u2615 Buy me a coffee';
+    donateBtn.textContent = 'Donate $5';
     donateBtn.addEventListener('mouseenter', function() { donateBtn.style.background = 'var(--ua-accent)'; donateBtn.style.color = '#fff'; });
     donateBtn.addEventListener('mouseleave', function() { donateBtn.style.background = 'rgba(255,255,255,0.08)'; donateBtn.style.color = 'var(--ua-accent)'; });
     donateWrap.appendChild(donateBtn);


### PR DESCRIPTION
## Summary
- Replaced passive "Like what you see? Buy a coffee" link with a prominent, centered donation section
- Copy: casual founder voice + concrete cost anchoring ("A $5 donation covers a full day...")
- Styled button with hover effect instead of inline text link
- Button says "Donate" and links to BMAC where visitors pick their amount

## Context
Zero donations since launch. The old CTA was 12px muted text buried at the bottom — easy to miss. New version is more direct without being guilt-trippy.

## Test plan
- [ ] Hard refresh theblueboard.co after deploy
- [ ] Trigger waitlist modal (10 clicks or 5min)
- [ ] Verify donation section appears below email form
- [ ] Verify "Donate" button links to buymeacoffee.com/notjbg
- [ ] Verify button hover effect works

🤖 Generated with [Claude Code](https://claude.com/claude-code)