### PR TITLE
Add welcome emails on waitlist signup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,6 @@ CRON_SECRET=
 # Supabase (waitlist / email capture)
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
+
+# Resend (waitlist welcome emails)
+RESEND_API_KEY=re_your-key-here

--- a/api/_resend.ts
+++ b/api/_resend.ts
@@ -1,0 +1,9 @@
+import { Resend } from 'resend';
+
+const apiKey = process.env.RESEND_API_KEY || '';
+
+if (!apiKey) {
+  console.warn('RESEND_API_KEY missing — welcome emails will not be sent');
+}
+
+export const resend = new Resend(apiKey);

--- a/api/waitlist.ts
+++ b/api/waitlist.ts
@@ -1,6 +1,7 @@
 import type { VercelRequest, VercelResponse } from './types.js';
 import { createRateLimiter } from './_rate-limit.js';
 import { supabase } from './_supabase.js';
+import { resend } from './_resend.js';
 
 // 5 submissions per IP per hour → ~5 per 60 minutes
 // Rate limiter works in 60s windows, so allow 5 per 60s window
@@ -8,6 +9,174 @@ import { supabase } from './_supabase.js';
 const isRateLimited = createRateLimiter('waitlist', 5);
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const FROM_ADDRESS = 'Jonah @ The Blue Board <hello@theblueboard.co>';
+const REPLY_TO = 'hello@theblueboard.co';
+
+function buildWelcomeEmail(): string {
+  const p = 'font-size:16px;line-height:1.7;color:#b0b0b0;margin:0 0 16px';
+  const divider = 'border:none;border-top:1px solid #1a2035;margin:32px 0';
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="dark">
+  <meta name="supported-color-schemes" content="dark">
+</head>
+<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background-color:#0a0e1a;color:#e0e0e0;padding:0;margin:0;">
+  <!-- Preheader (inbox preview text) -->
+  <div style="display:none;max-height:0;overflow:hidden;font-size:1px;line-height:1px;color:#0a0e1a;">
+    You just joined 25,000+ United flyers. Here's what's live right now.
+  </div>
+
+  <div style="max-width:560px;margin:0 auto;padding:40px 24px;">
+
+    <!-- Header -->
+    <p style="font-size:13px;color:#4a90d9;letter-spacing:0.5px;margin:0 0 24px;text-transform:uppercase;">
+      THE BLUE BOARD
+    </p>
+
+    <!-- Welcome -->
+    <h1 style="color:#e0e0e0;font-size:24px;font-weight:600;margin:0 0 24px;line-height:1.3;">
+      Welcome aboard ✈️
+    </h1>
+
+    <p style="${p}">
+      You just joined 25,000+ United flyers who are tired of checking three different apps to figure out what's happening with their flight.
+    </p>
+
+    <p style="${p}">
+      I built The Blue Board because I wanted to see United the way an ops center would — live flight positions, delay predictions, fleet data, hub weather, all in one dark, data-dense dashboard. No ads. No paywalls. Just one United nerd who hates bad flight trackers.
+    </p>
+
+    <!-- Features -->
+    <p style="font-size:15px;color:#e0e0e0;font-weight:600;margin:24px 0 16px;">
+      Here's what's live right now:
+    </p>
+
+    <table role="presentation" style="width:100%;border-collapse:collapse;">
+      <tr>
+        <td style="padding:8px 12px 8px 0;vertical-align:top;width:24px;font-size:15px;">&#x1F4E1;</td>
+        <td style="padding:8px 0;font-size:15px;line-height:1.5;color:#b0b0b0;">
+          <strong style="color:#e0e0e0;">600+ flights tracked live</strong> — updated every 30 seconds on a dark ops map
+        </td>
+      </tr>
+      <tr>
+        <td style="padding:8px 12px 8px 0;vertical-align:top;width:24px;font-size:15px;">&#x26A0;&#xFE0F;</td>
+        <td style="padding:8px 0;font-size:15px;line-height:1.5;color:#b0b0b0;">
+          <strong style="color:#e0e0e0;">AI delay predictions</strong> — 8-signal risk scoring with plain-English explanations
+        </td>
+      </tr>
+      <tr>
+        <td style="padding:8px 12px 8px 0;vertical-align:top;width:24px;font-size:15px;">&#x2708;&#xFE0F;</td>
+        <td style="padding:8px 0;font-size:15px;line-height:1.5;color:#b0b0b0;">
+          <strong style="color:#e0e0e0;">Starlink WiFi tracker</strong> — check if your plane has it before you board
+        </td>
+      </tr>
+      <tr>
+        <td style="padding:8px 12px 8px 0;vertical-align:top;width:24px;font-size:15px;">&#x1F4C5;</td>
+        <td style="padding:8px 0;font-size:15px;line-height:1.5;color:#b0b0b0;">
+          <strong style="color:#e0e0e0;">Departure boards for all 9 hubs</strong> — with equipment swap alerts
+        </td>
+      </tr>
+      <tr>
+        <td style="padding:8px 12px 8px 0;vertical-align:top;width:24px;font-size:15px;">&#x1F50D;</td>
+        <td style="padding:8px 0;font-size:15px;line-height:1.5;color:#b0b0b0;">
+          <strong style="color:#e0e0e0;">"Where's My Plane?"</strong> — see your aircraft operating its previous flight
+        </td>
+      </tr>
+    </table>
+
+    <!-- Primary CTA -->
+    <div style="text-align:center;margin:32px 0;">
+      <a href="https://theblueboard.co" style="background-color:#4a90d9;color:#ffffff;text-decoration:none;padding:14px 32px;border-radius:6px;font-size:16px;font-weight:600;display:inline-block;">
+        Open The Blue Board
+      </a>
+    </div>
+
+    <hr style="${divider}">
+
+    <!-- Community / Feedback -->
+    <p style="font-size:15px;color:#e0e0e0;font-weight:600;margin:0 0 12px;">
+      You can shape what gets built next.
+    </p>
+
+    <p style="${p}">
+      Some of the best features came from flyers like you — suggestions from Reddit, FlyerTalk, and reply emails like this one. If you find a bug, have an idea, or just want to say something — <strong style="color:#e0e0e0;">hit reply. It goes straight to me.</strong>
+    </p>
+
+    <p style="margin:16px 0 0;">
+      <a href="https://github.com/notjbg/the-blue-board/issues" style="color:#4a90d9;text-decoration:none;font-size:14px;">Suggest a Feature on GitHub &rarr;</a>
+      &nbsp;&nbsp;&middot;&nbsp;&nbsp;
+      <a href="https://x.com/theblueboard" style="color:#4a90d9;text-decoration:none;font-size:14px;">Follow @theblueboard &rarr;</a>
+    </p>
+
+    <hr style="${divider}">
+
+    <!-- Donation -->
+    <p style="font-size:15px;color:#e0e0e0;font-weight:600;margin:0 0 12px;">
+      Keep The Blue Board in the air.
+    </p>
+
+    <p style="${p}">
+      This is free, ad-free, and open source. It costs real money to keep running — API calls, Vercel hosting, and the time to build and maintain it.
+    </p>
+
+    <p style="${p}">
+      <strong style="color:#e0e0e0;">A $5 donation covers a full day of live flights, API calls, and everything that keeps this running.</strong>
+    </p>
+
+    <div style="text-align:center;margin:24px 0;">
+      <a href="https://buymeacoffee.com/notjbg" style="background-color:transparent;color:#4a90d9;text-decoration:none;padding:12px 28px;border-radius:6px;font-size:15px;font-weight:600;display:inline-block;border:1.5px solid #4a90d9;">
+        Donate
+      </a>
+    </div>
+
+    <hr style="${divider}">
+
+    <!-- Sign-off -->
+    <p style="font-size:16px;color:#e0e0e0;margin:0 0 20px;font-style:italic;">
+      Thank you for flying with us ✈️
+    </p>
+
+    <p style="font-size:15px;color:#b0b0b0;margin:0 0 4px;">
+      — Jonah
+    </p>
+    <p style="font-size:13px;color:#666;margin:0;">
+      Builder of The Blue Board &middot; <a href="https://theblueboard.co" style="color:#4a90d9;text-decoration:none;">theblueboard.co</a>
+    </p>
+
+    <!-- Footer -->
+    <p style="font-size:11px;color:#444;margin:40px 0 0;">
+      Not affiliated with United Airlines, Inc. You're receiving this because you signed up at theblueboard.co.
+    </p>
+  </div>
+</body>
+</html>`;
+}
+
+async function sendWelcomeEmail(email: string): Promise<void> {
+  if (!process.env.RESEND_API_KEY) return;
+
+  try {
+    const { error } = await resend.emails.send({
+      from: FROM_ADDRESS,
+      replyTo: REPLY_TO,
+      to: email,
+      subject: 'Welcome aboard ✈️',
+      html: buildWelcomeEmail(),
+    });
+
+    if (error) {
+      console.error('Welcome email failed:', error);
+    }
+  } catch (e) {
+    // Don't let email failures block the signup
+    console.error('Welcome email error:', e);
+  }
+}
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   // CORS
@@ -35,12 +204,23 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(400).json({ error: 'Invalid or missing email address' });
   }
 
+  const normalizedEmail = email.trim().toLowerCase();
+
   try {
+    // Check if this email already exists (skip welcome email for re-submissions)
+    const { data: existing } = await supabase
+      .from('waitlist')
+      .select('email')
+      .eq('email', normalizedEmail)
+      .limit(1);
+
+    const isNewSignup = !existing || existing.length === 0;
+
     const { error } = await supabase
       .from('waitlist')
       .upsert(
         {
-          email: email.trim().toLowerCase(),
+          email: normalizedEmail,
           source: typeof source === 'string' ? source.slice(0, 50) : 'popup',
           feature_request: typeof featureRequest === 'string' ? featureRequest.slice(0, 500) : null,
         },
@@ -50,6 +230,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (error) {
       console.error('Waitlist upsert error:', error.message);
       return res.status(500).json({ error: 'Something went wrong — please try again' });
+    }
+
+    // Send welcome email only to first-time signups (fire-and-forget)
+    if (isNewSignup) {
+      sendWelcomeEmail(normalizedEmail);
     }
 
     return res.status(200).json({ success: true });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "the-blue-board",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "the-blue-board",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "license": "FSL-1.1-MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
         "@supabase/supabase-js": "^2.49.1",
         "astro": "^5.0.0",
-        "fast-xml-parser": "^5.4.2"
+        "fast-xml-parser": "^5.4.2",
+        "resend": "^6.9.4"
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.11.1",
@@ -1692,6 +1693,12 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
@@ -3778,6 +3785,12 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-xml-builder": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
@@ -5823,6 +5836,12 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.3.tgz",
+      "integrity": "sha512-MjhXadAJaWgYzevi46+3kLak8y6gbg0ku14O1gO/LNOuay8dO+1PtcSGvAdgDR0DoIsSaiIA8y/Ddw6MnrO0Tw==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -6123,6 +6142,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.9.4.tgz",
+      "integrity": "sha512-/M3dsJzu5OgozqVsA4Psd/1L7EdePgOIIxClas453GOQYFG3VHc2ZyCHZFlvqsc9aZCCd2BJRRqZgWC8D9c7/g==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.3",
+        "svix": "1.86.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve-from": {
@@ -6431,6 +6471,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -6532,6 +6582,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.86.0",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.86.0.tgz",
+      "integrity": "sha512-/HTvXwjLJe1l/MsLXAO1ddCYxElJk4eNR4DzOjDOEmGrPN/3BtBE8perGwMAaJ2sT5T172VkBYzmHcjUfM1JRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
       }
     },
     "node_modules/tar": {
@@ -7074,6 +7134,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vfile": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "@anthropic-ai/sdk": "^0.78.0",
     "@supabase/supabase-js": "^2.49.1",
     "astro": "^5.0.0",
-    "fast-xml-parser": "^5.4.2"
+    "fast-xml-parser": "^5.4.2",
+    "resend": "^6.9.4"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.1",


### PR DESCRIPTION
## Summary
- Install Resend SDK and configure API key in all environments
- Send branded welcome email when users join the waitlist (first signup only)
- Email includes feature highlights, community/feedback CTA with reply-to inbox, donation ask, and "thank you for flying with us" sign-off
- Updated visitor count to 25,000+

## Test plan
- Verify test email arrives in inbox with correct formatting
- Set up hello@theblueboard.co forwarding in Squarespace
- Test reply-to functionality
- Deploy and monitor first real signups receive emails

🤖 Generated with [Claude Code](https://claude.com/claude-code)