### PR TITLE
Persist and seed schedule cache across deploys

### DIFF
--- a/api/_schedule-snapshots.ts
+++ b/api/_schedule-snapshots.ts
@@ -1,0 +1,122 @@
+const SNAPSHOT_TABLE = 'schedule_snapshots';
+const SNAPSHOT_TTL_MS = 72 * 60 * 60 * 1000;
+
+interface PersistedSnapshotRow {
+  payload: any;
+  refreshed_at: string;
+}
+
+export interface PersistedScheduleSnapshot {
+  data: any;
+  refreshedAt: number;
+}
+
+interface SaveScheduleSnapshotArgs {
+  cacheKey: string;
+  hub: string;
+  dir: string;
+  ts: number;
+  data: any;
+}
+
+let warnedMissingConfig = false;
+let warnedInitFailure = false;
+let supabaseClientPromise: Promise<any | null> | null = null;
+
+function getSupabaseConfig(): { url: string; key: string } | null {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+  if (!url || !key) {
+    if (!warnedMissingConfig) {
+      console.warn('Schedule snapshots disabled: NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY is missing');
+      warnedMissingConfig = true;
+    }
+    return null;
+  }
+  return { url, key };
+}
+
+async function getSupabaseAdmin(): Promise<any | null> {
+  const config = getSupabaseConfig();
+  if (!config) return null;
+  if (!supabaseClientPromise) {
+    supabaseClientPromise = import('@supabase/supabase-js')
+      .then(({ createClient }) => createClient(config.url, config.key, {
+        auth: { persistSession: false, autoRefreshToken: false }
+      }))
+      .catch((error: any) => {
+        if (!warnedInitFailure) {
+          console.error('Failed to initialize Supabase for schedule snapshots:', error?.message || error);
+          warnedInitFailure = true;
+        }
+        return null;
+      });
+  }
+  return supabaseClientPromise;
+}
+
+export async function loadScheduleSnapshot(cacheKey: string): Promise<PersistedScheduleSnapshot | null> {
+  const supabase = await getSupabaseAdmin();
+  if (!supabase) return null;
+
+  try {
+    const { data, error } = await supabase
+      .from(SNAPSHOT_TABLE)
+      .select('payload, refreshed_at')
+      .eq('cache_key', cacheKey)
+      .gt('expires_at', new Date().toISOString())
+      .limit(1);
+
+    if (error) {
+      console.error(`Schedule snapshot read failed for ${cacheKey}:`, error.message);
+      return null;
+    }
+
+    const row = (data as PersistedSnapshotRow[] | null)?.[0];
+    if (!row?.payload) return null;
+
+    const refreshedAt = Date.parse(row.refreshed_at);
+    return {
+      data: row.payload,
+      refreshedAt: Number.isFinite(refreshedAt) ? refreshedAt : Date.now(),
+    };
+  } catch (error: any) {
+    console.error(`Schedule snapshot read threw for ${cacheKey}:`, error?.message || error);
+    return null;
+  }
+}
+
+export async function saveScheduleSnapshot({ cacheKey, hub, dir, ts, data }: SaveScheduleSnapshotArgs): Promise<void> {
+  if (!data || data.partial) return;
+
+  const supabase = await getSupabaseAdmin();
+  if (!supabase) return;
+
+  const nowIso = new Date().toISOString();
+  const expiresAtIso = new Date(Math.max(Date.now() + SNAPSHOT_TTL_MS, (ts * 1000) + SNAPSHOT_TTL_MS)).toISOString();
+
+  try {
+    const { error } = await supabase
+      .from(SNAPSHOT_TABLE)
+      .upsert({
+        cache_key: cacheKey,
+        hub: hub.toUpperCase(),
+        direction: dir,
+        day_ts: ts,
+        payload: data,
+        total: Number(data.total || 0),
+        source: String(data?.meta?.source || 'unknown'),
+        refreshed_at: nowIso,
+        expires_at: expiresAtIso,
+        updated_at: nowIso,
+      }, {
+        onConflict: 'cache_key'
+      });
+
+    if (error) {
+      console.error(`Schedule snapshot write failed for ${cacheKey}:`, error.message);
+    }
+  } catch (error: any) {
+    console.error(`Schedule snapshot write threw for ${cacheKey}:`, error?.message || error);
+  }
+}

--- a/api/cron/warm-schedules.ts
+++ b/api/cron/warm-schedules.ts
@@ -1,16 +1,56 @@
-// Vercel Cron Job: warms schedule CDN + in-memory cache for all UA hubs.
-// Runs every 15 minutes to ensure users always hit warm cache.
+// Vercel Cron Job: rotates through the 3-day schedule window (yesterday/today/tomorrow)
+// so exact hub/day/direction snapshots stay available across deploys and cold starts.
 // Config in vercel.json: { "path": "/api/cron/warm-schedules", "schedule": "*/15 * * * *" }
 
 import type { VercelRequest, VercelResponse } from '../types.js';
 import { getStartOfDayForHub } from '../irops.js';
 
 const HUBS = ['ORD', 'DEN', 'IAH', 'EWR', 'SFO', 'IAD', 'LAX', 'NRT', 'GUM'];
+const WARM_TASKS_PER_RUN = 4;
+const INTER_TASK_DELAY_MS = 3000;
 const BASE_URL = process.env.VERCEL_PROJECT_PRODUCTION_URL
   ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
   : process.env.VERCEL_URL
     ? `https://${process.env.VERCEL_URL}`
     : 'https://theblueboard.co';
+
+const WINDOW_TASKS = [
+  { dayOffset: 0, label: 'today', dir: 'departures' },
+  { dayOffset: 0, label: 'today', dir: 'arrivals' },
+  { dayOffset: -1, label: 'yesterday', dir: 'departures' },
+  { dayOffset: -1, label: 'yesterday', dir: 'arrivals' },
+  { dayOffset: 1, label: 'tomorrow', dir: 'departures' },
+  { dayOffset: 1, label: 'tomorrow', dir: 'arrivals' },
+] as const;
+
+type WarmTask = {
+  hub: string;
+  dir: 'departures' | 'arrivals';
+  dayOffset: -1 | 0 | 1;
+  label: 'yesterday' | 'today' | 'tomorrow';
+};
+
+export function buildWarmPlan(nowMs = Date.now()): WarmTask[] {
+  const tasks: WarmTask[] = [];
+  for (const task of WINDOW_TASKS) {
+    for (const hub of HUBS) {
+      tasks.push({
+        hub,
+        dir: task.dir,
+        dayOffset: task.dayOffset,
+        label: task.label,
+      });
+    }
+  }
+
+  const slot = Math.floor(nowMs / (15 * 60 * 1000));
+  const start = (slot * WARM_TASKS_PER_RUN) % tasks.length;
+  const plan: WarmTask[] = [];
+  for (let i = 0; i < Math.min(WARM_TASKS_PER_RUN, tasks.length); i++) {
+    plan.push(tasks[(start + i) % tasks.length]);
+  }
+  return plan;
+}
 
 async function warmOne(hub: string, dir: string, timestamp: number, label: string): Promise<{ key: string; result: any }> {
   const key = `${hub}-${dir}-${label}`;
@@ -44,15 +84,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   let warmed = 0;
   let failed = 0;
 
-  // Warm today departures for all hubs. Arrivals are less viewed and load on-demand.
-  // Tomorrow's data also loads on-demand — warming it here would exceed Vercel's 300s cron limit.
-  for (const hub of HUBS) {
-    const todayTs = getStartOfDayForHub(hub);
-    const { key, result } = await warmOne(hub, 'departures', todayTs, 'today');
+  // Rotate through the full 3-day window to keep persistent snapshots populated
+  // without blowing through the 300s cron budget or hammering FR24.
+  const warmPlan = buildWarmPlan();
+  for (let i = 0; i < warmPlan.length; i++) {
+    const task = warmPlan[i];
+    const ts = getStartOfDayForHub(task.hub) + (task.dayOffset * 86400);
+    const { key, result } = await warmOne(task.hub, task.dir, ts, task.label);
     results[key] = result;
     if (result.status === 'ok') warmed++; else failed++;
-    // Pause between hubs to avoid FR24 rate limiting
-    await new Promise(r => setTimeout(r, 12000));
+    if (i < warmPlan.length - 1) {
+      await new Promise(r => setTimeout(r, INTER_TASK_DELAY_MS));
+    }
   }
 
   // Phase 1.5: warm Starlink data cache (single fast request)
@@ -71,9 +114,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     failed++;
   }
 
-  // Tomorrow's data loads on-demand when users navigate to it.
-  // Warming it here would push cron runtime past Vercel's 300s limit.
-
-  console.log(`Cron warm-schedules: ${warmed} warmed, ${failed} failed`, results);
-  return res.status(200).json({ warmed, failed, results, timestamp: new Date().toISOString() });
+  console.log(`Cron warm-schedules: ${warmed} warmed, ${failed} failed`, { warmPlan, results });
+  return res.status(200).json({
+    warmed,
+    failed,
+    warmPlan,
+    results,
+    timestamp: new Date().toISOString()
+  });
 }

--- a/api/cron/warm-schedules.ts
+++ b/api/cron/warm-schedules.ts
@@ -6,8 +6,8 @@ import type { VercelRequest, VercelResponse } from '../types.js';
 import { getStartOfDayForHub } from '../irops.js';
 
 const HUBS = ['ORD', 'DEN', 'IAH', 'EWR', 'SFO', 'IAD', 'LAX', 'NRT', 'GUM'];
-const WARM_TASKS_PER_RUN = 4;
-const INTER_TASK_DELAY_MS = 3000;
+const WARM_TASKS_PER_RUN = Math.max(1, Math.min(8, Number(process.env.SCHEDULE_WARM_TASKS_PER_RUN || 4) || 4));
+const INTER_TASK_DELAY_MS = Math.max(0, Number(process.env.SCHEDULE_WARM_DELAY_MS || 3000) || 3000);
 const BASE_URL = process.env.VERCEL_PROJECT_PRODUCTION_URL
   ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
   : process.env.VERCEL_URL
@@ -17,10 +17,10 @@ const BASE_URL = process.env.VERCEL_PROJECT_PRODUCTION_URL
 const WINDOW_TASKS = [
   { dayOffset: 0, label: 'today', dir: 'departures' },
   { dayOffset: 0, label: 'today', dir: 'arrivals' },
-  { dayOffset: -1, label: 'yesterday', dir: 'departures' },
-  { dayOffset: -1, label: 'yesterday', dir: 'arrivals' },
   { dayOffset: 1, label: 'tomorrow', dir: 'departures' },
   { dayOffset: 1, label: 'tomorrow', dir: 'arrivals' },
+  { dayOffset: -1, label: 'yesterday', dir: 'departures' },
+  { dayOffset: -1, label: 'yesterday', dir: 'arrivals' },
 ] as const;
 
 type WarmTask = {
@@ -84,8 +84,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   let warmed = 0;
   let failed = 0;
 
-  // Rotate through the full 3-day window to keep persistent snapshots populated
-  // without blowing through the 300s cron budget or hammering FR24.
+  // There are 54 total windows (9 hubs × 3 days × 2 directions).
+  // Keep the default conservative for FR24, and use the seed script for first-fill.
   const warmPlan = buildWarmPlan();
   for (let i = 0; i < warmPlan.length; i++) {
     const task = warmPlan[i];

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -1,18 +1,19 @@
 import type { VercelRequest, VercelResponse } from './types.js';
 import { createRateLimiter } from './_rate-limit.js';
+import { loadScheduleSnapshot, saveScheduleSnapshot } from './_schedule-snapshots.js';
 
 const isRateLimited = createRateLimiter('schedule', 30);
 
 // In-memory LRU cache for FR24 schedule data
 const cache = new Map<string, { data: any; expires: number; time: number }>();
-const MAX_CACHE_SIZE = 200;
+const MAX_CACHE_SIZE = 400;
 
 // Separate cache for last-known-complete aggregates (fallback when fresh fetch is partial)
 const lastCompleteCache = new Map<string, { data: any; time: number }>();
 // Broader fallback cache keyed by hub+direction (survives day-key misses)
 const lastCompleteByHubDir = new Map<string, { data: any; time: number; sourceKey: string }>();
-const MAX_COMPLETE_CACHE_SIZE = 50;
-const COMPLETE_CACHE_MAX_AGE = 1800000; // 30 minutes
+const MAX_COMPLETE_CACHE_SIZE = 128;
+const COMPLETE_CACHE_MAX_AGE = 21600000; // 6 hours
 const BATCH_DELAY = 500; // 500ms pause between parallel batches
 const STALE_GRACE = 120000; // serve stale data for up to 2min past expiry
 
@@ -96,12 +97,12 @@ function cacheGetStale(key: string) {
   return entry;
 }
 
-function saveComplete(key: string, data: any): void {
+function saveComplete(key: string, data: any, savedAtMs = Date.now()): void {
   if (data.partial) return;
   if (lastCompleteCache.size >= MAX_COMPLETE_CACHE_SIZE) {
     lastCompleteCache.delete(lastCompleteCache.keys().next().value!);
   }
-  lastCompleteCache.set(key, { data, time: Date.now() });
+  lastCompleteCache.set(key, { data, time: savedAtMs });
 
   // Also populate hub+direction+day level cache for broader fallback
   const aggMatch = /^agg:([A-Z]{3,4}):(departures|arrivals):(\d+)$/i.exec(key);
@@ -110,7 +111,7 @@ function saveComplete(key: string, data: any): void {
     if (lastCompleteByHubDir.size >= MAX_COMPLETE_CACHE_SIZE) {
       lastCompleteByHubDir.delete(lastCompleteByHubDir.keys().next().value!);
     }
-    lastCompleteByHubDir.set(hdKey, { data, time: Date.now(), sourceKey: key });
+    lastCompleteByHubDir.set(hdKey, { data, time: savedAtMs, sourceKey: key });
   }
 }
 
@@ -133,6 +134,28 @@ function getLastCompleteByHubDir(hub: string, dir: string, ts: number) {
     return null;
   }
   return entry;
+}
+
+async function getPersistentComplete(key: string) {
+  const snapshot = await loadScheduleSnapshot(key);
+  if (!snapshot || snapshot.data?.partial) return null;
+  saveComplete(key, snapshot.data, snapshot.refreshedAt);
+  return { data: snapshot.data, time: snapshot.refreshedAt };
+}
+
+function buildDegradedResponse(entry: { data: any; time: number }, fallbackScope: 'exact' | 'hub_dir' | 'persistent') {
+  const dataAge = Math.max(0, Math.round((Date.now() - entry.time) / 1000));
+  return {
+    ...entry.data,
+    cached: true,
+    stale: true,
+    degraded: true,
+    meta: {
+      ...(entry.data?.meta || {}),
+      dataAge,
+      fallbackScope,
+    }
+  };
 }
 
 function cacheSet(key: string, data: any, ttlMs: number): void {
@@ -602,9 +625,10 @@ const pendingAggs = new Map<string, Promise<any>>();
 function triggerBackgroundRefresh(hub: string, dir: string, ts: number, aggKey: string, ttl: number): void {
   if (pendingAggs.has(aggKey)) return;
   const refreshHub = String(hub);
-  const promise = fetchAllPages(refreshHub, dir, ts, undefined, Date.now() + 55000).then(result => {
+  const promise = fetchAllPages(refreshHub, dir, ts, undefined, Date.now() + 55000).then(async result => {
     cacheSet(aggKey, result, result.partial ? 60000 : ttl);
     saveComplete(aggKey, result);
+    await saveScheduleSnapshot({ cacheKey: aggKey, hub: refreshHub, dir, ts, data: result });
     return result;
   }).catch(e => {
     console.error(`Background refresh failed for ${refreshHub} [${aggKey}]:`, e.message);
@@ -646,7 +670,7 @@ async function tryOfficialFallback(
     const remaining = Math.max(2000, effectiveDeadline - Date.now() - 1000);
     const result = await fetchViaOfficialAPI(logHub, dir, ts, Math.min(remaining, 30000));
     if (result && result.total > 0) {
-      result.meta = { ...result.meta, fallbackFrom: 'scraping' };
+      result.meta = { ...(result.meta as any), fallbackFrom: 'scraping' };
       return result;
     }
   } catch (e: any) {
@@ -861,6 +885,8 @@ async function fetchAllPages(hub: string, dir: string, ts: number, timeoutMs?: n
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
+  let aggKey: string | null = null;
+  let swr = 600;
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
@@ -896,7 +922,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const isOld = (now - ts) > 86400;
     const ttl = isOld ? 600000 : 900000;
     const cdnMaxAge = isOld ? 3600 : 900;
-    const swr = 600;
+    swr = 600;
 
     // Single page mode (backward compat)
     if (page !== undefined) {
@@ -920,75 +946,83 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     // Aggregation mode
-    const aggKey = `agg:${hub}:${dir}:${ts}`;
+    const currentAggKey = `agg:${hub}:${dir}:${ts}`;
+    aggKey = currentAggKey;
 
-    const cached = cacheGet(aggKey);
+    const cached = cacheGet(currentAggKey);
     if (cached) {
       res.setHeader('Cache-Control', `s-maxage=${cdnMaxAge}, stale-while-revalidate=${swr}`);
       return res.status(200).json({ ...cached.data, cached: true });
     }
 
-    const stale = cacheGetStale(aggKey);
+    const stale = cacheGetStale(currentAggKey);
     if (stale && !stale.data.partial) {
-      triggerBackgroundRefresh(hub, dir, ts, aggKey, ttl);
+      triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl);
       res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
       return res.status(200).json({ ...stale.data, cached: true, stale: true });
     }
 
-    const exactLastComplete = getLastComplete(aggKey);
+    const exactLastComplete = getLastComplete(currentAggKey);
     const fallbackComplete = exactLastComplete || getLastCompleteByHubDir(hub, dir, ts);
     if (fallbackComplete) {
-      triggerBackgroundRefresh(hub, dir, ts, aggKey, ttl);
-      const dataAge = Math.round((Date.now() - fallbackComplete.time) / 1000);
+      triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl);
       res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
-      return res.status(200).json({ ...fallbackComplete.data, cached: true, stale: true, degraded: true,
-        meta: {
-          ...fallbackComplete.data.meta,
-          dataAge,
-          fallbackScope: exactLastComplete ? 'exact' : 'hub_dir',
-        }
-      });
+      return res.status(200).json(buildDegradedResponse(fallbackComplete, exactLastComplete ? 'exact' : 'hub_dir'));
     }
 
-    if (pendingAggs.has(aggKey)) {
-      const result = await pendingAggs.get(aggKey);
+    const persistentComplete = await getPersistentComplete(currentAggKey);
+    if (persistentComplete) {
+      triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl);
+      res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
+      return res.status(200).json(buildDegradedResponse(persistentComplete, 'persistent'));
+    }
+
+    if (pendingAggs.has(currentAggKey)) {
+      const result = await pendingAggs.get(currentAggKey);
       if (result) {
         res.setHeader('Cache-Control', `s-maxage=${cdnMaxAge}, stale-while-revalidate=${swr}`);
         return res.status(200).json({ ...result, cached: true });
       }
     }
 
-    const aggPromise = fetchAllPages(hub, dir, ts, undefined, functionDeadline).then(result => {
-      cacheSet(aggKey, result, result.partial ? 60000 : ttl);
-      saveComplete(aggKey, result);
+    const aggPromise = fetchAllPages(hub, dir, ts, undefined, functionDeadline).then(async result => {
+      cacheSet(currentAggKey, result, result.partial ? 60000 : ttl);
+      saveComplete(currentAggKey, result);
+      await saveScheduleSnapshot({ cacheKey: currentAggKey, hub, dir, ts, data: result });
       return result;
     });
 
-    pendingAggs.set(aggKey, aggPromise);
+    pendingAggs.set(currentAggKey, aggPromise);
     try {
       const result = await aggPromise;
       if (result.partial) {
-        const exactLc = getLastComplete(aggKey);
+        const exactLc = getLastComplete(currentAggKey);
         const lc = exactLc || getLastCompleteByHubDir(hub, dir, ts);
         if (lc) {
-          const dataAge = Math.round((Date.now() - lc.time) / 1000);
           res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
-          return res.status(200).json({ ...lc.data, cached: true, stale: true, degraded: true,
-            meta: {
-              ...lc.data.meta,
-              dataAge,
-              fallbackScope: exactLc ? 'exact' : 'hub_dir',
-            }
-          });
+          return res.status(200).json(buildDegradedResponse(lc, exactLc ? 'exact' : 'hub_dir'));
+        }
+
+        const persistentLc = await getPersistentComplete(currentAggKey);
+        if (persistentLc) {
+          res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
+          return res.status(200).json(buildDegradedResponse(persistentLc, 'persistent'));
         }
       }
       res.setHeader('Cache-Control', `s-maxage=${cdnMaxAge}, stale-while-revalidate=${swr}`);
       return res.status(200).json(result);
     } finally {
-      pendingAggs.delete(aggKey);
+      pendingAggs.delete(currentAggKey);
     }
   } catch (e) {
     console.error('Schedule API error:', e);
+    if (aggKey) {
+      const persistentFallback = await getPersistentComplete(aggKey);
+      if (persistentFallback) {
+        res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
+        return res.status(200).json(buildDegradedResponse(persistentFallback, 'persistent'));
+      }
+    }
     return res.status(502).json({ error: 'Upstream service unavailable' });
   }
 }

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -1,6 +1,7 @@
 import type { VercelRequest, VercelResponse } from './types.js';
 import { createRateLimiter } from './_rate-limit.js';
 import { loadScheduleSnapshot, saveScheduleSnapshot } from './_schedule-snapshots.js';
+import { waitUntil } from '@vercel/functions';
 
 const isRateLimited = createRateLimiter('schedule', 30);
 
@@ -621,6 +622,18 @@ async function fetchViaOfficialAPI(hub: string, dir: string, ts: number, timeout
 }
 
 const pendingAggs = new Map<string, Promise<any>>();
+let warnedWaitUntilUnavailable = false;
+
+function enqueueBackgroundTask(promise: Promise<any>): void {
+  try {
+    waitUntil(promise);
+  } catch (error: any) {
+    if (!warnedWaitUntilUnavailable) {
+      console.warn('waitUntil unavailable; schedule background refresh is best-effort:', error?.message || error);
+      warnedWaitUntilUnavailable = true;
+    }
+  }
+}
 
 function triggerBackgroundRefresh(hub: string, dir: string, ts: number, aggKey: string, ttl: number): void {
   if (pendingAggs.has(aggKey)) return;
@@ -636,6 +649,7 @@ function triggerBackgroundRefresh(hub: string, dir: string, ts: number, aggKey: 
     pendingAggs.delete(aggKey);
   });
   pendingAggs.set(aggKey, promise);
+  enqueueBackgroundTask(promise);
 }
 
 // ── Circuit breaker: stop falling back to official API during sustained scraping outages ──

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
         "@supabase/supabase-js": "^2.49.1",
+        "@vercel/functions": "^3.4.3",
         "astro": "^5.0.0",
         "fast-xml-parser": "^5.4.2",
         "resend": "^6.9.4"
@@ -1933,6 +1934,26 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@vercel/functions": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.4.3.tgz",
+      "integrity": "sha512-kA14KIUVgAY6VXbhZ5jjY+s0883cV3cZqIU3WhrSRxuJ9KvxatMjtmzl0K23HK59oOUjYl7HaE/eYMmhmqpZzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vercel/nft": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-1.1.1.tgz",
@@ -2487,6 +2508,15 @@
         "@esbuild/win32-arm64": "0.27.0",
         "@esbuild/win32-ia32": "0.27.0",
         "@esbuild/win32-x64": "0.27.0"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@vercel/python-analysis": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "vite build --config vite.dashboard.config.js && astro build && node scripts/stamp-seo-build-date.mjs",
     "build:dashboard": "vite build --config vite.dashboard.config.js",
     "preview": "astro preview",
+    "seed:schedules": "node scripts/seed-schedules.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "ui-audit": "node scripts/ui-audit.mjs"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
     "@supabase/supabase-js": "^2.49.1",
+    "@vercel/functions": "^3.4.3",
     "astro": "^5.0.0",
     "fast-xml-parser": "^5.4.2",
     "resend": "^6.9.4"

--- a/scripts/seed-schedules.mjs
+++ b/scripts/seed-schedules.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+
+const HUB_TIMEZONES = {
+  ORD: 'America/Chicago',
+  DEN: 'America/Denver',
+  IAH: 'America/Chicago',
+  EWR: 'America/New_York',
+  SFO: 'America/Los_Angeles',
+  IAD: 'America/New_York',
+  LAX: 'America/Los_Angeles',
+  NRT: 'Asia/Tokyo',
+  GUM: 'Pacific/Guam',
+};
+
+const HUBS = Object.keys(HUB_TIMEZONES);
+const DAY_WINDOWS = [
+  { label: 'yesterday', offset: -1 },
+  { label: 'today', offset: 0 },
+  { label: 'tomorrow', offset: 1 },
+];
+const DIRECTIONS = ['departures', 'arrivals'];
+
+function parseArgs(argv) {
+  const options = {
+    baseUrl: process.env.BLUEBOARD_BASE_URL || 'https://theblueboard.co',
+    delayMs: Number(process.env.SCHEDULE_SEED_DELAY_MS || 1500),
+    timeoutMs: Number(process.env.SCHEDULE_SEED_TIMEOUT_MS || 65000),
+    retries: Number(process.env.SCHEDULE_SEED_RETRIES || 2),
+  };
+
+  for (const arg of argv) {
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else if (arg.startsWith('--base-url=')) {
+      options.baseUrl = arg.slice('--base-url='.length);
+    } else if (arg.startsWith('--delay-ms=')) {
+      options.delayMs = Number(arg.slice('--delay-ms='.length));
+    } else if (arg.startsWith('--timeout-ms=')) {
+      options.timeoutMs = Number(arg.slice('--timeout-ms='.length));
+    } else if (arg.startsWith('--retries=')) {
+      options.retries = Number(arg.slice('--retries='.length));
+    }
+  }
+
+  return options;
+}
+
+function printHelp() {
+  console.log(`Usage: npm run seed:schedules -- [options]
+
+Options:
+  --base-url=https://theblueboard.co   Target site to seed
+  --delay-ms=1500                      Pause between requests
+  --timeout-ms=65000                   Per-request timeout
+  --retries=2                          Retries per failed request
+
+Env overrides:
+  BLUEBOARD_BASE_URL
+  SCHEDULE_SEED_DELAY_MS
+  SCHEDULE_SEED_TIMEOUT_MS
+  SCHEDULE_SEED_RETRIES`);
+}
+
+function getStartOfDayForHub(hub, dayOffset) {
+  const tz = HUB_TIMEZONES[hub] || 'America/Chicago';
+  const now = new Date();
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).formatToParts(now);
+
+  const get = (type) => Number(parts.find((part) => part.type === type)?.value || '0');
+  const secondsSinceMidnight = (get('hour') * 3600) + (get('minute') * 60) + get('second');
+  const startOfToday = Math.floor(now.getTime() / 1000) - secondsSinceMidnight;
+  return startOfToday + (dayOffset * 86400);
+}
+
+function buildSeedPlan() {
+  const plan = [];
+  for (const window of DAY_WINDOWS) {
+    for (const dir of DIRECTIONS) {
+      for (const hub of HUBS) {
+        plan.push({
+          hub,
+          dir,
+          dayLabel: window.label,
+          timestamp: getStartOfDayForHub(hub, window.offset),
+        });
+      }
+    }
+  }
+  return plan;
+}
+
+async function fetchWithTimeout(url, timeoutMs) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        'User-Agent': 'BlueBoard-ScheduleSeeder/1.0',
+        'Accept': 'application/json',
+      },
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function seedOne(task, options) {
+  const url = new URL('/api/schedule', options.baseUrl);
+  url.searchParams.set('hub', task.hub);
+  url.searchParams.set('dir', task.dir);
+  url.searchParams.set('timestamp', String(task.timestamp));
+
+  let lastError = null;
+  for (let attempt = 1; attempt <= options.retries + 1; attempt++) {
+    try {
+      const response = await fetchWithTimeout(url, options.timeoutMs);
+      const raw = await response.text();
+      let body = null;
+      try {
+        body = raw ? JSON.parse(raw) : null;
+      } catch {
+        body = null;
+      }
+
+      if (!response.ok) {
+        lastError = new Error(`HTTP ${response.status}`);
+      } else if (body?.error) {
+        lastError = new Error(body.error);
+      } else {
+        return {
+          ok: true,
+          status: response.status,
+          total: Number(body?.total || 0),
+          partial: Boolean(body?.partial),
+          degraded: Boolean(body?.degraded),
+          cached: Boolean(body?.cached),
+          source: body?.meta?.source || 'unknown',
+        };
+      }
+    } catch (error) {
+      lastError = error;
+    }
+
+    if (attempt <= options.retries) {
+      await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
+    }
+  }
+
+  return {
+    ok: false,
+    error: lastError?.message || 'Unknown error',
+  };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const plan = buildSeedPlan();
+  const startedAt = Date.now();
+  let ok = 0;
+  let failed = 0;
+
+  console.log(`Seeding ${plan.length} schedule windows against ${options.baseUrl}`);
+  console.log(`Delay ${options.delayMs}ms · timeout ${options.timeoutMs}ms · retries ${options.retries}`);
+
+  for (let index = 0; index < plan.length; index++) {
+    const task = plan[index];
+    const label = `${task.hub} ${task.dir} ${task.dayLabel}`;
+    const result = await seedOne(task, options);
+
+    if (result.ok) {
+      ok++;
+      const flags = [];
+      if (result.cached) flags.push('cached');
+      if (result.partial) flags.push('partial');
+      if (result.degraded) flags.push('degraded');
+      console.log(`[${index + 1}/${plan.length}] OK   ${label} · ${result.total} flights · ${result.source}${flags.length ? ` · ${flags.join(',')}` : ''}`);
+    } else {
+      failed++;
+      console.log(`[${index + 1}/${plan.length}] FAIL ${label} · ${result.error}`);
+    }
+
+    if (index < plan.length - 1 && options.delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, options.delayMs));
+    }
+  }
+
+  const elapsedSec = Math.round((Date.now() - startedAt) / 1000);
+  console.log(`Done in ${elapsedSec}s · ${ok} ok · ${failed} failed`);
+  if (failed > 0) process.exitCode = 1;
+}
+
+main().catch((error) => {
+  console.error('Schedule seed failed:', error);
+  process.exitCode = 1;
+});

--- a/sql/003_schedule_snapshots.sql
+++ b/sql/003_schedule_snapshots.sql
@@ -16,4 +16,5 @@ CREATE INDEX idx_schedule_snapshots_lookup ON schedule_snapshots (hub, direction
 CREATE INDEX idx_schedule_snapshots_expires_at ON schedule_snapshots (expires_at);
 
 -- Server-side only table for resilient schedule fallbacks across deploys.
+-- Intentionally no anon/authenticated policies: only server-side secret/service-role access should touch this table.
 ALTER TABLE schedule_snapshots ENABLE ROW LEVEL SECURITY;

--- a/sql/003_schedule_snapshots.sql
+++ b/sql/003_schedule_snapshots.sql
@@ -1,0 +1,19 @@
+CREATE TABLE schedule_snapshots (
+  cache_key TEXT PRIMARY KEY,
+  hub TEXT NOT NULL,
+  direction TEXT NOT NULL CHECK (direction IN ('departures', 'arrivals')),
+  day_ts BIGINT NOT NULL,
+  payload JSONB NOT NULL,
+  total INTEGER NOT NULL DEFAULT 0,
+  source TEXT NOT NULL DEFAULT 'unknown',
+  refreshed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_schedule_snapshots_lookup ON schedule_snapshots (hub, direction, day_ts);
+CREATE INDEX idx_schedule_snapshots_expires_at ON schedule_snapshots (expires_at);
+
+-- Server-side only table for resilient schedule fallbacks across deploys.
+ALTER TABLE schedule_snapshots ENABLE ROW LEVEL SECURITY;

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -5,7 +5,12 @@ const scheduleSnapshotMocks = vi.hoisted(() => ({
   saveScheduleSnapshot: vi.fn(async () => {}),
 }));
 
+const vercelFunctionMocks = vi.hoisted(() => ({
+  waitUntil: vi.fn(),
+}));
+
 vi.mock('../api/_schedule-snapshots.js', () => scheduleSnapshotMocks);
+vi.mock('@vercel/functions', () => vercelFunctionMocks);
 
 import handler, { shouldAttemptOfficialFallback, recordFallback, resetFallbackBreaker } from '../api/schedule.js';
 import { getStartOfDayForHub } from '../api/irops.js';
@@ -40,6 +45,7 @@ describe('schedule API', () => {
     scheduleSnapshotMocks.saveScheduleSnapshot.mockReset();
     scheduleSnapshotMocks.loadScheduleSnapshot.mockResolvedValue(null);
     scheduleSnapshotMocks.saveScheduleSnapshot.mockResolvedValue(undefined);
+    vercelFunctionMocks.waitUntil.mockReset();
   });
 
   afterEach(() => {
@@ -644,6 +650,7 @@ describe('schedule API', () => {
     expect(res.body.meta.fallbackScope).toBe('persistent');
     expect(scheduleSnapshotMocks.loadScheduleSnapshot).toHaveBeenCalledWith(`agg:ORD:departures:${ts}`);
     expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(vercelFunctionMocks.waitUntil).toHaveBeenCalledTimes(1);
   });
 
   it('persists complete aggregated results after a successful fetch', async () => {

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -1,4 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const scheduleSnapshotMocks = vi.hoisted(() => ({
+  loadScheduleSnapshot: vi.fn(async () => null),
+  saveScheduleSnapshot: vi.fn(async () => {}),
+}));
+
+vi.mock('../api/_schedule-snapshots.js', () => scheduleSnapshotMocks);
+
 import handler, { shouldAttemptOfficialFallback, recordFallback, resetFallbackBreaker } from '../api/schedule.js';
 import { getStartOfDayForHub } from '../api/irops.js';
 
@@ -28,6 +36,10 @@ function createRes() {
 describe('schedule API', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    scheduleSnapshotMocks.loadScheduleSnapshot.mockReset();
+    scheduleSnapshotMocks.saveScheduleSnapshot.mockReset();
+    scheduleSnapshotMocks.loadScheduleSnapshot.mockResolvedValue(null);
+    scheduleSnapshotMocks.saveScheduleSnapshot.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -576,6 +588,117 @@ describe('schedule API', () => {
     expect(res.statusCode).toBe(200);
     expect(res.body.total).toBe(1);
     expect(res.body.meta.source).toBe('scraping');
+  });
+
+  it('returns persisted exact snapshot on cold start while refreshing in the background', async () => {
+    const ts = Math.floor(Date.now() / 1000) - 46800;
+    scheduleSnapshotMocks.loadScheduleSnapshot.mockResolvedValue({
+      data: {
+        flights: [{
+          airline: { code: { iata: 'UA' } },
+          identification: { number: { default: 'UA777' } },
+          time: { scheduled: { departure: 1741653600, arrival: 1741660800 } },
+          airport: {
+            origin: { code: { iata: 'ORD' } },
+            destination: { code: { iata: 'SFO' } }
+          }
+        }],
+        total: 1,
+        totalFetched: 1,
+        pagesScanned: 1,
+        totalPages: 1,
+        cached: false,
+        partial: false,
+        hub: 'ORD',
+        dir: 'departures',
+        meta: {
+          partialReason: null,
+          pagesRequested: 1,
+          pagesSucceeded: 1,
+          pagesFailed: 0,
+          missingPages: [],
+          completeness: 1,
+          elapsedMs: 50,
+          source: 'scraping'
+        }
+      },
+      refreshedAt: Date.now() - (5 * 60 * 1000)
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      throw new Error('fetch should not run when an exact persisted snapshot is available');
+    });
+
+    const req = {
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'ORD', dir: 'departures', timestamp: String(ts) }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.total).toBe(1);
+    expect(res.body.degraded).toBe(true);
+    expect(res.body.meta.fallbackScope).toBe('persistent');
+    expect(scheduleSnapshotMocks.loadScheduleSnapshot).toHaveBeenCalledWith(`agg:ORD:departures:${ts}`);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists complete aggregated results after a successful fetch', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        result: {
+          response: {
+            airport: {
+              pluginData: {
+                schedule: {
+                  departures: {
+                    page: { current: 1, total: 1 },
+                    data: [{
+                      flight: {
+                        airline: { code: { iata: 'UA' } },
+                        identification: { number: { default: 'UA888' } },
+                        time: { scheduled: { departure: 1741653600, arrival: 1741660800 } },
+                        airport: {
+                          origin: { code: { iata: 'EWR' } },
+                          destination: { code: { iata: 'LAX' } }
+                        }
+                      }
+                    }]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }),
+    });
+
+    const ts = Math.floor(Date.now() / 1000) - 50400;
+    const req = {
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'EWR', dir: 'departures', timestamp: String(ts) }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.partial).toBe(false);
+    expect(scheduleSnapshotMocks.saveScheduleSnapshot).toHaveBeenCalledWith(expect.objectContaining({
+      cacheKey: `agg:EWR:departures:${ts}`,
+      hub: 'EWR',
+      dir: 'departures',
+      ts,
+      data: expect.objectContaining({
+        partial: false,
+        total: 1
+      })
+    }));
   });
 
   it('scrape-first: rate-limited mid-loop pauses and continues fetching', { timeout: 15000 }, async () => {


### PR DESCRIPTION
Adds a Supabase-backed exact-day schedule snapshot layer, plus the SQL migration to store last-known-complete hub/day/direction data across deploys and upstream outages. Expands the Vercel schedule warmer to rotate across yesterday, today, and tomorrow for both departures and arrivals instead of only warming today departures. Adds a one-shot `npm run seed:schedules -- --base-url=...` script for immediately backfilling all 54 schedule windows after rollout. Tests: `npm test -- tests/schedule.test.js`.