### PR TITLE
Persist best-known partial schedule fallbacks

### DIFF
--- a/api/_schedule-snapshots.ts
+++ b/api/_schedule-snapshots.ts
@@ -1,5 +1,6 @@
 const SNAPSHOT_TABLE = 'schedule_snapshots';
 const SNAPSHOT_TTL_MS = 72 * 60 * 60 * 1000;
+const MIN_PARTIAL_SNAPSHOT_COMPLETENESS = 0.25;
 
 interface PersistedSnapshotRow {
   payload: any;
@@ -22,6 +23,39 @@ interface SaveScheduleSnapshotArgs {
 let warnedMissingConfig = false;
 let warnedInitFailure = false;
 let supabaseClientPromise: Promise<any | null> | null = null;
+
+function getSnapshotCompleteness(data: any): number {
+  const completeness = Number(data?.meta?.completeness);
+  if (Number.isFinite(completeness)) {
+    return Math.max(0, Math.min(1, completeness));
+  }
+  return data?.partial ? 0 : 1;
+}
+
+function shouldPersistPartialSnapshot(data: any): boolean {
+  if (!data?.partial) return false;
+  const total = Number(data?.total || 0);
+  return total > 0 && getSnapshotCompleteness(data) >= MIN_PARTIAL_SNAPSHOT_COMPLETENESS;
+}
+
+function isSnapshotCandidateBetter(candidate: any, existing: any): boolean {
+  if (!existing) return true;
+  if (!candidate?.partial) return true;
+  if (!existing?.partial) return false;
+
+  const candidateCompleteness = getSnapshotCompleteness(candidate);
+  const existingCompleteness = getSnapshotCompleteness(existing);
+  if (candidateCompleteness > existingCompleteness + 0.01) return true;
+  if (candidateCompleteness + 0.01 < existingCompleteness) return false;
+
+  const candidateTotal = Number(candidate?.total || 0);
+  const existingTotal = Number(existing?.total || 0);
+  if (candidateTotal !== existingTotal) return candidateTotal > existingTotal;
+
+  const candidatePages = Number(candidate?.meta?.pagesSucceeded || 0);
+  const existingPages = Number(existing?.meta?.pagesSucceeded || 0);
+  return candidatePages > existingPages;
+}
 
 function getSupabaseConfig(): { url: string; key: string } | null {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
@@ -87,7 +121,10 @@ export async function loadScheduleSnapshot(cacheKey: string): Promise<PersistedS
 }
 
 export async function saveScheduleSnapshot({ cacheKey, hub, dir, ts, data }: SaveScheduleSnapshotArgs): Promise<void> {
-  if (!data || data.partial) return;
+  if (!data) return;
+
+  const isCompleteSnapshot = !data.partial;
+  if (!isCompleteSnapshot && !shouldPersistPartialSnapshot(data)) return;
 
   const supabase = await getSupabaseAdmin();
   if (!supabase) return;
@@ -96,6 +133,22 @@ export async function saveScheduleSnapshot({ cacheKey, hub, dir, ts, data }: Sav
   const expiresAtIso = new Date(Math.max(Date.now() + SNAPSHOT_TTL_MS, (ts * 1000) + SNAPSHOT_TTL_MS)).toISOString();
 
   try {
+    if (!isCompleteSnapshot) {
+      const { data: existingRows, error: existingError } = await supabase
+        .from(SNAPSHOT_TABLE)
+        .select('payload')
+        .eq('cache_key', cacheKey)
+        .limit(1);
+
+      if (existingError) {
+        console.error(`Schedule snapshot read-before-write failed for ${cacheKey}:`, existingError.message);
+        return;
+      }
+
+      const existingPayload = (existingRows as PersistedSnapshotRow[] | null)?.[0]?.payload;
+      if (!isSnapshotCandidateBetter(data, existingPayload)) return;
+    }
+
     const { error } = await supabase
       .from(SNAPSHOT_TABLE)
       .upsert({

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -1,9 +1,14 @@
 import type { VercelRequest, VercelResponse } from './types.js';
 import { createRateLimiter } from './_rate-limit.js';
 import { loadScheduleSnapshot, saveScheduleSnapshot } from './_schedule-snapshots.js';
+import { getStartOfDayForHub } from './irops.js';
 import { waitUntil } from '@vercel/functions';
 
 const isRateLimited = createRateLimiter('schedule', 30);
+
+type ScheduleFetchOptions = {
+  allowTargetedOfficialRescue?: boolean;
+};
 
 // In-memory LRU cache for FR24 schedule data
 const cache = new Map<string, { data: any; expires: number; time: number }>();
@@ -17,6 +22,7 @@ const MAX_COMPLETE_CACHE_SIZE = 128;
 const COMPLETE_CACHE_MAX_AGE = 21600000; // 6 hours
 const BATCH_DELAY = 500; // 500ms pause between parallel batches
 const STALE_GRACE = 120000; // serve stale data for up to 2min past expiry
+const TARGETED_OFFICIAL_RESCUE_HUBS = new Set(['ORD', 'DEN', 'IAH', 'EWR', 'SFO', 'IAD', 'LAX']);
 
 // Busy hubs get more time to fetch all pages (capped at 55s for Vercel's 60s maxDuration)
 const HUB_TIMEOUT_MS: Record<string, number> = { ORD: 55000, EWR: 55000, IAH: 55000, SFO: 55000, LAX: 55000, DEN: 55000, IAD: 55000, NRT: 55000, GUM: 55000 };
@@ -137,15 +143,25 @@ function getLastCompleteByHubDir(hub: string, dir: string, ts: number) {
   return entry;
 }
 
-async function getPersistentComplete(key: string) {
+async function getPersistentFallback(key: string) {
   const snapshot = await loadScheduleSnapshot(key);
-  if (!snapshot || snapshot.data?.partial) return null;
-  saveComplete(key, snapshot.data, snapshot.refreshedAt);
-  return { data: snapshot.data, time: snapshot.refreshedAt };
+  if (!snapshot) return null;
+  if (!snapshot.data?.partial) {
+    saveComplete(key, snapshot.data, snapshot.refreshedAt);
+  }
+  return {
+    data: snapshot.data,
+    time: snapshot.refreshedAt,
+    fallbackScope: snapshot.data?.partial ? 'persistent_partial' as const : 'persistent' as const,
+  };
 }
 
-function buildDegradedResponse(entry: { data: any; time: number }, fallbackScope: 'exact' | 'hub_dir' | 'persistent') {
+function buildDegradedResponse(
+  entry: { data: any; time: number },
+  fallbackScope: 'exact' | 'hub_dir' | 'persistent' | 'persistent_partial'
+) {
   const dataAge = Math.max(0, Math.round((Date.now() - entry.time) / 1000));
+  const isBestKnownPartial = entry.data?.partial === true;
   return {
     ...entry.data,
     cached: true,
@@ -155,8 +171,18 @@ function buildDegradedResponse(entry: { data: any; time: number }, fallbackScope
       ...(entry.data?.meta || {}),
       dataAge,
       fallbackScope,
+      bestKnownPartial: isBestKnownPartial,
     }
   };
+}
+
+function shouldAttemptTargetedOfficialRescue(hub: string, ts: number, options?: ScheduleFetchOptions): boolean {
+  if (!options?.allowTargetedOfficialRescue || !process.env.FR24_API_TOKEN) return false;
+  const hubUpper = hub.toUpperCase();
+  if (!TARGETED_OFFICIAL_RESCUE_HUBS.has(hubUpper)) return false;
+
+  const startOfToday = getStartOfDayForHub(hubUpper);
+  return ts === startOfToday || ts === startOfToday + 86400;
 }
 
 function cacheSet(key: string, data: any, ttlMs: number): void {
@@ -635,10 +661,17 @@ function enqueueBackgroundTask(promise: Promise<any>): void {
   }
 }
 
-function triggerBackgroundRefresh(hub: string, dir: string, ts: number, aggKey: string, ttl: number): void {
+function triggerBackgroundRefresh(
+  hub: string,
+  dir: string,
+  ts: number,
+  aggKey: string,
+  ttl: number,
+  options: ScheduleFetchOptions = {}
+): void {
   if (pendingAggs.has(aggKey)) return;
   const refreshHub = String(hub);
-  const promise = fetchAllPages(refreshHub, dir, ts, undefined, Date.now() + 55000).then(async result => {
+  const promise = fetchAllPages(refreshHub, dir, ts, undefined, Date.now() + 55000, options).then(async result => {
     cacheSet(aggKey, result, result.partial ? 60000 : ttl);
     saveComplete(aggKey, result);
     await saveScheduleSnapshot({ cacheKey: aggKey, hub: refreshHub, dir, ts, data: result });
@@ -693,10 +726,18 @@ async function tryOfficialFallback(
   return null;
 }
 
-async function fetchAllPages(hub: string, dir: string, ts: number, timeoutMs?: number, overallDeadline?: number) {
+async function fetchAllPages(
+  hub: string,
+  dir: string,
+  ts: number,
+  timeoutMs?: number,
+  overallDeadline?: number,
+  options: ScheduleFetchOptions = {}
+) {
   const logHub = String(hub);
   const now = Date.now();
   const effectiveDeadline = overallDeadline || (now + (timeoutMs || HUB_TIMEOUT_MS[logHub.toUpperCase()] || 45000));
+  const allowTargetedOfficialRescue = shouldAttemptTargetedOfficialRescue(logHub, ts, options);
 
   // ── Source routing decision tree ──
   const srcPriority = (process.env.SCHEDULE_SOURCE_PRIORITY || 'scrape').toLowerCase();
@@ -747,8 +788,8 @@ async function fetchAllPages(hub: string, dir: string, ts: number, timeoutMs?: n
   const startTime = Date.now();
   const firstPage = await fetchOnePage(logHub, dir, ts, 1, deadline);
   if (!firstPage || firstPage._rateLimited) {
-    // Scraping failed on first page — try official API fallback if in scrape-first mode
-    if (srcPriority === 'scrape') {
+    // Targeted rescue: only spend official credits for missing high-priority windows.
+    if (srcPriority === 'scrape' && allowTargetedOfficialRescue) {
       console.log(`Scraping failed on first page for ${logHub} ${dir}, trying official API fallback`);
       const fallback = await tryOfficialFallback(logHub, dir, ts, effectiveDeadline);
       if (fallback) return fallback;
@@ -889,7 +930,7 @@ async function fetchAllPages(hub: string, dir: string, ts: number, timeoutMs?: n
   };
 
   // Scrape-first fallback: if scraping failed completely, try official API (with circuit breaker)
-  if (srcPriority === 'scrape' && scrapeResult.total === 0 && scrapeResult.partial) {
+  if (srcPriority === 'scrape' && allowTargetedOfficialRescue && scrapeResult.total === 0 && scrapeResult.partial) {
     console.log(`Scraping returned 0 flights for ${logHub} ${dir}, trying official API fallback`);
     const fallback = await tryOfficialFallback(logHub, dir, ts, effectiveDeadline);
     if (fallback) return fallback;
@@ -971,7 +1012,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     const stale = cacheGetStale(currentAggKey);
     if (stale && !stale.data.partial) {
-      triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl);
+      triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, { allowTargetedOfficialRescue: false });
       res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
       return res.status(200).json({ ...stale.data, cached: true, stale: true });
     }
@@ -979,16 +1020,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const exactLastComplete = getLastComplete(currentAggKey);
     const fallbackComplete = exactLastComplete || getLastCompleteByHubDir(hub, dir, ts);
     if (fallbackComplete) {
-      triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl);
+      triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, { allowTargetedOfficialRescue: false });
       res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
       return res.status(200).json(buildDegradedResponse(fallbackComplete, exactLastComplete ? 'exact' : 'hub_dir'));
     }
 
-    const persistentComplete = await getPersistentComplete(currentAggKey);
-    if (persistentComplete) {
-      triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl);
+    const persistentFallback = await getPersistentFallback(currentAggKey);
+    if (persistentFallback) {
+      triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, {
+        allowTargetedOfficialRescue: persistentFallback.fallbackScope === 'persistent_partial'
+      });
       res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
-      return res.status(200).json(buildDegradedResponse(persistentComplete, 'persistent'));
+      return res.status(200).json(buildDegradedResponse(persistentFallback, persistentFallback.fallbackScope));
     }
 
     if (pendingAggs.has(currentAggKey)) {
@@ -999,7 +1042,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       }
     }
 
-    const aggPromise = fetchAllPages(hub, dir, ts, undefined, functionDeadline).then(async result => {
+    const aggPromise = fetchAllPages(hub, dir, ts, undefined, functionDeadline, {
+      allowTargetedOfficialRescue: true
+    }).then(async result => {
       cacheSet(currentAggKey, result, result.partial ? 60000 : ttl);
       saveComplete(currentAggKey, result);
       await saveScheduleSnapshot({ cacheKey: currentAggKey, hub, dir, ts, data: result });
@@ -1017,10 +1062,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           return res.status(200).json(buildDegradedResponse(lc, exactLc ? 'exact' : 'hub_dir'));
         }
 
-        const persistentLc = await getPersistentComplete(currentAggKey);
-        if (persistentLc) {
+        const persistentResult = await getPersistentFallback(currentAggKey);
+        if (persistentResult && persistentResult.fallbackScope === 'persistent') {
           res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
-          return res.status(200).json(buildDegradedResponse(persistentLc, 'persistent'));
+          return res.status(200).json(buildDegradedResponse(persistentResult, 'persistent'));
         }
       }
       res.setHeader('Cache-Control', `s-maxage=${cdnMaxAge}, stale-while-revalidate=${swr}`);
@@ -1031,10 +1076,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   } catch (e) {
     console.error('Schedule API error:', e);
     if (aggKey) {
-      const persistentFallback = await getPersistentComplete(aggKey);
+      const persistentFallback = await getPersistentFallback(aggKey);
       if (persistentFallback) {
         res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
-        return res.status(200).json(buildDegradedResponse(persistentFallback, 'persistent'));
+        return res.status(200).json(buildDegradedResponse(persistentFallback, persistentFallback.fallbackScope));
       }
     }
     return res.status(502).json({ error: 'Upstream service unavailable' });

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -3057,7 +3057,9 @@ async function loadScheduleData() {
       let msg = '';
       if (result.degraded && meta.dataAge) {
         const ageMin = Math.round(meta.dataAge / 60);
-        msg = `Showing cached complete data from ${ageMin}m ago while refreshing.`;
+        msg = result.partial
+          ? `Showing cached partial data from ${ageMin}m ago while refreshing.`
+          : `Showing cached complete data from ${ageMin}m ago while refreshing.`;
       } else if (meta.partialReason === 'deadline_exceeded') {
         msg = 'The request timed out before all pages were fetched.';
       } else if (meta.partialReason === 'first_page_failed') {
@@ -3067,7 +3069,13 @@ async function loadScheduleData() {
       } else {
         msg = 'Some flights may be missing.';
       }
-      const pct = meta.completeness != null && !result.degraded ? ` ${Math.round(meta.completeness * 100)}% loaded.` : '';
+      const pct = meta.completeness != null
+        ? result.degraded && result.partial
+          ? ` ${Math.round(meta.completeness * 100)}% previously loaded.`
+          : !result.degraded
+            ? ` ${Math.round(meta.completeness * 100)}% loaded.`
+            : ''
+        : '';
       const bgColor = result.degraded ? 'rgba(78,205,196,.12)' : 'rgba(234,179,8,.12)';
       const borderColor = result.degraded ? 'rgba(78,205,196,.3)' : 'rgba(234,179,8,.3)';
       const textColor = result.degraded ? '#4ecdc4' : '#eab308';

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -12,7 +12,7 @@ import {
 
 const BASE_URL = 'https://theblueboard.co';
 
-function renderUrl(path, lastmod, changefreq, priority) {
+function renderUrl(path: string, lastmod: string, changefreq: string, priority: string) {
   return [
     '  <url>',
     `    <loc>${xmlEscape(`${BASE_URL}${path}`)}</loc>`,
@@ -24,10 +24,11 @@ function renderUrl(path, lastmod, changefreq, priority) {
 }
 
 export function GET() {
+  const fleetKeys = fleetOrder as Array<keyof typeof fleetTypes>;
   const urls = [
     renderUrl('/', getLastModified(homeLastmodPaths), 'daily', '1.0'),
     renderUrl('/fleet', getLastModified(fleetIndexLastmodPaths), 'daily', '0.9'),
-    ...fleetOrder.map((key) =>
+    ...fleetKeys.map((key) =>
       renderUrl(
         `/fleet/${fleetTypes[key].slug}`,
         getLastModified(getFleetRouteLastmodPaths(fleetTypes[key].slug)),

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -376,32 +376,19 @@ describe('schedule API', () => {
     }
   });
 
-  it('scrape-first: scraping fails, falls back to official API', async () => {
+  it('scrape-first: historical failures do not trigger official API rescue', async () => {
     process.env.FR24_API_TOKEN = 'test-token-12345678';
 
-    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
       const urlStr = String(url);
       if (urlStr.includes('fr24api.flightradar24.com')) {
-        return {
-          ok: true,
-          json: async () => ({
-            data: [{
-              flight_icao: 'UAL200',
-              flight_iata: 'UA200',
-              status: 'scheduled',
-              orig_iata: 'LAX',
-              dest_iata: 'SFO',
-              scheduled_departure: 1741653600,
-              scheduled_arrival: 1741660800,
-            }]
-          }),
-        };
+        throw new Error('Official API should not be called for historical windows');
       }
       // Scraping returns 403
       return { ok: false, status: 403, text: async () => 'Forbidden', headers: { get: () => null } };
     });
 
-    const ts = Math.floor(Date.now() / 1000) - 25200;
+    const ts = getStartOfDayForHub('LAX') - 86400;
     const req = {
       method: 'GET',
       headers: { origin: 'http://localhost:3000' },
@@ -412,8 +399,11 @@ describe('schedule API', () => {
     await handler(req, res);
 
     expect(res.statusCode).toBe(200);
-    expect(res.body.meta.source).toBe('official-api');
-    expect(res.body.meta.fallbackFrom).toBe('scraping');
+    expect(res.body.partial).toBe(true);
+    expect(res.body.meta.source).toBe('scraping');
+    for (const call of fetchSpy.mock.calls) {
+      expect(String(call[0])).not.toContain('fr24api.flightradar24.com');
+    }
   });
 
   it('scrape-first: tomorrow uses official fallback when scraping fails', async () => {
@@ -653,6 +643,64 @@ describe('schedule API', () => {
     expect(vercelFunctionMocks.waitUntil).toHaveBeenCalledTimes(1);
   });
 
+  it('returns persisted partial snapshot on cold start while refreshing in the background', async () => {
+    const ts = getStartOfDayForHub('ORD') + 86400;
+    scheduleSnapshotMocks.loadScheduleSnapshot.mockResolvedValue({
+      data: {
+        flights: [{
+          airline: { code: { iata: 'UA' } },
+          identification: { number: { default: 'UA123' } },
+          time: { scheduled: { departure: 1741653600, arrival: 1741660800 } },
+          airport: {
+            origin: { code: { iata: 'ORD' } },
+            destination: { code: { iata: 'LAX' } }
+          }
+        }],
+        total: 1,
+        totalFetched: 2,
+        pagesScanned: 2,
+        totalPages: 4,
+        cached: false,
+        partial: true,
+        hub: 'ORD',
+        dir: 'departures',
+        meta: {
+          partialReason: 'rate_limited',
+          pagesRequested: 4,
+          pagesSucceeded: 2,
+          pagesFailed: 2,
+          missingPages: [3, 4],
+          completeness: 0.5,
+          elapsedMs: 75,
+          source: 'scraping'
+        }
+      },
+      refreshedAt: Date.now() - (7 * 60 * 1000)
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      throw new Error('background refresh should be best-effort');
+    });
+
+    const req = {
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'ORD', dir: 'departures', timestamp: String(ts) }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.total).toBe(1);
+    expect(res.body.partial).toBe(true);
+    expect(res.body.degraded).toBe(true);
+    expect(res.body.meta.fallbackScope).toBe('persistent_partial');
+    expect(res.body.meta.bestKnownPartial).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(vercelFunctionMocks.waitUntil).toHaveBeenCalledTimes(1);
+  });
+
   it('persists complete aggregated results after a successful fetch', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: true,
@@ -704,6 +752,73 @@ describe('schedule API', () => {
       data: expect.objectContaining({
         partial: false,
         total: 1
+      })
+    }));
+  });
+
+  it('persists partial aggregated results when they are the best available fallback', { timeout: 15000 }, async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const urlStr = String(url);
+      const pageMatch = urlStr.match(/page=(\d+)/);
+      const page = pageMatch ? parseInt(pageMatch[1], 10) : 1;
+
+      if (page === 2) {
+        return { ok: false, status: 429, text: async () => 'Too Many Requests', headers: { get: () => null } };
+      }
+
+      return {
+        ok: true,
+        json: async () => ({
+          result: {
+            response: {
+              airport: {
+                pluginData: {
+                  schedule: {
+                    departures: {
+                      page: { current: page, total: 2 },
+                      data: [{
+                        flight: {
+                          airline: { code: { iata: 'UA' } },
+                          identification: { number: { default: `UA8${page}` } },
+                          time: { scheduled: { departure: 1741653600, arrival: 1741660800 } },
+                          airport: {
+                            origin: { code: { iata: 'ORD' } },
+                            destination: { code: { iata: 'LAX' } }
+                          }
+                        }
+                      }]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }),
+      };
+    });
+
+    const ts = getStartOfDayForHub('ORD') + 86400;
+    const req = {
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'ORD', dir: 'departures', timestamp: String(ts) }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.partial).toBe(true);
+    expect(res.body.total).toBe(1);
+    expect(scheduleSnapshotMocks.saveScheduleSnapshot).toHaveBeenCalledWith(expect.objectContaining({
+      cacheKey: `agg:ORD:departures:${ts}`,
+      data: expect.objectContaining({
+        partial: true,
+        total: 1,
+        meta: expect.objectContaining({
+          completeness: 0.5,
+          partialReason: 'rate_limited'
+        })
       })
     }));
   });


### PR DESCRIPTION
## Summary
- persist best-known partial schedule snapshots without overwriting complete ones and serve them as degraded fallbacks when a full snapshot is missing
- limit official FR24 rescue calls to missing high-priority today/tomorrow windows at major hubs while keeping scrape as the steady-state path
- update schedule UI copy to distinguish cached partial vs complete data and add tests for partial persistence, degraded fallback, and targeted rescue behavior
- fix the sitemap TypeScript typing errors so \ is clean again

## Verification
- npm test -- tests/schedule.test.js
- npx tsc --noEmit