### PR TITLE
Restore compact IROPS stats bar

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -427,6 +427,10 @@ tbody td{padding:5px 8px;white-space:nowrap}
   #radar-map{height:260px}
   .wx-detail-panel{flex:1;border-left:none;border-top:1px solid var(--ua-border)}
   .hub-cards{padding:10px}
+  .irops-bar{flex-wrap:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;padding:4px 10px;gap:0}
+  .irops-bar::-webkit-scrollbar{display:none}
+  .irops-bar-sep{display:none}
+  .irops-bar-item{white-space:nowrap;flex-shrink:0;background:rgba(30,41,59,.4);border-radius:12px;padding:4px 10px;margin:2px 3px}
   /* Analytics mobile */
   .metric-row{flex-wrap:wrap;gap:0}
   .metric-card{min-width:45%}
@@ -556,23 +560,21 @@ tbody td{padding:5px 8px;white-space:nowrap}
 .fleet-enrich-detail.show{display:block}
 .fleet-enrich-inline{font-size:9px;color:var(--ua-muted);margin-top:1px}
 
-/* IROPS Monitor — compact side panel */
-#irops-section{padding:10px 14px;border-bottom:1px solid var(--ua-border);flex-shrink:0}
-.irops-compact{display:flex;flex-direction:column;gap:4px}
-.irops-compact-header{display:flex;align-items:center;gap:8px}
-.irops-compact-label{font-size:10px;color:var(--ua-muted)}
-.irops-compact-metrics{display:flex;flex-wrap:wrap;gap:2px 10px;font-size:10px;color:var(--ua-muted)}
-.irops-compact-metrics b{font-family:var(--font-mono);font-size:11px}
-.irops-compact-time{font-size:8px;color:var(--ua-muted);text-align:right;margin-top:2px}
-.irops-compact-faa{font-size:9px;color:#f59e0b;margin-top:2px}
-.irops-score{display:inline-block;padding:3px 10px;border-radius:4px;font-size:14px;font-weight:700}
+/* IROPS Monitor — thin stats bar */
+#irops-section{padding:0;border-bottom:1px solid var(--ua-border);flex-shrink:0}
+.irops-bar{display:flex;align-items:center;padding:6px 14px;gap:4px;font-size:10px;flex-wrap:wrap}
+.irops-bar-item{display:flex;align-items:center;gap:4px}
+.irops-bar-val{font-family:var(--font-mono);font-weight:700;font-size:11px}
+.irops-bar-label{color:var(--ua-muted);font-family:var(--font-ui)}
+.irops-bar-sep{color:var(--ua-border);margin:0 4px}
+.irops-bar-faa{font-size:9px;color:#f59e0b;padding:2px 14px 6px;border-bottom:1px solid var(--ua-border)}
+.irops-score{display:inline-block;padding:2px 8px;border-radius:4px;font-size:12px;font-weight:700}
 .irops-score.low{background:rgba(34,197,94,.15);color:#22c55e}
 .irops-score.med{background:rgba(245,158,11,.15);color:#f59e0b}
 .irops-score.high{background:rgba(239,68,68,.15);color:#ef4444}
-.irops-worst{padding:10px 14px;border-top:1px solid var(--ua-border)}
-.irops-worst h4{font-size:10px;color:var(--ua-muted);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:6px}
-.irops-worst-row{display:flex;justify-content:space-between;padding:3px 0;border-bottom:1px solid rgba(30,41,59,.3);font-size:10px}
-.irops-empty{text-align:center;padding:20px;color:var(--ua-muted);font-size:10px}
+.irops-empty{text-align:center;padding:12px;color:var(--ua-muted);font-size:10px}
+.hub-cards{position:relative}
+.hub-cards::after{content:'';position:sticky;bottom:0;left:0;right:0;height:24px;background:linear-gradient(to bottom,transparent,var(--bg-body));pointer-events:none;display:block}
 
 /* FAA Delay Context */
 .faa-delay-context{font-size:9px;color:#f59e0b;font-style:italic;margin-top:2px;opacity:.85}
@@ -607,8 +609,8 @@ tbody td{padding:5px 8px;white-space:nowrap}
 #watch-notification .wn-dismiss{background:none;border:1px solid rgba(255,255,255,.3);color:#fff;padding:4px 10px;border-radius:3px;cursor:pointer;font-family:var(--font-ui);font-size:10px}
 
 /* ═══ HYBRID TYPOGRAPHY: Mono for data elements ═══ */
-table,thead th,tbody td,.stat-val,.metric-val,.big-number,.ticker,.ticker-item,.hub-code,.hub-card-code,.popup-callsign,.popup-field-value,.popup-route,.hub-raw,.hub-tooltip,.sched-status,#countdown,#clock,.irops-card .iv,.irops-score,.hh-hub,.fleet-chip .count,.equip-change-badge,.cat-badge,.hub-metric-val,.starlink-badge,.popup-phase,.seat-block,.freshness,.squawk-alert{font-family:var(--font-mono)}
-.onboarding-subtitle,.onboarding-desc,.onboarding-footer,.source-desc,.hub-explainer,.wx-explainer,.error-state,.empty-state,.hub-card-name,.stat-label,.metric-label,.big-number-label,.irops-card .il,.hub-metric-label,.popup-field-label,.popup-route-est,.source-name,.source-link{font-family:var(--font-ui)}
+table,thead th,tbody td,.stat-val,.metric-val,.big-number,.ticker,.ticker-item,.hub-code,.hub-card-code,.popup-callsign,.popup-field-value,.popup-route,.hub-raw,.hub-tooltip,.sched-status,#countdown,#clock,.irops-bar-val,.irops-score,.hh-hub,.fleet-chip .count,.equip-change-badge,.cat-badge,.hub-metric-val,.starlink-badge,.popup-phase,.seat-block,.freshness,.squawk-alert{font-family:var(--font-mono)}
+.onboarding-subtitle,.onboarding-desc,.onboarding-footer,.source-desc,.hub-explainer,.wx-explainer,.error-state,.empty-state,.hub-card-name,.stat-label,.metric-label,.big-number-label,.irops-bar-label,.hub-metric-label,.popup-field-label,.popup-route-est,.source-name,.source-link{font-family:var(--font-ui)}
 
 /* ═══ MICRO-INTERACTIONS: :active press feedback ═══ */
 .tab-btn:active,.ctrl-btn:active,.refresh-btn:active,.retry-btn:active,.sched-day-btn:active,.sched-load-more:active,#onboarding-dismiss:active,#onboarding-help:active,.watch-btn:active,.share-btn:active,#watch-header-btn:active,#mobile-bottom-nav button:active,.fleet-chip:active,.hub-nav a:active,.show-all-btn:active{transform:scale(.97)}

--- a/public/index.html
+++ b/public/index.html
@@ -493,14 +493,27 @@ body{background:#0a0f1a;color:#e2e8f0;margin:0;overflow:hidden;font-family:'Inte
     </div>
     <div class="wx-detail-panel" id="wx-detail-panel">
       <div id="irops-section">
-        <div id="irops-content" aria-live="polite"><div class="irops-empty" style="color:var(--ua-muted);font-size:10px">Loading IROPS data…</div></div>
+        <div id="irops-content" aria-live="polite">
+          <div class="irops-bar">
+            <span class="irops-bar-item"><span class="irops-bar-val">—</span><span class="irops-bar-label">Score</span></span>
+            <span class="irops-bar-sep">│</span>
+            <span class="irops-bar-item"><span class="irops-bar-val">—</span><span class="irops-bar-label">Cancellations</span></span>
+            <span class="irops-bar-sep">│</span>
+            <span class="irops-bar-item"><span class="irops-bar-val">—</span><span class="irops-bar-label">&gt;30m</span></span>
+            <span class="irops-bar-sep">│</span>
+            <span class="irops-bar-item"><span class="irops-bar-val">—</span><span class="irops-bar-label">&gt;60m</span></span>
+            <span class="irops-bar-sep">│</span>
+            <span class="irops-bar-item"><span class="irops-bar-val">—</span><span class="irops-bar-label">Diversions</span></span>
+            <span class="irops-bar-sep">│</span>
+            <span class="irops-bar-item"><span class="irops-bar-val">—</span><span class="irops-bar-label">Total Flights</span></span>
+          </div>
+        </div>
       </div>
       <div class="wx-panel-divider" id="wx-scroll-hint">
         <span>Hub Stations</span>
         <span class="scroll-hint-arrow">↓</span>
       </div>
       <div class="hub-cards" id="hub-cards"></div>
-      <div id="irops-worst-flights"></div>
     </div>
   </div>
 </div>

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -3985,7 +3985,7 @@ function updateIrops() {
   }
 
   if (allSchedFlts.length === 0) {
-    content.innerHTML = '<div class="irops-empty">Load schedule data from the Schedule tab to see IROPS metrics<br><button class="retry-btn" style="margin-top:8px" data-action="irops-load">📅 Load Schedule Data</button></div>';
+    content.innerHTML = '<div class="irops-bar"><span class="irops-bar-item"><span class="irops-bar-val" style="color:var(--ua-muted)">—</span><span class="irops-bar-label">Loading schedule data…</span></span></div>';
     return;
   }
 
@@ -4024,17 +4024,23 @@ function updateIrops() {
   worstDelays.sort((a, b) => b.delay - a.delay);
   const top5 = worstDelays.slice(0, 5);
 
-  let html = '<div class="irops-compact">';
-  html += `<div class="irops-compact-header"><span class="irops-score ${scoreCls}">${score}</span><span class="irops-compact-label">${scoreLabel}</span></div>`;
-  html += '<div class="irops-compact-metrics">';
-  html += `<span><b style="color:#f59e0b">${delayed30}</b> &gt;30m</span>`;
-  html += `<span><b style="color:#ef4444">${delayed60}</b> &gt;60m</span>`;
-  html += `<span><b style="color:#c026d3">${diversions}</b> div</span>`;
-  if (groundStops) html += `<span><b style="color:#ef4444">${groundStops}</b> GS</span>`;
-  html += `<span><b style="color:var(--ua-accent)">${totalFlights}</b> flights</span>`;
+  // NOTE: All values here are computed numbers/strings from internal schedule data,
+  // not user input. FAA alerts use escapeHtml() below.
+  let html = '<div class="irops-bar">';
+  html += `<span class="irops-bar-item"><span class="irops-score ${scoreCls}" style="font-size:12px;padding:2px 8px">${score}</span><span class="irops-bar-label">${scoreLabel}</span></span>`;
+  html += '<span class="irops-bar-sep">│</span>';
+  html += `<span class="irops-bar-item"><span class="irops-bar-val" style="color:#ef4444">${cancellations}</span><span class="irops-bar-label">Cancellations</span></span>`;
+  html += '<span class="irops-bar-sep">│</span>';
+  html += `<span class="irops-bar-item"><span class="irops-bar-val" style="color:#f59e0b">${delayed30}</span><span class="irops-bar-label">&gt;30m</span></span>`;
+  html += '<span class="irops-bar-sep">│</span>';
+  html += `<span class="irops-bar-item"><span class="irops-bar-val" style="color:#ef4444">${delayed60}</span><span class="irops-bar-label">&gt;60m</span></span>`;
+  html += '<span class="irops-bar-sep">│</span>';
+  html += `<span class="irops-bar-item"><span class="irops-bar-val" style="color:#c026d3">${diversions}</span><span class="irops-bar-label">Diversions</span></span>`;
+  html += '<span class="irops-bar-sep">│</span>';
+  html += `<span class="irops-bar-item"><span class="irops-bar-val" style="color:var(--ua-blue)">${totalFlights}</span><span class="irops-bar-label">Total Flights</span></span>`;
   html += '</div>';
 
-  // FAA alerts
+  // FAA alerts — separate line below bar (escapeHtml for safety)
   const faaAlerts = [];
   for (const [apt, data] of Object.entries(faaDelayIndex)) {
     if (data.delays && data.delays.length > 0) {
@@ -4042,21 +4048,9 @@ function updateIrops() {
     }
   }
   if (faaAlerts.length) {
-    html += `<div class="irops-compact-faa">${faaAlerts.map(a => escapeHtml(a)).join(' · ')}</div>`;
+    html += `<div class="irops-bar-faa">${faaAlerts.map(a => escapeHtml(a)).join(' · ')}</div>`;
   }
-  html += '</div>';
   content.innerHTML = html;
-
-  // Most disrupted flights — bottom of detail panel
-  const worstEl = document.getElementById('irops-worst-flights');
-  if (worstEl && top5.length) {
-    let wh = '<div class="irops-worst"><h4>Most Disrupted Flights</h4>';
-    top5.forEach(f => {
-      wh += `<div class="irops-worst-row"><span style="color:var(--ua-accent);font-weight:600">${escapeHtml(f.ident)} <span style="color:var(--ua-muted);font-weight:400">${escapeHtml(f.route)}</span></span><span style="color:#ef4444;font-weight:700">+${f.delay}m</span></div>`;
-    });
-    wh += '</div>';
-    worstEl.innerHTML = wh;
-  }
 }
 
 function autoLoadIrops() {
@@ -4074,7 +4068,7 @@ function fetchIropsFromAPI() {
 }
 async function _doFetchIropsFromAPI() {
   const content = document.getElementById('irops-content');
-  if (content) content.innerHTML = '<div class="irops-empty" style="color:var(--ua-muted);font-size:10px">Loading IROPS data…</div>';
+  // Keep the default bar with — placeholders during load (already in HTML)
   try {
     const resp = await fetch('/api/irops');
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
@@ -4082,7 +4076,7 @@ async function _doFetchIropsFromAPI() {
     renderIropsFromAPI(data);
   } catch (e) {
     console.error('IROPS API failed, falling back to manual:', e);
-    if (content) content.innerHTML = '<div class="irops-empty">Load schedule data from the Schedule tab to see IROPS metrics<br><button class="retry-btn" style="margin-top:8px" data-action="irops-load">📅 Load Schedule Data</button></div>';
+    if (content) content.innerHTML = '<div class="irops-bar"><span class="irops-bar-item"><span class="irops-bar-val" style="color:var(--ua-muted)">—</span><span class="irops-bar-label">IROPS unavailable</span></span></div>';
   }
 }
 
@@ -4122,29 +4116,20 @@ function renderIropsFromAPI(data) {
   const scoreCls = score < 5 ? 'low' : score < 15 ? 'med' : 'high';
   const scoreLabel = score < 5 ? 'Normal Ops' : score < 15 ? 'Minor Disruptions' : 'Significant IROPS';
 
-  let html = `<div style="margin-bottom:10px"><span class="irops-score ${scoreCls}">${score}</span> <span style="font-size:10px;color:var(--ua-muted)">${scoreLabel} · Disruption Score</span></div>`;
-  html += '<div class="irops-metrics">';
-  html += `<div class="irops-card"><div class="iv" style="color:#ef4444">${data.cancellations || '—'}</div><div class="il">Cancellations<span style="font-size:7px;display:block;color:var(--ua-muted)" title="FR24 schedule data does not reliably include cancelled flights">Limited data</span></div></div>`;
-  html += `<div class="irops-card"><div class="iv" style="color:#f59e0b">${data.delayed30}</div><div class="il">Delayed &gt;30m</div></div>`;
-  html += `<div class="irops-card"><div class="iv" style="color:#ef4444">${data.delayed60}</div><div class="il">Delayed &gt;60m</div></div>`;
-  html += `<div class="irops-card"><div class="iv" style="color:#c026d3">${data.diversions}</div><div class="il">Diversions</div></div>`;
-  html += `<div class="irops-card"><div class="iv" style="color:var(--ua-blue)">${data.totalFlights}</div><div class="il">Total Flights</div></div>`;
+  // NOTE: All values here are from the IROPS API (internal, not user input).
+  let html = '<div class="irops-bar">';
+  html += `<span class="irops-bar-item"><span class="irops-score ${scoreCls}" style="font-size:12px;padding:2px 8px">${score}</span><span class="irops-bar-label">${scoreLabel}</span></span>`;
+  html += '<span class="irops-bar-sep">│</span>';
+  html += `<span class="irops-bar-item"><span class="irops-bar-val" style="color:#ef4444">${data.cancellations || '—'}</span><span class="irops-bar-label">Cancellations</span></span>`;
+  html += '<span class="irops-bar-sep">│</span>';
+  html += `<span class="irops-bar-item"><span class="irops-bar-val" style="color:#f59e0b">${data.delayed30}</span><span class="irops-bar-label">&gt;30m</span></span>`;
+  html += '<span class="irops-bar-sep">│</span>';
+  html += `<span class="irops-bar-item"><span class="irops-bar-val" style="color:#ef4444">${data.delayed60}</span><span class="irops-bar-label">&gt;60m</span></span>`;
+  html += '<span class="irops-bar-sep">│</span>';
+  html += `<span class="irops-bar-item"><span class="irops-bar-val" style="color:#c026d3">${data.diversions}</span><span class="irops-bar-label">Diversions</span></span>`;
+  html += '<span class="irops-bar-sep">│</span>';
+  html += `<span class="irops-bar-item"><span class="irops-bar-val" style="color:var(--ua-blue)">${data.totalFlights}</span><span class="irops-bar-label">Total Flights</span></span>`;
   html += '</div>';
-
-  // Worst delays
-  if (data.worstDelays && data.worstDelays.length) {
-    html += '<div class="irops-worst"><h4>Most Disrupted Flights</h4>';
-    data.worstDelays.forEach(f => {
-      html += `<div class="irops-worst-row"><span style="color:var(--ua-accent);font-weight:600">${escapeHtml(f.ident)} <span style="color:var(--ua-muted);font-weight:400">${escapeHtml(f.route)}</span></span><span style="color:#ef4444;font-weight:700">+${f.delay}m</span></div>`;
-    });
-    html += '</div>';
-  }
-
-  // Timestamp
-  if (data.generatedAt) {
-    const ago = Math.round((Date.now() - new Date(data.generatedAt).getTime()) / 60000);
-    html += `<div style="text-align:right;font-size:8px;color:var(--ua-muted);margin-top:8px">${ago < 1 ? 'Just now' : ago + 'm ago'}${data.cached ? ' · cached' : ''}</div>`;
-  }
 
   content.innerHTML = html;
 }


### PR DESCRIPTION
This restores the weather tab IROPS panel to a thin stats bar instead of the taller side-panel treatment. It updates the HTML and dashboard rendering logic to use compact loading, unavailable, and loaded bar states, removes the separate worst-flights block, and keeps FAA alerts on a compact second line. It also refreshes the matching desktop/mobile CSS so the bar wraps cleanly on desktop and scrolls as pills on mobile, with a subtle fade at the bottom of the hub list. Validation: npm run build:dashboard; npm test.