### PR TITLE
Ignore workspace context files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vercel
 node_modules
 .DS_Store
+.context/
 *.bak
 dist
 .astro


### PR DESCRIPTION
Add .context/ to the repo-level .gitignore so Conductor workspace files are ignored consistently across clones and worktrees. This moves that behavior out of machine-local Git exclude settings and into the tracked repository config.