### PR TITLE
Improve mobile dashboard nav and touch targets

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -451,7 +451,8 @@ tbody td{padding:5px 8px;white-space:nowrap}
   /* ── Hub health bar: compact pill grid on mobile (Change 5) ── */
   #hub-health-bar{display:flex!important;flex-wrap:wrap;justify-content:center;padding:4px 8px;gap:0}
   #hub-health-bar .hh-label,#hub-health-bar .hh-explainer,#hub-health-bar .hh-info,#hub-health-bar .hh-sep,#hub-health-bar .hh-avg{display:none!important}
-  #hub-health-bar .hh-hub{padding:3px 8px;font-size:10px;flex-shrink:0;background:rgba(30,41,59,.4);border-radius:12px;margin:2px 3px;min-height:auto}
+  #hub-health-bar .hh-hub{padding:6px 10px;font-size:11px;flex-shrink:0;background:rgba(30,41,59,.4);border-radius:12px;margin:2px 3px;min-height:32px;display:inline-flex;align-items:center}
+  #hub-health-bar .hh-hub a{min-height:32px;display:inline-flex;align-items:center}
   #tip-strip{display:none!important}
   /* ── Footer: condensed single line (Change 6) ── */
   .footer-hub-links,.footer-data-sources{display:none!important}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -361,7 +361,8 @@ tbody td{padding:5px 8px;white-space:nowrap}
   #header{flex-direction:row;gap:0;padding:0 12px;height:44px;text-align:left;align-items:center}
   #header h1{font-size:14px;letter-spacing:1px;white-space:nowrap}
   #header h1 span[style]{display:none}
-  #brand-strip{flex-direction:column;align-items:flex-start;padding:8px 12px;font-size:9px}
+  #brand-strip{flex-direction:column;align-items:flex-start;padding:4px 12px;font-size:9px}
+  #brand-strip p{display:none}
   #global-search-wrap{position:absolute!important;top:44px;left:0;right:0;flex:none!important;order:0;display:none;padding:8px 12px;background:var(--ua-dark);border-bottom:1px solid var(--ua-border);z-index:999}
   #global-search-wrap.mobile-search-open{display:block!important}
   #header-right{font-size:14px;gap:8px;margin-left:auto}

--- a/public/index.html
+++ b/public/index.html
@@ -197,17 +197,17 @@ body{background:#0a0f1a;color:#e2e8f0;margin:0;overflow:hidden;font-family:'Inte
 
 <!-- MOBILE BOTTOM NAV -->
 <nav id="mobile-bottom-nav" aria-label="Mobile navigation">
-  <button data-tab="tab-myflight"><span class="bnav-icon">🎫</span><span class="bnav-label">My Flights</span></button>
   <button data-tab="tab-live" class="active"><span class="bnav-icon">📡</span><span class="bnav-label">Live</span></button>
+  <button data-tab="tab-weather"><span class="bnav-icon">🌦</span><span class="bnav-label">Weather</span></button>
   <button data-tab="tab-schedule"><span class="bnav-icon">📅</span><span class="bnav-label">Schedule</span></button>
   <button data-tab="tab-fleet"><span class="bnav-icon">✈️</span><span class="bnav-label">Fleet</span></button>
-  <button data-tab="tab-weather" class="bnav-overflow-item"><span class="bnav-icon">🌦</span><span class="bnav-label">Weather</span></button>
+  <button data-tab="tab-myflight" class="bnav-overflow-item"><span class="bnav-icon">🎫</span><span class="bnav-label">My Flights</span></button>
   <button data-tab="tab-analytics" class="bnav-overflow-item"><span class="bnav-icon">📊</span><span class="bnav-label">Stats</span></button>
   <button data-tab="tab-sources" class="bnav-overflow-item"><span class="bnav-icon">ℹ️</span><span class="bnav-label">Sources</span></button>
   <button id="mobile-more-btn" aria-label="More tabs"><span class="bnav-icon">▾</span><span class="bnav-label">More</span></button>
 </nav>
 <div id="mobile-more-menu">
-  <button data-tab="tab-weather"><span class="bnav-icon">🌦</span> Weather</button>
+  <button data-tab="tab-myflight"><span class="bnav-icon">🎫</span> My Flights</button>
   <button data-tab="tab-analytics"><span class="bnav-icon">📊</span> Stats</button>
   <button data-tab="tab-sources"><span class="bnav-icon">ℹ️</span> Sources</button>
 </div>

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -541,7 +541,7 @@ function applyFleetDeepLinkFilter(filter, { render = true } = {}) {
 const _origSwitchToTab = switchToTab;
 switchToTab = function(tabId, updateHash) {
   _origSwitchToTab(tabId, updateHash);
-  var overflowTabs = ['tab-weather','tab-analytics','tab-sources'];
+  var overflowTabs = ['tab-myflight','tab-analytics','tab-sources'];
   var moreBtn = document.getElementById('mobile-more-btn');
   document.querySelectorAll('#mobile-bottom-nav button[data-tab]:not(.bnav-overflow-item)').forEach(function(b) {
     b.classList.toggle('active', b.dataset.tab === tabId);


### PR DESCRIPTION
## Summary
- promote Weather into the visible mobile bottom nav and move My Flights into the More menu
- update the mobile tab active-state logic so the More button only highlights for overflow tabs
- tighten the mobile brand strip and enlarge hub health pills to reclaim space and improve tap targets