### PR TITLE
Split weather tab into 60/40 desktop layout

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -254,19 +254,21 @@ tbody td{padding:5px 8px;white-space:nowrap}
 .special-aircraft-item .sa-type{font-size:9px;color:var(--ua-muted)}
 .special-aircraft-item .sa-status{font-size:9px;color:var(--ua-muted);text-align:right;flex-shrink:0}
 
-/* ═══ TAB 3: WEATHER ═══ */
-#tab-weather{padding:0;flex:1;min-height:0;overflow-y:auto}
-.wx-hero{position:relative}
+/* ═══ TAB 3: WEATHER — Desktop Split Layout ═══ */
+#tab-weather{padding:0;flex:1;min-height:0;overflow:hidden}
+.wx-layout{display:flex;height:100%}
+.wx-map-panel{flex:3;position:relative;min-width:0;display:flex;flex-direction:column}
+.wx-hero{flex:1;position:relative;min-height:0}
 .wx-hero h3{position:absolute;top:10px;left:14px;z-index:500;font-size:13px;color:#fff;text-shadow:0 1px 4px rgba(0,0,0,.7)}
-#radar-map{height:420px;width:100%}
-.wx-legend{display:flex;align-items:center;justify-content:center;gap:18px;padding:8px 16px;background:var(--ua-panel);border-bottom:1px solid var(--ua-border);font-size:10px}
+#radar-map{width:100%;height:100%}
+.wx-legend{display:flex;align-items:center;justify-content:center;gap:18px;padding:8px 16px;background:var(--ua-panel);border-top:1px solid var(--ua-border);font-size:10px;flex-shrink:0}
 .wx-legend-item{display:flex;align-items:center;gap:5px}
 .wx-legend-dot{width:10px;height:10px;border-radius:50%;display:inline-block}
-.wx-scroll-hint{display:flex;align-items:center;justify-content:center;gap:10px;padding:10px 16px;color:var(--ua-accent);font-size:11px;font-weight:500;letter-spacing:.5px;transition:opacity .5s}
-.wx-section-header{text-transform:uppercase;letter-spacing:.8px}
+.wx-detail-panel{flex:2;display:flex;flex-direction:column;overflow-y:auto;border-left:1px solid var(--ua-border)}
+.wx-panel-divider{display:flex;align-items:center;justify-content:space-between;padding:8px 14px;color:var(--ua-accent);font-size:10px;font-weight:600;letter-spacing:.5px;text-transform:uppercase;border-bottom:1px solid var(--ua-border);flex-shrink:0;transition:opacity .5s}
 .scroll-hint-arrow{animation:bounce 1.5s ease-in-out infinite;font-size:14px}
 @keyframes bounce{0%,100%{transform:translateY(0)}50%{transform:translateY(5px)}}
-.hub-cards{display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:14px;padding:16px;min-height:200px;flex-shrink:0}
+.hub-cards{display:flex;flex-direction:column;gap:10px;padding:12px;flex-shrink:0}
 .hub-card{background:var(--ua-panel);border:1px solid var(--ua-border);border-radius:6px;overflow:hidden;transition:border-color .2s}
 .hub-card:hover{border-color:var(--ua-accent)}
 .hub-card-top{padding:12px 14px 8px;display:flex;align-items:center;justify-content:space-between}
@@ -420,8 +422,11 @@ tbody td{padding:5px 8px;white-space:nowrap}
   .special-aircraft-grid{grid-template-columns:1fr}
   .special-aircraft-item{padding:10px 12px}
   /* Weather tab mobile */
+  .wx-layout{flex-direction:column}
+  .wx-map-panel{flex:none}
   #radar-map{height:260px}
-  .hub-cards{grid-template-columns:1fr;padding:10px}
+  .wx-detail-panel{flex:1;border-left:none;border-top:1px solid var(--ua-border)}
+  .hub-cards{padding:10px}
   /* Analytics mobile */
   .metric-row{flex-wrap:wrap;gap:0}
   .metric-card{min-width:45%}
@@ -551,21 +556,23 @@ tbody td{padding:5px 8px;white-space:nowrap}
 .fleet-enrich-detail.show{display:block}
 .fleet-enrich-inline{font-size:9px;color:var(--ua-muted);margin-top:1px}
 
-/* IROPS Monitor */
-#irops-section{padding:16px;border-bottom:1px solid var(--ua-border);flex-shrink:0}
-#irops-section h3{font-size:13px;color:#f59e0b;margin-bottom:12px}
-.irops-metrics{display:grid;grid-template-columns:repeat(auto-fill,minmax(140px,1fr));gap:10px;margin-bottom:14px}
-.irops-card{background:var(--ua-panel);border:1px solid var(--ua-border);border-radius:6px;padding:10px;text-align:center}
-.irops-card .iv{font-size:22px;font-weight:700}
-.irops-card .il{font-size:9px;color:var(--ua-muted);text-transform:uppercase;letter-spacing:.5px;margin-top:2px}
-.irops-score{display:inline-block;padding:4px 12px;border-radius:4px;font-size:16px;font-weight:700;margin-bottom:10px}
+/* IROPS Monitor — compact side panel */
+#irops-section{padding:10px 14px;border-bottom:1px solid var(--ua-border);flex-shrink:0}
+.irops-compact{display:flex;flex-direction:column;gap:4px}
+.irops-compact-header{display:flex;align-items:center;gap:8px}
+.irops-compact-label{font-size:10px;color:var(--ua-muted)}
+.irops-compact-metrics{display:flex;flex-wrap:wrap;gap:2px 10px;font-size:10px;color:var(--ua-muted)}
+.irops-compact-metrics b{font-family:var(--font-mono);font-size:11px}
+.irops-compact-time{font-size:8px;color:var(--ua-muted);text-align:right;margin-top:2px}
+.irops-compact-faa{font-size:9px;color:#f59e0b;margin-top:2px}
+.irops-score{display:inline-block;padding:3px 10px;border-radius:4px;font-size:14px;font-weight:700}
 .irops-score.low{background:rgba(34,197,94,.15);color:#22c55e}
 .irops-score.med{background:rgba(245,158,11,.15);color:#f59e0b}
 .irops-score.high{background:rgba(239,68,68,.15);color:#ef4444}
-.irops-worst{margin-top:10px}
-.irops-worst h4{font-size:11px;color:var(--ua-muted);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:6px}
-.irops-worst-row{display:flex;justify-content:space-between;padding:4px 0;border-bottom:1px solid rgba(30,41,59,.3);font-size:10px}
-.irops-empty{text-align:center;padding:30px;color:var(--ua-muted);font-size:11px}
+.irops-worst{padding:10px 14px;border-top:1px solid var(--ua-border)}
+.irops-worst h4{font-size:10px;color:var(--ua-muted);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:6px}
+.irops-worst-row{display:flex;justify-content:space-between;padding:3px 0;border-bottom:1px solid rgba(30,41,59,.3);font-size:10px}
+.irops-empty{text-align:center;padding:20px;color:var(--ua-muted);font-size:10px}
 
 /* FAA Delay Context */
 .faa-delay-context{font-size:9px;color:#f59e0b;font-style:italic;margin-top:2px;opacity:.85}

--- a/public/index.html
+++ b/public/index.html
@@ -478,25 +478,30 @@ body{background:#0a0f1a;color:#e2e8f0;margin:0;overflow:hidden;font-family:'Inte
 
 <!-- TAB 3: WEATHER -->
 <div class="tab-content" id="tab-weather" role="tabpanel" aria-label="Delays, weather, and hub status">
-  <div class="wx-hero">
-    <h3 id="radar-title">🌧 NEXRAD Radar</h3>
-    <div id="radar-map"></div>
-  </div>
-  <div class="wx-legend">
-    <div class="wx-legend-item"><span class="wx-legend-dot" style="background:#22c55e"></span>VFR</div>
-    <div class="wx-legend-item"><span class="wx-legend-dot" style="background:#eab308"></span>MVFR</div>
-    <div class="wx-legend-item"><span class="wx-legend-dot" style="background:#ef4444"></span>IFR</div>
-    <div class="wx-legend-item"><span class="wx-legend-dot" style="background:#c026d3"></span>LIFR</div>
-  </div>
-  <div class="wx-scroll-hint" id="wx-scroll-hint">
-    <span class="wx-section-header">Hub Weather Details</span>
-    <span class="scroll-hint-arrow">↓</span>
-  </div>
-  <div class="hub-cards" id="hub-cards"></div>
-  <!-- IROPS Monitor -->
-  <div id="irops-section">
-    <h3>⚠️ IROPS Monitor</h3>
-    <div id="irops-content" aria-live="polite"><div class="irops-empty" style="color:var(--ua-muted);font-size:10px">Loading IROPS data…</div></div>
+  <div class="wx-layout">
+    <div class="wx-map-panel">
+      <div class="wx-hero">
+        <h3 id="radar-title">🌧 NEXRAD Radar</h3>
+        <div id="radar-map"></div>
+      </div>
+      <div class="wx-legend">
+        <div class="wx-legend-item"><span class="wx-legend-dot" style="background:#22c55e"></span>VFR</div>
+        <div class="wx-legend-item"><span class="wx-legend-dot" style="background:#eab308"></span>MVFR</div>
+        <div class="wx-legend-item"><span class="wx-legend-dot" style="background:#ef4444"></span>IFR</div>
+        <div class="wx-legend-item"><span class="wx-legend-dot" style="background:#c026d3"></span>LIFR</div>
+      </div>
+    </div>
+    <div class="wx-detail-panel" id="wx-detail-panel">
+      <div id="irops-section">
+        <div id="irops-content" aria-live="polite"><div class="irops-empty" style="color:var(--ua-muted);font-size:10px">Loading IROPS data…</div></div>
+      </div>
+      <div class="wx-panel-divider" id="wx-scroll-hint">
+        <span>Hub Stations</span>
+        <span class="scroll-hint-arrow">↓</span>
+      </div>
+      <div class="hub-cards" id="hub-cards"></div>
+      <div id="irops-worst-flights"></div>
+    </div>
   </div>
 </div>
 

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -2347,6 +2347,7 @@ async function initWeatherTab() {
   const radarMap = L.map('radar-map', {center:[39,-98],zoom:4,zoomControl:true,attributionControl:false});
   L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png',{maxZoom:18,subdomains:'abcd',tileSize:256,detectRetina:true}).addTo(radarMap);
   L.tileLayer('https://mesonet.agron.iastate.edu/cache/tile.py/1.0.0/nexrad-n0q-900913/{z}/{x}/{y}.png',{opacity:0.6}).addTo(radarMap);
+  setTimeout(() => radarMap.invalidateSize(), 200);
   document.getElementById('radar-title').textContent = `🌧 NEXRAD Radar — ${new Date().toUTCString().slice(17,25)}Z`;
 
   // Place hub markers immediately with neutral color (updated after METAR loads)
@@ -2484,7 +2485,7 @@ async function initWeatherTab() {
   if (wxHint) {
     const observer = new IntersectionObserver(([entry]) => {
       wxHint.style.opacity = entry.isIntersecting ? '0' : '1';
-    }, {root: document.getElementById('tab-weather'), threshold: 0.1});
+    }, {root: document.getElementById('wx-detail-panel'), threshold: 0.1});
     observer.observe(document.getElementById('hub-cards'));
   }
 }
@@ -4023,13 +4024,14 @@ function updateIrops() {
   worstDelays.sort((a, b) => b.delay - a.delay);
   const top5 = worstDelays.slice(0, 5);
 
-  let html = `<div style="margin-bottom:10px"><span class="irops-score ${scoreCls}">${score}</span> <span style="font-size:10px;color:var(--ua-muted)">${scoreLabel} · Disruption Score</span></div>`;
-  html += '<div class="irops-metrics">';
-  html += `<div class="irops-card"><div class="iv" style="color:#f59e0b">${delayed30}</div><div class="il">Delayed &gt;30m</div></div>`;
-  html += `<div class="irops-card"><div class="iv" style="color:#ef4444">${delayed60}</div><div class="il">Delayed &gt;60m</div></div>`;
-  html += `<div class="irops-card"><div class="iv" style="color:#c026d3">${diversions}</div><div class="il">Diversions</div></div>`;
-  html += `<div class="irops-card"><div class="iv" style="color:#ef4444">${groundStops}</div><div class="il">Ground Stops (FAA)</div></div>`;
-  html += `<div class="irops-card"><div class="iv" style="color:var(--ua-blue)">${totalFlights}</div><div class="il">Total Flights</div></div>`;
+  let html = '<div class="irops-compact">';
+  html += `<div class="irops-compact-header"><span class="irops-score ${scoreCls}">${score}</span><span class="irops-compact-label">${scoreLabel}</span></div>`;
+  html += '<div class="irops-compact-metrics">';
+  html += `<span><b style="color:#f59e0b">${delayed30}</b> &gt;30m</span>`;
+  html += `<span><b style="color:#ef4444">${delayed60}</b> &gt;60m</span>`;
+  html += `<span><b style="color:#c026d3">${diversions}</b> div</span>`;
+  if (groundStops) html += `<span><b style="color:#ef4444">${groundStops}</b> GS</span>`;
+  html += `<span><b style="color:var(--ua-accent)">${totalFlights}</b> flights</span>`;
   html += '</div>';
 
   // FAA alerts
@@ -4040,18 +4042,21 @@ function updateIrops() {
     }
   }
   if (faaAlerts.length) {
-    html += `<div style="background:rgba(245,158,11,.08);border:1px solid rgba(245,158,11,.2);border-radius:4px;padding:8px 10px;margin-bottom:10px;font-size:10px;color:#f59e0b"><strong>FAA Alerts:</strong> ${faaAlerts.map(a => escapeHtml(a)).join(' · ')}</div>`;
+    html += `<div class="irops-compact-faa">${faaAlerts.map(a => escapeHtml(a)).join(' · ')}</div>`;
   }
-
-  if (top5.length) {
-    html += '<div class="irops-worst"><h4>Most Disrupted Flights</h4>';
-    top5.forEach(f => {
-      html += `<div class="irops-worst-row"><span style="color:var(--ua-accent);font-weight:600">${escapeHtml(f.ident)} <span style="color:var(--ua-muted);font-weight:400">${escapeHtml(f.route)}</span></span><span style="color:#ef4444;font-weight:700">+${f.delay}m</span></div>`;
-    });
-    html += '</div>';
-  }
-
+  html += '</div>';
   content.innerHTML = html;
+
+  // Most disrupted flights — bottom of detail panel
+  const worstEl = document.getElementById('irops-worst-flights');
+  if (worstEl && top5.length) {
+    let wh = '<div class="irops-worst"><h4>Most Disrupted Flights</h4>';
+    top5.forEach(f => {
+      wh += `<div class="irops-worst-row"><span style="color:var(--ua-accent);font-weight:600">${escapeHtml(f.ident)} <span style="color:var(--ua-muted);font-weight:400">${escapeHtml(f.route)}</span></span><span style="color:#ef4444;font-weight:700">+${f.delay}m</span></div>`;
+    });
+    wh += '</div>';
+    worstEl.innerHTML = wh;
+  }
 }
 
 function autoLoadIrops() {


### PR DESCRIPTION
## Summary

Restructured the weather tab for desktop to display weather map (left 60%) and hub cards (right 40%) side-by-side, enabling users to correlate weather patterns with hub conditions instantly. Redesigned IROPS monitor to be compact and space-efficient.

## Changes

- **Layout**: Flexbox split (`60/40` map/cards) on desktop; vertical stack on mobile
- **Map panel**: NEXRAD radar with flight category legend at bottom
- **Detail panel**: Compact IROPS summary → hub stations divider → scrollable hub cards → most disrupted flights
- **IROPS redesign**: Score badge + inline metrics (compact format) instead of card grid
- **Interaction**: Click hub markers to scroll matching card in right panel
- **Mobile**: Preserves current behavior (map 260px, cards full-width below)

## Technical Notes

- Added `invalidateSize()` call for Leaflet map to properly fill flex container
- Updated scroll hint observer to use detail panel as root
- Both IROPS render paths (API + schedule fallback) updated for compact format

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>