### PR TITLE
docs: update README and CHANGELOG for v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,24 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versio
 ## [1.4.0] - 2026-03-19
 
 ### Added
-- United Airlines News Hub (`/news`) with curated article pages, SEO-optimized with NewsArticle structured data, BreadcrumbList schema, and OG/Twitter meta tags
-- Individual article pages (`/news/[slug]`) with source links, cross-links to related hub/fleet pages via tags, donation CTA, and Pro waitlist teaser
-- Google News sitemap (`/news-sitemap.xml`) for Google News indexing eligibility
-- Dynamic RSS feed (`/feed.xml`) now includes news articles with publication dates — replaces static feed
-- "Latest News" banner on dashboard (between header and tab bar) — dismissible, persists per-article via localStorage, tracks clicks via Vercel Analytics
-- Email digest endpoint (`/api/news-notify`) using Resend Broadcasts API — idempotent, auth-gated, tracks last-sent slug in Supabase
-- Shared `Footer.astro` component — extracted from hub and fleet layouts to eliminate DRY violation
+- **News Hub** (`/news`) — browse curated United Airlines articles with SEO-optimized pages, NewsArticle structured data, and OG/Twitter previews
+- **Individual article pages** (`/news/[slug]`) — each article links to its source, cross-links to related hub and fleet pages, and includes a donation CTA
+- **Google News sitemap** (`/news-sitemap.xml`) — makes articles eligible for Google News indexing
+- **Dynamic RSS feed** (`/feed.xml`) — now includes news articles with publication dates (replaces the old static feed)
+- **"Latest News" banner** on the dashboard — a dismissible banner between header and tab bar highlights the newest article, with per-article persistence via localStorage
+- **Email news digest** — waitlist subscribers receive a Resend-powered email when new articles are published, with idempotent delivery tracking
+- Dashboard navigation now includes a "News" link
+
+### For contributors
+- Shared `Footer.astro` component extracted from hub and fleet layouts
 - `DESIGN.md` — formalized design system (color tokens, typography, layout, components, accessibility)
-- `TODOS.md` — deferred work tracking (auto-curated news aggregation)
-- News data validation at build time (slug format, required fields, duplicate detection, https-only sources)
-- Tag resolver for cross-linking articles to hub and fleet pages with build-time warnings for unknown tags
+- News data validated at build time (slug format, required fields, duplicate detection, HTTPS-only sources)
+- Tag resolver cross-links articles to hub and fleet pages with build-time warnings for unknown tags
 - 20 new tests: 11 for news data model + tag resolver, 9 for news-notify endpoint (auth, idempotency, broadcast API)
 
 ### Changed
 - Sitemap now includes `/news` index and all article pages
 - `llms.txt` and `llms-full.txt` updated with news hub documentation
-- Dashboard brand strip includes "News" link
 - `vercel.json` adds cache headers for `/news/*` and function config for `news-notify`
 - `buildMetadata.js` extended with news lastmod path helpers
 
@@ -297,6 +298,15 @@ Initial public launch.
 - JSON-LD structured data, Open Graph metadata
 - Vercel hosting with edge caching
 
+[1.4.0]: https://github.com/notjbg/the-blue-board/compare/v1.3.8...v1.4.0
+[1.3.8]: https://github.com/notjbg/the-blue-board/compare/v1.3.7...v1.3.8
+[1.3.7]: https://github.com/notjbg/the-blue-board/compare/v1.3.6...v1.3.7
+[1.3.6]: https://github.com/notjbg/the-blue-board/compare/v1.3.5...v1.3.6
+[1.3.5]: https://github.com/notjbg/the-blue-board/compare/v1.3.4...v1.3.5
+[1.3.4]: https://github.com/notjbg/the-blue-board/compare/v1.3.3...v1.3.4
+[1.3.3]: https://github.com/notjbg/the-blue-board/compare/v1.3.2...v1.3.3
+[1.3.2]: https://github.com/notjbg/the-blue-board/compare/v1.3.1...v1.3.2
+[1.3.1]: https://github.com/notjbg/the-blue-board/compare/v1.3...v1.3.1
 [1.3]: https://github.com/notjbg/the-blue-board/compare/v1.2...v1.3
 [1.2]: https://github.com/notjbg/the-blue-board/compare/v1.1.1...v1.2
 [1.1.1]: https://github.com/notjbg/the-blue-board/compare/v1.1...v1.1.1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **An unofficial, real-time operations dashboard for United Airlines — built by flyers, for flyers.**
 
-**[→ Live Dashboard](https://theblueboard.co)** · **[📋 Changelog](CHANGELOG.md)** · **[☕ Support the Project](https://buymeacoffee.com/notjbg)** · **[💡 Suggest a Feature](https://github.com/notjbg/the-blue-board/issues)** · **[𝕏 Follow @theblueboard](https://x.com/theblueboard)**
+**[→ Live Dashboard](https://theblueboard.co)** · **[📋 Changelog](CHANGELOG.md)** · **[🎨 Design System](DESIGN.md)** · **[☕ Support the Project](https://buymeacoffee.com/notjbg)** · **[💡 Suggest a Feature](https://github.com/notjbg/the-blue-board/issues)** · **[𝕏 Follow @theblueboard](https://x.com/theblueboard)**
 
 ![The Blue Board — Live Operations Map](public/og-image.png)
 
@@ -28,7 +28,7 @@ Server-side disruption scoring across all 9 hubs — cancellations, delays (30m/
 Departure and arrival boards for all 9 UA hubs (ORD, DEN, IAH, EWR, SFO, IAD, LAX, NRT, GUM). Filter by status or aircraft type. Equipment swap detection flags when a plane type changes. On-time performance stats. All times in airport-local timezone.
 
 ### ✈️ [Fleet](https://theblueboard.co#fleet)
-Complete database of 1,078+ mainline aircraft — searchable and sortable by type, registration, seat config, WiFi, and IFE. Starlink tracker for 258+ equipped aircraft with sortable columns and filters by fleet, type, and operator. Live fleet status correlates airborne flights with the database.
+Complete database of 1,078+ mainline aircraft — searchable and sortable by type, registration, seat config, WiFi, and IFE. Starlink tracker for 258+ equipped aircraft with sortable columns and filters by fleet, type, and operator. Live fleet status correlates airborne flights with the database. **19 dedicated fleet type pages** ([737 MAX 9](https://theblueboard.co/fleet/737-max-9), [A321neo](https://theblueboard.co/fleet/a321neo), [787-9](https://theblueboard.co/fleet/787-9-dreamliner), etc.) with full aircraft registries, structured data, and cross-type navigation.
 
 ### 🌦 [Delays · Weather · Hubs](https://theblueboard.co#weather)
 FAA NAS delay and ground stop alerts, METAR observations with plain-English explainers, NEXRAD radar overlay, and hub health indicators. Each hub gets a unified card with conditions, visibility, wind, ceiling, and current delay status. **Ops Impact Assessment** goes beyond standard flight categories to flag real operational risks — snow, gusts, freezing precipitation, thunderstorms — even when conditions are technically VFR. Radar map renders instantly; weather data loads in parallel via batched API calls.
@@ -41,6 +41,9 @@ Look up any UA flight number from the header search bar. Returns live position, 
 
 ### 🏢 [Hub Pages](https://theblueboard.co/hubs/ord)
 Dedicated SEO-rich pages for each of United's 9 hubs ([ORD](https://theblueboard.co/hubs/ord) · [DEN](https://theblueboard.co/hubs/den) · [IAH](https://theblueboard.co/hubs/iah) · [EWR](https://theblueboard.co/hubs/ewr) · [SFO](https://theblueboard.co/hubs/sfo) · [IAD](https://theblueboard.co/hubs/iad) · [LAX](https://theblueboard.co/hubs/lax) · [NRT](https://theblueboard.co/hubs/nrt) · [GUM](https://theblueboard.co/hubs/gum)). Each page includes live flight counts, hub overview with terminal/concourse details, United Club and Polaris lounge locations, delay pattern analysis by season, Starlink WiFi info, construction alerts with links to official project pages, structured FAQ, and FAQPage + Airport schema markup for search engines. Jump navigation and scroll hints guide visitors through the content.
+
+### 📰 [News](https://theblueboard.co/news)
+Curated United Airlines news hub with individual article pages, source links, and cross-links to related hub and fleet pages via tags. Google News sitemap and dynamic RSS feed for indexing. "Latest News" banner on the dashboard links to the newest article. Optional email digest via Resend Broadcasts notifies waitlist subscribers of new articles.
 
 ### More
 - **AI delay risk scoring** — 8-signal algorithm considers weather, FAA programs, hub OTP, inbound aircraft, time-of-day cascade risk, and hub-specific profiles
@@ -73,18 +76,31 @@ Dedicated SEO-rich pages for each of United's 9 hubs ([ORD](https://theblueboard
     ┌──────────▼──────────────────────────────┐
     │        Vercel Serverless Functions       │
     │                                          │
-    │  /api/schedule    — FR24 schedule proxy  │
-    │                     (cached, rate-limited│
-    │                      UA-filtered)        │
-    │  /api/irops      — Precomputed IROPS   │
-    │                     metrics (5min cache)  │
-    │  /api/fr24-feed   — Live flight positions│
-    │  /api/fr24-flight — Flight lookup        │
-    │                     (official FR24 API)  │
-    │  /api/metar       — AWC weather proxy    │
-    │                     (batched, all hubs)   │
-    │  /api/faa         — FAA NAS status proxy │
-    │  /api/fleet       — Fleet data proxy     │
+    │  /api/schedule      — FR24 schedule proxy│
+    │                       (cached, rate-     │
+    │                        limited, filtered)│
+    │  /api/irops         — Precomputed IROPS  │
+    │                       metrics (5min cache)│
+    │  /api/fr24-feed     — Live flight feed   │
+    │  /api/fr24-flight   — Flight lookup      │
+    │  /api/delay-explain — AI delay briefings │
+    │                       (Claude, cached)   │
+    │  /api/metar         — AWC weather proxy  │
+    │  /api/faa           — FAA NAS status     │
+    │  /api/fleet         — Fleet data proxy   │
+    │  /api/waitlist      — Waitlist signup     │
+    │  /api/news-notify   — Email digest       │
+    │  /api/fr24-usage    — FR24 credit monitor│
+    │                                          │
+    │  Cron jobs (vercel.json):                │
+    │  /api/cron/warm-schedules  — every 15min │
+    │  /api/cron/sync-starlink   — every 4hrs  │
+    └──────────┬──────────────────────────────┘
+               │
+    ┌──────────▼──────────────────────────────┐
+    │           Supabase (Postgres)            │
+    │  waitlist · schedule_snapshots           │
+    │  news_notifications · RLS policies       │
     └─────────────────────────────────────────┘
 ```
 
@@ -108,29 +124,38 @@ Dedicated SEO-rich pages for each of United's 9 hubs ([ORD](https://theblueboard
 | [United Fleet Site](https://sites.google.com/site/unitedfleetsite/) | Fleet database | Daily | Community-maintained |
 | [Starlink Tracker](https://unitedstarlinktracker.com) | WiFi-equipped aircraft | Daily | [@martinamps](https://github.com/martinamps/ua-starlink-tracker) |
 | [Iowa State NEXRAD](https://mesonet.agron.iastate.edu) | Radar imagery | ~5min | Direct tile server |
+| [Supabase](https://supabase.com) | Waitlist, schedule snapshots, notifications | Real-time | Postgres with RLS |
+| [Anthropic Claude](https://anthropic.com) | AI delay explanations | On-demand | Haiku model, cached 5min |
+| [Resend](https://resend.com) | Email delivery | On-demand | Welcome emails, news digests |
 
 ---
 
 ## Tech Stack
 
-- **Frontend:** Vanilla HTML/CSS/JS — single-file dashboard, Astro-templated hub pages
+- **Frontend:** Vanilla HTML/CSS/JS — single-file dashboard, Astro-templated content pages
 - **Map:** [Leaflet](https://leafletjs.com) + CartoDB dark tiles
 - **Radar:** Iowa State NEXRAD WMS tiles
-- **Font:** [JetBrains Mono](https://www.jetbrains.com/lp/mono/)
-- **Build:** [Astro](https://astro.build) (static site generator for hub pages)
+- **Fonts:** [Inter](https://rsms.me/inter/) (UI) + [JetBrains Mono](https://www.jetbrains.com/lp/mono/) (data) — self-hosted WOFF2
+- **Build:** [Astro](https://astro.build) (static pages) + [Vite](https://vite.dev) (dashboard bundle)
 - **Hosting:** [Vercel](https://vercel.com) (serverless functions + edge CDN)
+- **Database:** [Supabase](https://supabase.com) (waitlist, schedule snapshots, news notifications)
+- **Email:** [Resend](https://resend.com) (waitlist welcome emails, news digest broadcasts)
+- **AI:** [Anthropic Claude](https://anthropic.com) (delay risk explanations)
+- **Testing:** [Vitest](https://vitest.dev) + [Playwright](https://playwright.dev)
 - **Analytics:** Vercel Web Analytics + Speed Insights
-- **Design:** Dark NOC theme, inspired by Bloomberg terminals and airline ops centers
+- **Design:** Dark NOC theme, inspired by Bloomberg terminals and airline ops centers ([design system](DESIGN.md))
 
 ---
 
 ## Security
 
 - **Content Security Policy** — Strict CSP via Vercel headers with `default-src 'self'`, `frame-ancestors 'none'`, and scoped source directives
-- **Security headers** — `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `Permissions-Policy`
+- **Security headers** — `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `Permissions-Policy`, `Strict-Transport-Security` (HSTS with preload)
 - **XSS protection** — All dynamic API data is HTML-escaped before DOM insertion (including single quotes). Zero inline event handlers — all interaction via delegated `data-action` attributes.
 - **CORS** — API endpoints locked to `theblueboard.co` origin
 - **Input validation** — All API parameters validated and sanitized server-side
+- **Row-level security** — Supabase RLS policies on all user-facing tables
+- **Prompt injection protection** — AI delay-explain endpoint sanitizes input before passing to Claude
 - **Tabnabbing protection** — All external links use `rel="noopener noreferrer"`
 
 ---
@@ -139,34 +164,65 @@ Dedicated SEO-rich pages for each of United's 9 hubs ([ORD](https://theblueboard
 
 ```
 ├── src/
+│   ├── components/
+│   │   └── Footer.astro          # Shared footer (disclaimer, sources, donation CTA)
+│   ├── dashboard/
+│   │   └── main.js               # Dashboard SPA entry point (Vite-bundled)
 │   ├── layouts/
-│   │   └── HubLayout.astro  # Shared hub page template (CSS, footer, live script)
+│   │   ├── HubLayout.astro       # Shared hub page template
+│   │   ├── FleetTypeLayout.astro # Fleet type page template
+│   │   └── NewsLayout.astro      # News article page template
+│   ├── lib/
+│   │   ├── delay-risk.js         # 8-signal delay risk scoring engine
+│   │   ├── metar.js              # METAR parsing and weather classification
+│   │   └── buildMetadata.js      # SEO metadata helpers (lastmod, sitemap)
 │   ├── pages/
-│   │   ├── 404.astro        # Branded "Flight not found" 404 page
-│   │   └── hubs/
-│   │       └── [hub].astro  # Dynamic route → generates all 9 hub pages
+│   │   ├── 404.astro             # Branded "Flight not found" 404 page
+│   │   ├── sitemap.xml.ts        # Dynamic sitemap (all pages)
+│   │   ├── feed.xml.ts           # Dynamic RSS feed (news + updates)
+│   │   ├── news-sitemap.xml.ts   # Google News sitemap
+│   │   ├── hubs/
+│   │   │   └── [hub].astro       # Dynamic route → 9 hub pages
+│   │   ├── fleet/
+│   │   │   ├── index.astro       # Fleet overview (all 19 types)
+│   │   │   └── [type].astro      # Dynamic route → 19 fleet type pages
+│   │   └── news/
+│   │       ├── index.astro       # News hub index
+│   │       └── [slug].astro      # Dynamic route → individual articles
 │   └── data/
-│       └── hubs.js          # Hub metadata, content, SEO, schemas (all 9 hubs)
+│       ├── hubs.js               # Hub metadata (all 9 hubs)
+│       ├── fleet/                 # Fleet type data (19 aircraft types)
+│       └── news/                  # News article data
 ├── public/
-│   ├── index.html       # The entire dashboard (single file)
-│   ├── data/
-│   │   ├── fleet.json   # Fleet database
-│   │   └── starlink.json # Starlink-equipped aircraft
-│   ├── og-image.png     # Social media preview image (1200×630)
-│   ├── manifest.json    # PWA manifest
-│   ├── sw.js            # Service worker (split caches, offline support)
-│   ├── icons/           # PWA app icons (192px, 512px)
-│   ├── robots.txt       # Search engine directives (blocks /api/ and /data/ from crawlers)
-│   └── sitemap.xml      # Sitemap (homepage + all hub pages)
+│   ├── index.html                # The entire dashboard (single file)
+│   ├── css/style.css             # Extracted dashboard styles
+│   ├── fonts/                    # Self-hosted Inter + JetBrains Mono (WOFF2)
+│   ├── data/                     # Fleet + Starlink JSON databases
+│   ├── og-image.png              # Social media preview image (1200×630)
+│   ├── manifest.json             # PWA manifest
+│   ├── sw.js                     # Service worker (split caches, offline support)
+│   ├── icons/                    # PWA app icons (192px, 512px)
+│   └── robots.txt                # Search engine directives
 ├── api/
-│   ├── schedule.js      # FR24 schedule proxy (cached, rate-limited, UA-filtered)
-│   ├── irops.js        # Server-side IROPS aggregation (all hubs, 5min cache)
-│   ├── fr24-feed.js     # FR24 live flight feed proxy
-│   ├── fr24-flight.js   # FR24 official API flight lookup
-│   ├── metar.js         # AWC METAR weather proxy (supports batched station IDs)
-│   ├── faa.js           # FAA NAS status proxy (XML → JSON)
-│   └── fleet.js         # Fleet data proxy
-└── vercel.json          # Vercel config + security headers + CSP + caching
+│   ├── schedule.ts               # FR24 schedule proxy (cached, rate-limited)
+│   ├── irops.ts                  # Server-side IROPS aggregation (5min cache)
+│   ├── fr24-feed.ts              # Live flight feed proxy
+│   ├── fr24-flight.ts            # FR24 official API flight lookup
+│   ├── delay-explain.ts          # AI delay explanations (Claude)
+│   ├── metar.ts                  # AWC METAR weather proxy (batched)
+│   ├── faa.ts                    # FAA NAS status proxy (XML → JSON)
+│   ├── fleet.ts                  # Fleet data proxy
+│   ├── waitlist.ts               # Waitlist signup + welcome email
+│   ├── news-notify.ts            # News digest email broadcasts
+│   ├── fr24-usage.ts             # FR24 credit usage monitor
+│   ├── cron/warm-schedules.ts    # Schedule cache warming (every 15min)
+│   └── cron/sync-starlink.ts     # Starlink data sync (every 4hrs)
+├── sql/                          # Supabase migration files
+├── scripts/                      # Build + seed scripts
+├── tests/                        # Vitest test suite
+├── DESIGN.md                     # Design system documentation
+├── CHANGELOG.md                  # Release history
+└── vercel.json                   # Vercel config + headers + CSP + crons
 ```
 
 ---
@@ -187,7 +243,7 @@ Every donation helps cover server costs and keeps the dashboard free for everyon
 
 Got an idea? Found a bug? **[Open an issue →](https://github.com/notjbg/the-blue-board/issues)**
 
-The community drives this project. Some of the best features came from user suggestions on Reddit and FlyerTalk. PRs welcome too — it's a single HTML file, so the barrier to entry is low.
+The community drives this project. Some of the best features came from user suggestions on Reddit and FlyerTalk. PRs welcome too — the dashboard is a single HTML file, and content pages are Astro templates, so the barrier to entry is low.
 
 **Follow [@theblueboard](https://x.com/theblueboard) on X** for updates, new features, and release notes.
 


### PR DESCRIPTION
## Summary

Post-ship documentation update aligning README, CHANGELOG, and DESIGN.md with v1.4.0 release.

**README:** Added News Hub and Fleet Type Pages feature highlights, updated Architecture diagram with new API endpoints and Supabase integration, refreshed Tech Stack section to include Supabase, Resend, Claude AI, Vite, and Vitest, expanded Data Sources table with new services, enhanced Security section with HSTS and RLS details, and completely rewrote Project Structure tree with accurate file extensions, new layouts, and current directory organization.

**CHANGELOG:** Polished v1.4.0 entry voice (user-forward language, bold feature names), separated contributor items into dedicated subsection, removed phantom TODOS.md reference, and added all missing version comparison links (v1.3.1–v1.4.0).

All documentation is now current and consistent with v1.4.0 release.

🤖 Generated with Claude Code