### PR TITLE
fix: dynamic import for resend — unbreak waitlist

### DIFF
--- a/api/_resend.ts
+++ b/api/_resend.ts
@@ -1,9 +1,0 @@
-import { Resend } from 'resend';
-
-const apiKey = process.env.RESEND_API_KEY || '';
-
-if (!apiKey) {
-  console.warn('RESEND_API_KEY missing — welcome emails will not be sent');
-}
-
-export const resend = new Resend(apiKey);

--- a/api/waitlist.ts
+++ b/api/waitlist.ts
@@ -1,7 +1,6 @@
 import type { VercelRequest, VercelResponse } from './types.js';
 import { createRateLimiter } from './_rate-limit.js';
 import { supabase } from './_supabase.js';
-import { resend } from './_resend.js';
 
 // 5 submissions per IP per hour → ~5 per 60 minutes
 // Rate limiter works in 60s windows, so allow 5 per 60s window
@@ -161,6 +160,9 @@ async function sendWelcomeEmail(email: string): Promise<void> {
   if (!process.env.RESEND_API_KEY) return;
 
   try {
+    const { Resend } = await import('resend');
+    const resend = new Resend(process.env.RESEND_API_KEY);
+
     const { error } = await resend.emails.send({
       from: FROM_ADDRESS,
       replyTo: REPLY_TO,


### PR DESCRIPTION
## Summary
The static `import { resend } from './_resend.js'` was crashing the waitlist function at module load time (`FUNCTION_INVOCATION_FAILED`). Switched to a dynamic `await import('resend')` inside `sendWelcomeEmail()` so the function stays healthy regardless of resend bundling.

## Test plan
- `curl -X POST https://theblueboard.co/api/waitlist` returns 200 (not 500)
- Waitlist modal submits without "Network error"