### PR TITLE
Fix tomorrow schedule fallback

### DIFF
--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -1,6 +1,5 @@
 import type { VercelRequest, VercelResponse } from './types.js';
 import { createRateLimiter } from './_rate-limit.js';
-import { HUB_TZ } from './irops.js';
 
 const isRateLimited = createRateLimiter('schedule', 30);
 
@@ -232,20 +231,6 @@ function formatForFR24(date: Date): string {
   return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
 }
 
-function getEndOfTodayForHub(hub: string): Date {
-  const tz = HUB_TZ[hub.toUpperCase()] || 'America/New_York';
-  const now = new Date();
-  const parts = new Intl.DateTimeFormat('en-US', {
-    timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit',
-    hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false
-  }).formatToParts(now);
-  const get = (type: string) => parseInt(parts.find(p => p.type === type)?.value || '0');
-  const hour = get('hour'), minute = get('minute'), second = get('second');
-  const secondsSinceMidnight = hour * 3600 + minute * 60 + second;
-  const startOfTodayUnix = Math.floor(now.getTime() / 1000) - secondsSinceMidnight;
-  return new Date((startOfTodayUnix + 86400 - 1) * 1000);
-}
-
 function icaoToIata(icao: string): string {
   if (!icao) return '';
   if (icao.length === 4 && icao.startsWith('K')) return icao.slice(1);
@@ -400,16 +385,7 @@ async function fetchViaOfficialAPI(hub: string, dir: string, ts: number, timeout
   const deadline = startTime + timeoutMs;
 
   const dayStart = new Date(ts * 1000);
-  let dayEnd = new Date((ts + 86400) * 1000);
-
-  const endOfToday = getEndOfTodayForHub(logHub);
-  if (dayStart > endOfToday) {
-    console.log(`Official FR24 API: skipping ${logHub} ${dir} — requested date is tomorrow (ts=${ts})`);
-    return null;
-  }
-  if (dayEnd > endOfToday) {
-    dayEnd = endOfToday;
-  }
+  const dayEnd = new Date((ts + 86400 - 1) * 1000);
 
   console.log(`Official FR24 API: fetching ${logHub} ${dir} (filter=${dir === 'departures' ? 'outbound' : 'inbound'}:${logHub}) from=${formatForFR24(dayStart)} to=${formatForFR24(dayEnd)} limit=${OFFICIAL_API_PAGE_SIZE}`);
 

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import handler, { shouldAttemptOfficialFallback, recordFallback, resetFallbackBreaker } from '../api/schedule.js';
+import { getStartOfDayForHub } from '../api/irops.js';
+
+function formatForFR24Test(date) {
+  return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
 
 function createRes() {
   return {
@@ -391,6 +396,49 @@ describe('schedule API', () => {
     expect(res.statusCode).toBe(200);
     expect(res.body.meta.source).toBe('official-api');
     expect(res.body.meta.fallbackFrom).toBe('scraping');
+  });
+
+  it('scrape-first: tomorrow uses official fallback when scraping fails', async () => {
+    process.env.FR24_API_TOKEN = 'test-token-12345678';
+
+    let officialUrl = '';
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes('fr24api.flightradar24.com')) {
+        officialUrl = urlStr;
+        return {
+          ok: true,
+          json: async () => ({
+            data: [{
+              flight_icao: 'UAL201',
+              flight_iata: 'UA201',
+              status: 'scheduled',
+              orig_iata: 'LAX',
+              dest_iata: 'ORD',
+              scheduled_departure: 1741653600,
+              scheduled_arrival: 1741660800,
+            }]
+          }),
+        };
+      }
+      return { ok: false, status: 403, text: async () => 'Forbidden', headers: { get: () => null } };
+    });
+
+    const ts = getStartOfDayForHub('LAX') + 86400;
+    const req = {
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'LAX', dir: 'departures', timestamp: String(ts) }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.meta.source).toBe('official-api');
+    expect(res.body.meta.fallbackFrom).toBe('scraping');
+    expect(officialUrl).toContain(`flight_datetime_from=${encodeURIComponent(formatForFR24Test(new Date(ts * 1000)))}`);
+    expect(officialUrl).toContain(`flight_datetime_to=${encodeURIComponent(formatForFR24Test(new Date((ts + 86400 - 1) * 1000)))}`);
   });
 
   it('circuit breaker trips after repeated fallbacks', () => {


### PR DESCRIPTION
Fix the schedule API so tomorrow requests can fall back to the official FR24 source instead of returning the long-standing 0% loaded upstream error. The official fetcher now queries the full requested day window, and the unused end-of-today guard/import are removed. Added a regression test for the scrape-first tomorrow fallback path and verified with npm test -- tests/schedule.test.js.