### PR TITLE
fix: restore __HOME_LASTMOD__ placeholders reverted by #104

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -736,7 +736,7 @@ if ('serviceWorker' in navigator) {
     "width": 1200,
     "height": 630
   },
-  "dateModified": "2026-03-17",
+  "dateModified": "__HOME_LASTMOD__",
   "inLanguage": "en-US"
 }
 </script>
@@ -859,7 +859,7 @@ if ('serviceWorker' in navigator) {
   "url": "https://theblueboard.co",
   "license": "https://theblueboard.co",
   "creator": {"@type": "Person", "name": "Jonah Berg", "url": "https://github.com/notjbg"},
-  "dateModified": "2026-03-17",
+  "dateModified": "__HOME_LASTMOD__",
   "keywords": ["United Airlines", "flight tracking", "flight delays", "on-time performance", "Starlink WiFi", "fleet data", "aviation", "airline operations"],
   "temporalCoverage": "2025/..",
   "spatialCoverage": {"@type": "Place", "name": "United States"},


### PR DESCRIPTION
## Summary
- PR #104 accidentally reverted the `__HOME_LASTMOD__` build-time placeholders in `public/index.html` back to a hardcoded date
- This broke the `stamp-seo-build-date.mjs` post-build step which expects those placeholders
- Restores both occurrences so the build passes again

## Test plan
- [ ] Vercel build succeeds (no more `Expected __HOME_LASTMOD__ placeholder` error)
- [ ] `dateModified` in structured data is stamped with the correct build date

🤖 Generated with [Claude Code](https://claude.com/claude-code)