### PR TITLE
feat: redesign Fleet tab with 3-zone layout and family grouping

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -205,11 +205,6 @@ main{flex:1;min-height:0;display:flex;flex-direction:column;overflow:hidden}
 #tab-fleet{padding:16px;flex:1;min-height:0;overflow-y:auto}
 .card{background:var(--ua-panel);border:1px solid var(--ua-border);border-radius:6px;padding:14px;margin-bottom:14px}
 .card h3{font-size:11px;color:var(--ua-blue);text-transform:uppercase;letter-spacing:1px;margin-bottom:10px}
-.fleet-chips{display:grid;grid-template-columns:repeat(auto-fill,minmax(120px,1fr));gap:6px;margin-bottom:14px}
-.fleet-chip{background:rgba(15,23,41,.8);border:1px solid var(--ua-border);border-radius:6px;padding:8px;text-align:center;cursor:pointer;transition:border-color .2s cubic-bezier(.4,0,.2,1),background-color .2s cubic-bezier(.4,0,.2,1)}
-.fleet-chip:hover,.fleet-chip.active{border-color:var(--ua-blue);background:rgba(0,93,170,.1)}
-.fleet-chip .count{font-size:20px;font-weight:700;color:var(--ua-blue)}
-.fleet-chip .label{font-size:9px;color:var(--ua-muted);margin-top:1px}
 .two-col{display:grid;grid-template-columns:1fr 1fr;gap:14px}
 @media(max-width:900px){.two-col{grid-template-columns:1fr}}
 .fleet-controls{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:10px;align-items:center}
@@ -237,13 +232,116 @@ tbody td{padding:5px 8px;white-space:nowrap}
 .refresh-btn{background:var(--ua-blue);color:#fff;border:none;padding:6px 14px;border-radius:4px;cursor:pointer;font-family:var(--font-ui);font-size:10px;font-weight:600;transition:background-color .2s cubic-bezier(.4,0,.2,1),transform .15s cubic-bezier(.4,0,.2,1)}
 .refresh-btn:hover{background:#0070cc}
 
+/* ═══ ZONE 1: FLEET PULSE ═══ */
+.fleet-pulse-zone{background:var(--ua-panel);border:1px solid var(--ua-border);border-radius:6px;padding:14px;margin-bottom:14px;position:relative;flex-shrink:0}
+.fleet-pulse-shimmer{position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--ua-green),var(--ua-blue),var(--ua-green));background-size:200% 100%;animation:liveShimmer 2s linear infinite;z-index:1;border-radius:6px 6px 0 0}
+.fleet-pulse-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:12px}
+.fleet-pulse-title{font-size:10px;color:var(--ua-blue);text-transform:uppercase;letter-spacing:1.5px;margin:0}
+.fleet-pulse-badges{display:flex;align-items:center;gap:8px}
+.fleet-pulse-time{font-size:9px;color:var(--ua-muted)}
+.fleet-pulse-panels{display:flex;gap:20px}
+.fleet-pulse-left{flex:1;min-width:0}
+.fleet-pulse-right{flex:1;min-width:0;border-left:1px solid var(--ua-border);padding-left:20px}
+.fleet-pulse-hero{display:flex;align-items:center;gap:10px;margin-bottom:6px}
+.fleet-pulse-airborne-count{font-size:36px;font-weight:700;color:var(--ua-blue);line-height:1;font-family:var(--font-mono)}
+.fleet-pulse-airborne-label{font-size:10px;color:var(--ua-muted);text-transform:uppercase;letter-spacing:1px}
+.fleet-pulse-subtitle{font-size:10px;color:var(--ua-muted);margin-bottom:8px}
+.fleet-pulse-util{font-size:10px;color:var(--ua-green);margin-bottom:10px;font-weight:600}
+.fleet-type-utilization{display:flex;flex-direction:column;gap:3px}
+.type-util-row{display:flex;align-items:center;gap:6px;font-size:10px}
+.type-util-label{color:var(--ua-muted);min-width:70px;text-align:right;font-family:var(--font-mono);font-size:9px}
+.type-util-track{flex:1;height:6px;background:var(--ua-border);border-radius:3px;overflow:hidden}
+.type-util-fill{height:100%;background:var(--ua-green);border-radius:3px;transition:width .5s}
+.type-util-count{color:var(--ua-accent);min-width:55px;font-family:var(--font-mono);font-size:9px;font-weight:600}
+.fleet-loading-text{color:var(--ua-muted);font-size:11px;padding:20px 0;text-align:center}
+
 /* Fleet Health Dashboard */
 .fleet-health-bar{display:flex;align-items:center;gap:8px;margin-bottom:6px}
 .fleet-health-bar .fh-label{font-size:10px;color:var(--ua-muted);min-width:110px;text-align:right;font-family:var(--font-ui)}
-.fleet-health-bar .fh-track{flex:1;height:16px;background:rgba(15,23,41,.8);border-radius:3px;overflow:hidden}
+.fleet-health-bar .fh-track{flex:1;height:14px;background:rgba(15,23,41,.8);border-radius:3px;overflow:hidden}
 .fleet-health-bar .fh-fill{height:100%;border-radius:3px;transition:width .5s}
 .fleet-health-bar .fh-count{font-size:10px;color:var(--ua-accent);font-weight:700;min-width:70px;text-align:right;font-family:var(--font-mono)}
 .fh-legend-dot{display:inline-block;width:8px;height:8px;border-radius:2px;margin-right:4px;vertical-align:middle}
+.fleet-health-summary{display:flex;align-items:center;gap:16px;margin-bottom:14px}
+.fleet-starlink-progress{display:flex;align-items:center;gap:10px;margin-top:14px;padding-top:10px;border-top:1px solid var(--ua-border)}
+.fleet-starlink-track{flex:1;height:4px;background:var(--ua-border);border-radius:2px;overflow:hidden}
+.fleet-starlink-fill{height:100%;background:var(--ua-green);border-radius:2px;transition:width .5s}
+.fleet-starlink-pct{font-size:10px;color:var(--ua-green);font-weight:700;font-family:var(--font-mono)}
+.fleet-starlink-label{font-size:9px;color:var(--ua-muted)}
+.fleet-starlink-stats{display:flex;gap:8px;flex-wrap:wrap;margin-top:10px}
+.fleet-starlink-stats:empty{display:none}
+.fleet-starlink-chip{display:inline-flex;flex-direction:column;align-items:center;padding:6px 12px;border-radius:4px;font-size:10px}
+.fleet-starlink-source{font-size:10px;color:var(--ua-muted);padding:8px 0;text-align:center}
+.fleet-starlink-updated{color:var(--ua-green)}
+.fleet-source-link{color:var(--ua-green);text-decoration:none}
+.fleet-source-link:hover{text-decoration:underline}
+
+/* ═══ ZONE 2: FLEET COMPOSITION ═══ */
+.fleet-composition-zone{margin-bottom:14px}
+.zone-title{font-size:11px;color:var(--ua-blue);text-transform:uppercase;letter-spacing:1.5px;margin-bottom:14px}
+.fleet-families{margin-bottom:14px}
+.fleet-family{margin-bottom:16px}
+.fleet-family[role="group"]{outline:none}
+.fleet-family-header{display:flex;align-items:center;gap:10px;margin-bottom:8px;border-bottom:1px solid var(--ua-border);padding-bottom:6px}
+.fleet-family-name{font-size:11px;text-transform:uppercase;letter-spacing:1.5px;color:var(--ua-blue);font-weight:700}
+.fleet-family-count{font-size:11px;color:var(--ua-accent);font-family:var(--font-mono);font-weight:700}
+.fleet-family-role{font-size:9px;color:var(--ua-muted);margin-left:auto;font-style:italic}
+.fleet-family-route{font-size:9px;color:var(--ua-muted);font-style:italic;margin-top:2px;margin-bottom:6px}
+.fleet-family-body{display:flex;flex-wrap:wrap;gap:6px;align-items:flex-start}
+.fleet-subgroup{display:flex;align-items:flex-start;gap:6px}
+.fleet-subgroup-label{font-size:8px;color:var(--ua-muted);text-transform:uppercase;letter-spacing:1px;writing-mode:vertical-rl;transform:rotate(180deg);align-self:center;padding:4px 0}
+.fleet-subgroup-cards{display:flex;gap:6px;flex-wrap:wrap}
+.fleet-subgroup-sep{width:1px;background:var(--ua-border);border-style:dotted;border-width:0 0 0 1px;align-self:stretch;margin:0 4px}
+.variant-card{background:rgba(15,23,41,.8);border:1px solid var(--ua-border);border-radius:6px;padding:10px;text-align:center;cursor:pointer;transition:border-color .2s cubic-bezier(.4,0,.2,1),background-color .2s cubic-bezier(.4,0,.2,1);min-width:80px;min-height:44px}
+.variant-card:hover{border-color:var(--ua-blue);background:rgba(0,93,170,.1)}
+.variant-card:focus-visible{outline:2px solid var(--ua-blue);outline-offset:2px}
+.variant-card.active{border-color:var(--ua-blue);background:rgba(0,93,170,.15);border-left:3px solid var(--ua-blue)}
+.variant-count{font-size:20px;font-weight:700;color:var(--ua-blue);font-family:var(--font-mono)}
+.variant-name{font-size:9px;color:var(--ua-muted);text-transform:uppercase;letter-spacing:.5px;margin-top:2px}
+.fleet-widebody-divider{display:flex;align-items:center;gap:12px;margin:16px 0 12px;font-size:9px;color:var(--ua-muted);letter-spacing:2px;text-transform:uppercase}
+.fleet-widebody-divider::before,.fleet-widebody-divider::after{content:'';flex:1;height:1px;background:var(--ua-border)}
+.fleet-age-subtitle{font-size:9px;color:var(--ua-muted);margin-bottom:4px}
+.fleet-age-chart{position:relative}
+.fleet-age-stats{font-size:10px;color:var(--ua-muted);margin-top:6px}
+
+/* Seat Config Empty State */
+.fleet-config-empty{text-align:center;padding:20px 10px;color:var(--ua-muted)}
+.fleet-config-empty-text{font-size:11px;margin-bottom:10px}
+.fleet-config-quick-links{display:flex;gap:8px;justify-content:center;flex-wrap:wrap}
+.fleet-config-quick{font-size:10px;color:var(--ua-accent);cursor:pointer;padding:4px 10px;border:1px solid var(--ua-border);border-radius:3px;font-family:var(--font-mono);transition:border-color .2s,background .2s}
+.fleet-config-quick:hover{border-color:var(--ua-blue);background:rgba(0,93,170,.1)}
+
+/* ═══ ZONE 3: AIRCRAFT LOOKUP ═══ */
+.fleet-lookup-zone{background:var(--ua-panel);border:1px solid var(--ua-border);border-radius:6px;padding:14px;margin-bottom:14px}
+.fleet-lookup-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:12px}
+.fleet-data-source{font-size:10px;color:var(--ua-muted)}
+.fleet-subtab-bar{display:flex;gap:0;border-bottom:1px solid var(--ua-border);margin-bottom:12px;overflow-x:auto;scrollbar-width:none}
+.fleet-subtab-bar::-webkit-scrollbar{display:none}
+.fleet-subtab{background:none;border:none;border-bottom:2px solid transparent;color:var(--ua-muted);font-family:var(--font-ui);font-size:11px;padding:8px 14px;cursor:pointer;transition:color .2s,border-color .2s;white-space:nowrap}
+.fleet-subtab:hover{color:var(--ua-text)}
+.fleet-subtab.active{color:var(--ua-text);border-bottom-color:var(--ua-blue)}
+.fleet-subtab-count{font-family:var(--font-mono);font-size:10px;color:var(--ua-accent);margin-left:4px}
+.fleet-view-panel{display:none}
+.fleet-view-panel.active{display:block}
+.fleet-zero-results{text-align:center;padding:20px;font-size:11px;color:var(--ua-muted)}
+.fleet-clear-filters{background:none;border:1px solid var(--ua-blue);color:var(--ua-blue);padding:4px 12px;border-radius:3px;cursor:pointer;font-family:var(--font-ui);font-size:10px;margin-left:6px;transition:background .2s}
+.fleet-clear-filters:hover{background:rgba(0,93,170,.15)}
+.fleet-filtered-count{font-size:9px;color:var(--ua-muted);align-self:center}
+.fleet-lookup-seat-config{margin-bottom:10px}
+.fleet-lookup-seat-config:empty{display:none}
+
+/* Config Gallery (shared between Zone 2 and Zone 3) */
+.fleet-config-title{font-size:13px;font-weight:700;color:var(--ua-accent);margin-bottom:8px}
+.fleet-config-item{margin-bottom:8px;padding:8px;background:rgba(0,0,0,.2);border-radius:4px}
+.fleet-config-name{font-size:10px;margin-bottom:4px}
+.fleet-config-meta{color:var(--ua-muted)}
+.fleet-health-active-text{font-size:10px;color:var(--ua-green);margin-top:2px}
+.fh-pct{font-size:9px;color:var(--ua-muted);font-weight:400}
+.fleet-td-reg{font-weight:700}
+.fleet-td-status{font-size:9px;max-width:120px;overflow:hidden;text-overflow:ellipsis}
+.sa-flight-info{font-size:9px;color:var(--ua-green);margin-top:2px}
+.fleet-starlink-chip-val{font-size:16px;font-weight:700}
+.fleet-starlink-chip-label{color:var(--ua-muted);font-size:10px}
 
 /* Special Aircraft Badge & Tracker */
 .special-badge{background:rgba(139,92,246,.2);color:#a78bfa;padding:2px 6px;border-radius:3px;font-size:9px;font-weight:700;font-family:var(--font-mono)}
@@ -317,20 +415,13 @@ tbody td{padding:5px 8px;white-space:nowrap}
 .phase-row:hover{background:rgba(0,93,170,.1)}
 .phase-row.phase-selected{background:rgba(0,93,170,.2);border-left:2px solid var(--ua-accent)}
 
-/* Live Fleet Status */
-.live-fleet-panel{background:var(--ua-panel);border:1px solid var(--ua-border);border-radius:6px;padding:14px;margin-bottom:14px;position:relative;overflow:hidden}
-.live-fleet-panel::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--ua-green),var(--ua-blue),var(--ua-green));background-size:200% 100%;animation:liveShimmer 2s linear infinite}
+/* Live Fleet Status (legacy compat) */
 @keyframes liveShimmer{0%{background-position:200% 0}100%{background-position:-200% 0}}
 .live-badge{display:inline-flex;align-items:center;gap:4px;background:rgba(34,197,94,.15);color:var(--ua-green);font-size:10px;font-weight:700;padding:2px 8px;border-radius:3px;letter-spacing:1px}
 .pulse-dot{width:8px;height:8px;border-radius:50%;background:var(--ua-green);animation:pulse 1.5s ease-in-out infinite}
 @keyframes pulse{0%,100%{opacity:1;box-shadow:0 0 0 0 rgba(34,197,94,.4)}50%{opacity:.7;box-shadow:0 0 0 6px rgba(34,197,94,0)}}
 .big-number{font-size:36px;font-weight:700;color:var(--ua-blue);line-height:1}
 .big-number-label{font-size:10px;color:var(--ua-muted);text-transform:uppercase;letter-spacing:1px}
-.type-breakdown{display:grid;grid-template-columns:repeat(auto-fill,minmax(110px,1fr));gap:4px;margin:10px 0}
-.type-bar{display:flex;justify-content:space-between;align-items:center;padding:3px 6px;background:rgba(0,0,0,.2);border-radius:3px;font-size:10px}
-.type-bar .airborne{color:var(--ua-green);font-weight:700}
-.type-bar .total{color:var(--ua-muted)}
-.live-table-wrap{max-height:350px;overflow-y:auto;border:1px solid var(--ua-border);border-radius:4px;margin-top:10px}
 
 /* Weather Explainer */
 .wx-explainer{background:rgba(0,93,170,.06);border:1px solid rgba(0,93,170,.15);border-radius:4px;padding:8px 10px;margin:4px 0 8px;font-size:10px;line-height:1.5;color:var(--ua-text)}
@@ -414,7 +505,8 @@ tbody td{padding:5px 8px;white-space:nowrap}
   table{min-width:600px}
   /* Fleet tab mobile */
   #tab-fleet{padding:10px}
-  .fleet-chips{grid-template-columns:repeat(3,1fr)}
+  .fleet-pulse-panels{flex-direction:column}
+  .fleet-pulse-right{border-left:none;padding-left:0;border-top:1px solid var(--ua-border);padding-top:14px;margin-top:10px}
   .fleet-controls{flex-direction:column}
   .fleet-controls select,.fleet-controls input{width:100%;min-height:44px;font-size:14px}
   .two-col{grid-template-columns:1fr}
@@ -422,6 +514,10 @@ tbody td{padding:5px 8px;white-space:nowrap}
   .fleet-health-bar .fh-count{min-width:55px;font-size:9px}
   .special-aircraft-grid{grid-template-columns:1fr}
   .special-aircraft-item{padding:10px 12px}
+  .variant-card{min-width:60px}
+  .fleet-subgroup-cards{flex-wrap:wrap}
+  .fleet-subtab-bar{overflow-x:auto;-webkit-overflow-scrolling:touch}
+  .fleet-subtab{padding:8px 10px;font-size:10px}
   /* Weather tab mobile */
   .wx-layout{flex-direction:column}
   .wx-map-panel{flex:none}
@@ -610,11 +706,11 @@ tbody td{padding:5px 8px;white-space:nowrap}
 #watch-notification .wn-dismiss{background:none;border:1px solid rgba(255,255,255,.3);color:#fff;padding:4px 10px;border-radius:3px;cursor:pointer;font-family:var(--font-ui);font-size:10px}
 
 /* ═══ HYBRID TYPOGRAPHY: Mono for data elements ═══ */
-table,thead th,tbody td,.stat-val,.metric-val,.big-number,.ticker,.ticker-item,.hub-code,.hub-card-code,.popup-callsign,.popup-field-value,.popup-route,.hub-raw,.hub-tooltip,.sched-status,#countdown,#clock,.irops-bar-val,.irops-score,.hh-hub,.fleet-chip .count,.equip-change-badge,.cat-badge,.hub-metric-val,.starlink-badge,.popup-phase,.seat-block,.freshness,.squawk-alert{font-family:var(--font-mono)}
+table,thead th,tbody td,.stat-val,.metric-val,.big-number,.ticker,.ticker-item,.hub-code,.hub-card-code,.popup-callsign,.popup-field-value,.popup-route,.hub-raw,.hub-tooltip,.sched-status,#countdown,#clock,.irops-bar-val,.irops-score,.hh-hub,.fleet-chip .count,.variant-count,.fleet-family-count,.equip-change-badge,.cat-badge,.hub-metric-val,.starlink-badge,.popup-phase,.seat-block,.freshness,.squawk-alert{font-family:var(--font-mono)}
 .onboarding-subtitle,.onboarding-desc,.onboarding-footer,.source-desc,.hub-explainer,.wx-explainer,.error-state,.empty-state,.hub-card-name,.stat-label,.metric-label,.big-number-label,.irops-bar-label,.hub-metric-label,.popup-field-label,.popup-route-est,.source-name,.source-link{font-family:var(--font-ui)}
 
 /* ═══ MICRO-INTERACTIONS: :active press feedback ═══ */
-.tab-btn:active,.ctrl-btn:active,.refresh-btn:active,.retry-btn:active,.sched-day-btn:active,.sched-load-more:active,#onboarding-dismiss:active,#onboarding-help:active,.watch-btn:active,.share-btn:active,#watch-header-btn:active,#mobile-bottom-nav button:active,.fleet-chip:active,.hub-nav a:active,.show-all-btn:active{transform:scale(.97)}
+.tab-btn:active,.ctrl-btn:active,.refresh-btn:active,.retry-btn:active,.sched-day-btn:active,.sched-load-more:active,#onboarding-dismiss:active,#onboarding-help:active,.watch-btn:active,.share-btn:active,#watch-header-btn:active,#mobile-bottom-nav button:active,.fleet-chip:active,.variant-card:active,.fleet-subtab:active,.hub-nav a:active,.show-all-btn:active{transform:scale(.97)}
 
 /* ═══ SKELETON SHIMMER loading states ═══ */
 @keyframes shimmerSlide{0%{background-position:-200% 0}100%{background-position:200% 0}}

--- a/public/index.html
+++ b/public/index.html
@@ -412,78 +412,123 @@ body{background:#0a0f1a;color:#e2e8f0;margin:0;overflow:hidden;font-family:'Inte
     <h2>United Airlines Fleet Database — 1,078 Aircraft</h2>
     <p>Complete searchable database of all 1,078 United Airlines mainline aircraft across 19 types: Boeing 737-700 (40), 737-800 (141), 737-900 (12), 737-900ER (136), 737 MAX 8 (123), 737 MAX 9 (129), 757-200 (40), 757-300 (21), 767-300ER (37), 767-400ER (16), 777-200 (19), 777-200ER (55), 777-300ER (22), 787-8 (12), 787-9 (48), 787-10 (21), and Airbus A319 (76), A320 (68), A321neo (62). Includes registration, seat configuration, WiFi type, IFE system, delivery date, and operational status. 258 aircraft equipped with SpaceX Starlink satellite WiFi. Live fleet utilization updated every 30 seconds. <a href="/fleet">View full fleet database</a>.</p>
   </section>
-  <div class="live-fleet-panel" id="live-fleet-panel" style="display:none">
-    <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:10px">
-      <h3 style="font-size:10px;color:var(--ua-blue);text-transform:uppercase;letter-spacing:1.5px;margin:0">🛩 Live Fleet Status</h3>
-      <div style="display:flex;align-items:center;gap:8px"><span class="live-badge"><span class="pulse-dot"></span> LIVE</span><span id="fleet-live-time" style="font-size:9px;color:var(--ua-muted)"></span></div>
-    </div>
-    <div id="fleet-live-content"><div style="color:var(--ua-muted);font-size:11px;padding:20px 0;text-align:center">Loading live fleet data...<br><button class="retry-btn" data-action="refresh-flights" style="margin-top:8px">⏳ Load Now</button></div></div>
-  </div>
-  <div class="card" id="fleet-health-card">
-    <h3>🏥 Fleet Health</h3>
-    <div id="fleet-health-content"><div style="color:var(--ua-muted);font-size:11px;padding:20px 0;text-align:center">Loading fleet health data...</div></div>
-  </div>
-  <div class="card">
-    <h3 id="fleet-overview-title">Fleet Overview</h3>
-    <div class="fleet-chips" id="fleet-chips"></div>
-    <div style="display:flex;align-items:center;gap:10px;margin-bottom:10px">
-      <div style="flex:1;background:var(--ua-border);height:4px;border-radius:2px;overflow:hidden">
-        <div id="starlink-progress" style="height:100%;background:var(--ua-green);border-radius:2px;transition:width .5s"></div>
+
+  <!-- ═══ ZONE 1: FLEET PULSE ═══ -->
+  <div class="fleet-pulse-zone" id="fleet-pulse-zone">
+    <div class="fleet-pulse-shimmer"></div>
+    <div class="fleet-pulse-header">
+      <h3 class="fleet-pulse-title">Live Fleet Status</h3>
+      <div class="fleet-pulse-badges">
+        <span class="live-badge"><span class="pulse-dot"></span> LIVE</span>
+        <span id="fleet-live-time" class="fleet-pulse-time"></span>
       </div>
-      <span id="starlink-pct" style="font-size:10px;color:var(--ua-green);font-weight:700"></span>
-      <span style="font-size:9px;color:var(--ua-muted)">Starlink Equipped</span>
+    </div>
+    <div class="fleet-pulse-panels">
+      <div class="fleet-pulse-left" id="fleet-pulse-left">
+        <div class="fleet-pulse-hero">
+          <span class="pulse-dot"></span>
+          <span class="fleet-pulse-airborne-count" id="fleet-airborne-count">--</span>
+          <span class="fleet-pulse-airborne-label">AIRBORNE</span>
+        </div>
+        <div class="fleet-pulse-subtitle" id="fleet-pulse-subtitle">Loading live flight data...</div>
+        <div class="fleet-pulse-util" id="fleet-pulse-util"></div>
+        <div class="fleet-type-utilization" id="fleet-type-utilization"></div>
+      </div>
+      <div class="fleet-pulse-right" id="fleet-pulse-right">
+        <div id="fleet-health-content"><div class="fleet-loading-text">Loading fleet health data...</div></div>
+        <div class="fleet-starlink-progress">
+          <div class="fleet-starlink-track">
+            <div class="fleet-starlink-fill" id="starlink-progress"></div>
+          </div>
+          <span class="fleet-starlink-pct" id="starlink-pct"></span>
+          <span class="fleet-starlink-label">Starlink Equipped</span>
+        </div>
+        <div class="fleet-starlink-stats" id="starlink-fleet-stats"></div>
+      </div>
     </div>
   </div>
-  <div class="two-col">
-    <div class="card">
-      <h3>Fleet Delivery Timeline</h3>
-      <div style="font-size:9px;color:var(--ua-muted);margin-bottom:4px">Aircraft deliveries by year · colored by family</div>
-      <div id="age-chart" style="position:relative"></div>
-      <div id="age-stats" style="font-size:10px;color:var(--ua-muted);margin-top:6px"></div>
-    </div>
-    <div class="card">
-      <h3>Seat Configuration</h3>
-      <div id="config-display"></div>
+
+  <!-- ═══ ZONE 2: FLEET COMPOSITION ═══ -->
+  <div class="fleet-composition-zone" id="fleet-composition-zone">
+    <h3 class="zone-title" id="fleet-overview-title">Fleet Overview</h3>
+    <div class="fleet-families" id="fleet-families"></div>
+    <div class="two-col">
+      <div class="card">
+        <h3>Fleet Delivery Timeline</h3>
+        <div class="fleet-age-subtitle">Aircraft deliveries by year, colored by family</div>
+        <div id="age-chart" class="fleet-age-chart"></div>
+        <div id="age-stats" class="fleet-age-stats"></div>
+      </div>
+      <div class="card">
+        <h3>Seat Configuration</h3>
+        <div id="config-display">
+          <div class="fleet-config-empty" id="fleet-config-empty">
+            <div class="fleet-config-empty-text">Select an aircraft type above to see cabin layout</div>
+            <div class="fleet-config-quick-links">
+              <span class="fleet-config-quick" data-action="filter-fleet-type" data-type="737-800">737-800</span>
+              <span class="fleet-config-quick" data-action="filter-fleet-type" data-type="A321neo">A321neo</span>
+              <span class="fleet-config-quick" data-action="filter-fleet-type" data-type="777-300ER">777-300ER</span>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
-  <div class="card">
-    <h3>Aircraft Database</h3>
-    <div style="font-size:10px;color:var(--ua-muted);margin-bottom:8px">Fleet data via <a href="https://sites.google.com/site/unitedfleetsite/mainline-fleet-tracking" target="_blank" rel="noopener noreferrer" style="color:var(--ua-green)">United Fleet Site</a>, updated daily</div>
-    <div class="fleet-controls">
+
+  <!-- ═══ ZONE 3: AIRCRAFT LOOKUP ═══ -->
+  <div class="fleet-lookup-zone" id="fleet-lookup-zone">
+    <div class="fleet-lookup-header">
+      <h3 class="zone-title">Aircraft Lookup</h3>
+      <div class="fleet-data-source">Fleet data via <a href="https://sites.google.com/site/unitedfleetsite/mainline-fleet-tracking" target="_blank" rel="noopener noreferrer" class="fleet-source-link">United Fleet Site</a>, updated daily</div>
+    </div>
+    <div class="fleet-subtab-bar" id="fleet-subtab-bar" role="tablist" aria-label="Aircraft lookup views">
+      <button class="fleet-subtab active" role="tab" aria-selected="true" data-action="fleet-subtab" data-view="all" id="fleet-subtab-all">All Aircraft <span class="fleet-subtab-count" id="fleet-subtab-count-all"></span></button>
+      <button class="fleet-subtab" role="tab" aria-selected="false" data-action="fleet-subtab" data-view="airborne" id="fleet-subtab-airborne">Airborne Now <span class="fleet-subtab-count" id="fleet-subtab-count-airborne"></span></button>
+      <button class="fleet-subtab" role="tab" aria-selected="false" data-action="fleet-subtab" data-view="starlink" id="fleet-subtab-starlink">Starlink <span class="fleet-subtab-count" id="fleet-subtab-count-starlink"></span></button>
+      <button class="fleet-subtab" role="tab" aria-selected="false" data-action="fleet-subtab" data-view="special" id="fleet-subtab-special">Special <span class="fleet-subtab-count" id="fleet-subtab-count-special"></span></button>
+    </div>
+    <div class="fleet-lookup-seat-config" id="fleet-lookup-seat-config"></div>
+    <div class="fleet-controls" id="fleet-controls">
+      <input type="text" id="fleet-search" aria-label="Fleet search" placeholder="Search reg, config...">
       <select id="fleet-filter-type" aria-label="Fleet type filter"><option value="">All Types</option></select>
       <select id="fleet-filter-wifi" aria-label="Fleet WiFi filter"><option value="">All WiFi</option></select>
-      <select id="fleet-filter-status" aria-label="Fleet status filter"><option value="">All Status</option><option value="active">Active</option><option value="stored">Stored/Maint</option><option value="starlink">⚡ Starlink</option><option value="special">⭐ Special/Named</option></select>
-      <input type="text" id="fleet-search" aria-label="Fleet search" placeholder="Search reg, config...">
-      <button class="refresh-btn" data-action="refresh-fleet-data">↻ Refresh Fleet Data</button>
+      <select id="fleet-filter-status" aria-label="Fleet status filter"><option value="">All Status</option><option value="active">Active</option><option value="stored">Stored/Maint</option><option value="starlink">Starlink</option><option value="special">Special/Named</option></select>
+      <button class="refresh-btn" data-action="refresh-fleet-data">Refresh</button>
     </div>
-    <div class="fleet-table-wrap">
-      <table id="fleet-table">
-        <thead><tr><th data-sort="r">Reg ↕</th><th data-sort="t">Type ↕</th><th data-sort="a">AC# ↕</th><th data-sort="c">Config</th><th data-sort="tot">Seats ↕</th><th data-sort="w">WiFi</th><th data-sort="i">IFE</th><th data-sort="d">Del ↕</th><th data-sort="s">Status</th><th>⚡</th></tr></thead>
+    <div class="fleet-controls fleet-controls-starlink" id="fleet-controls-starlink" style="display:none">
+      <input type="text" id="starlink-search" aria-label="Search Starlink aircraft" placeholder="Search tail...">
+      <select id="starlink-filter-fleet" aria-label="Starlink fleet filter"><option value="">All Fleets</option><option value="Mainline">Mainline</option><option value="Express">Express</option></select>
+      <select id="starlink-filter-type" aria-label="Starlink type filter"><option value="">All Types</option></select>
+      <select id="starlink-filter-operator" aria-label="Starlink operator filter"><option value="">All Operators</option></select>
+      <span id="starlink-filtered-count" class="fleet-filtered-count"></span>
+    </div>
+    <!-- All Aircraft table -->
+    <div class="fleet-table-wrap fleet-view-panel active" id="fleet-view-all">
+      <table id="fleet-table" aria-label="United Airlines fleet database">
+        <thead><tr><th data-sort="r" aria-sort="none">Reg</th><th data-sort="t" aria-sort="none">Type</th><th data-sort="a" aria-sort="none">AC#</th><th data-sort="c">Config</th><th data-sort="tot" aria-sort="none">Seats</th><th data-sort="w">WiFi</th><th data-sort="i">IFE</th><th data-sort="d" aria-sort="none">Del</th><th data-sort="s">Status</th><th>SL</th></tr></thead>
         <tbody id="fleet-tbody"></tbody>
       </table>
+      <div class="fleet-zero-results" id="fleet-zero-results" style="display:none">No aircraft match your filters. <button class="fleet-clear-filters" data-action="fleet-clear-filters">Clear Filters</button></div>
     </div>
-  </div>
-  <div class="card" id="special-aircraft-card">
-    <h3>⭐ Special &amp; Named Aircraft</h3>
-    <div id="special-aircraft-content"><div style="color:var(--ua-muted);font-size:11px;padding:20px 0;text-align:center">Loading special aircraft...</div></div>
-  </div>
-  <div class="card">
-    <h3>⚡ Starlink Tracker — <span id="starlink-count">258</span> Aircraft</h3>
-    <div style="font-size:10px;color:var(--ua-muted);margin-bottom:8px">Starlink data via <a href="https://unitedstarlinktracker.com" target="_blank" rel="noopener noreferrer" style="color:var(--ua-green)">unitedstarlinktracker.com</a> · <span id="starlink-updated" style="color:var(--ua-green)">live</span></div>
-    <div id="starlink-fleet-stats" style="display:none;gap:8px;flex-wrap:wrap;margin-bottom:8px"></div>
-    <div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:8px">
-      <input type="text" id="starlink-search" aria-label="Search Starlink aircraft" placeholder="Search tail..." style="background:var(--bg-card);color:var(--ua-text);border:1px solid var(--ua-border);padding:4px 8px;font-family:var(--mono);font-size:10px;border-radius:3px;width:120px">
-      <select id="starlink-filter-fleet" aria-label="Starlink fleet filter" style="background:var(--bg-card);color:var(--ua-text);border:1px solid var(--ua-border);padding:4px 6px;font-family:var(--mono);font-size:10px;border-radius:3px"><option value="">All Fleets</option><option value="Mainline">Mainline</option><option value="Express">Express</option></select>
-      <select id="starlink-filter-type" aria-label="Starlink type filter" style="background:var(--bg-card);color:var(--ua-text);border:1px solid var(--ua-border);padding:4px 6px;font-family:var(--mono);font-size:10px;border-radius:3px"><option value="">All Types</option></select>
-      <select id="starlink-filter-operator" aria-label="Starlink operator filter" style="background:var(--bg-card);color:var(--ua-text);border:1px solid var(--ua-border);padding:4px 6px;font-family:var(--mono);font-size:10px;border-radius:3px"><option value="">All Operators</option></select>
-      <span id="starlink-filtered-count" style="font-size:9px;color:var(--ua-muted);align-self:center"></span>
+    <!-- Airborne Now table -->
+    <div class="fleet-table-wrap fleet-view-panel" id="fleet-view-airborne" style="display:none">
+      <table id="airborne-table" aria-label="Currently airborne United aircraft">
+        <thead><tr><th data-airborne-sort="reg">Reg</th><th data-airborne-sort="type">Type</th><th data-airborne-sort="flight">Flight</th><th>Route</th><th data-airborne-sort="alt">Alt</th><th data-airborne-sort="phase">Phase</th><th>SL</th><th></th></tr></thead>
+        <tbody id="airborne-tbody"></tbody>
+      </table>
     </div>
-    <div class="fleet-table-wrap" style="max-height:400px">
-      <table id="starlink-table">
-        <thead><tr><th data-starlink-sort="tail" style="cursor:pointer">Tail ↕</th><th data-starlink-sort="fleet" style="cursor:pointer">Fleet ↕</th><th data-starlink-sort="type" style="cursor:pointer">Type ↕</th><th data-starlink-sort="operator" style="cursor:pointer">Operator ↕</th><th id="starlink-next-flight-th" style="display:none">Next Flight</th></tr></thead>
+    <!-- Starlink table -->
+    <div class="fleet-table-wrap fleet-view-panel" id="fleet-view-starlink" style="display:none">
+      <table id="starlink-table" aria-label="Starlink-equipped aircraft">
+        <thead><tr><th data-starlink-sort="tail">Tail</th><th data-starlink-sort="fleet">Fleet</th><th data-starlink-sort="type">Type</th><th data-starlink-sort="operator">Operator</th><th id="starlink-next-flight-th" style="display:none">Next Flight</th></tr></thead>
         <tbody id="starlink-tbody"></tbody>
       </table>
     </div>
+    <!-- Special Aircraft table -->
+    <div class="fleet-table-wrap fleet-view-panel" id="fleet-view-special" style="display:none">
+      <div id="special-aircraft-content"><div class="fleet-loading-text">Loading special aircraft...</div></div>
+    </div>
+    <div class="fleet-starlink-source" id="fleet-starlink-source" style="display:none">Starlink data via <a href="https://unitedstarlinktracker.com" target="_blank" rel="noopener noreferrer" class="fleet-source-link">unitedstarlinktracker.com</a> · <span id="starlink-updated" class="fleet-starlink-updated">live</span> · <span id="starlink-count">258</span> aircraft</div>
   </div>
 </div>
 

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -1,5 +1,6 @@
 import { computeDelayRiskModel, HUB_COORDINATES, HUB_RISK_PROFILES } from '../lib/delay-risk.js';
 import { normalizeMetarPayload } from '../lib/metar.js';
+import { categorizeFleetStatus, FLEET_HEALTH_CATEGORIES, FLEET_FAMILIES, normalizeWifi, WIFI_DISPLAY, sortFleetData, filterFleetData, parseFleetDeepLink, TAB_MAP, VALID_FLEET_VIEWS } from '../lib/fleet-utils.js';
 
 // ═══════════════════════════════════════════════
 // HUB LIST — CANONICAL REFERENCE
@@ -85,33 +86,7 @@ async function loadFleetData() {
   buildSpecialAircraftIndex();
 }
 
-// ═══ FLEET HEALTH CATEGORIZATION ═══
-const FLEET_HEALTH_CATEGORIES = [
-  { key: 'active',          label: 'Active',          color: '#22c55e' },
-  { key: 'maintenance',     label: 'Maintenance',     color: '#eab308' },
-  { key: 'stored',          label: 'Stored',           color: '#ef4444' },
-  { key: 'next_retrofit',   label: 'NEXT Retrofit',    color: '#8b5cf6' },
-  { key: 'painting',        label: 'Painting',         color: '#06b6d4' },
-  { key: 'starlink_install',label: 'Starlink Install', color: '#10b981' },
-  { key: 'future_gum',      label: 'Future GUM',       color: '#f97316' }
-];
-
-function categorizeFleetStatus(s) {
-  if (!s) return 'active';
-  if (s.startsWith('*')) return 'active';
-  if (/100 Year Sticker|Eco Demonstrator/i.test(s)) return 'active';
-  if (/stored/i.test(s)) return 'stored';
-  if (/\bpaint\b/i.test(s)) return 'painting';
-  if (/starlink/i.test(s)) return 'starlink_install';
-  if (/\bmod\s*next\b/i.test(s)) return 'next_retrofit';
-  if (/future\s*gum/i.test(s)) return 'future_gum';
-  if (/maint|induction/i.test(s)) return 'maintenance';
-  // Notes about NEXT status (Partial NEXT, NEXT???, Confirmed w.o NEXT) — aircraft is active
-  if (/next/i.test(s)) return 'active';
-  // Remaining non-empty statuses are likely maintenance at MRO locations
-  if (s.trim()) return 'maintenance';
-  return 'active';
-}
+// FLEET_HEALTH_CATEGORIES and categorizeFleetStatus imported from ../lib/fleet-utils.js
 
 // ═══ SPECIAL AIRCRAFT DETECTION ═══
 const SPECIAL_AIRCRAFT = {};
@@ -479,6 +454,21 @@ document.getElementById('tab-bar')?.addEventListener('keydown', function(e) {
       if (tab === 'fleet' && fleetFilter) {
         pendingFleetDeepLinkFilter = fleetFilter;
         applyFleetDeepLinkFilter(fleetFilter, { render: FLEET_DB.length > 0 });
+      }
+
+      // Fleet tab: support sub-tab deep links via ?view=starlink|airborne|special
+      if (tab === 'fleet') {
+        const viewParam = params.get('view');
+        if (viewParam && ['starlink','airborne','special'].includes(viewParam)) {
+          // Defer to after fleet data loads
+          const waitForFleet = setInterval(() => {
+            if (typeof switchFleetView === 'function' && FLEET_DB.length > 0) {
+              clearInterval(waitForFleet);
+              switchFleetView(viewParam);
+            }
+          }, 200);
+          setTimeout(() => clearInterval(waitForFleet), 10000);
+        }
       }
 
       // Schedule tab: filter by hub airport
@@ -1753,41 +1743,40 @@ function initTickerAnimation(tickerEl) {
 }
 
 // ═══ FLEET TAB ═══
+// FLEET_FAMILIES imported from ../lib/fleet-utils.js
+
+let activeFleetType = '';
+let activeFleetView = 'all';
+
 function initFleetTab() {
   // Set dynamic fleet count in title
-  document.getElementById('fleet-overview-title').textContent = `Fleet Overview — ${FLEET_DB.length} Mainline Aircraft`;
+  document.getElementById('fleet-overview-title').textContent = 'Fleet Overview — ' + FLEET_DB.length + ' Mainline Aircraft';
 
-  // Type chips
   const typeCounts = {};
   FLEET_DB.forEach(a => { typeCounts[a.t] = (typeCounts[a.t] || 0) + 1; });
   const typeOrder = ["A319","A320","A321neo","737-700","737-800","737-900","737-900ER","737 MAX 8","737 MAX 9","757-200","757-300","767-300ER","767-400ER","777-200","777-200ER","777-300ER","787-8","787-9","787-10"];
-  const icons = {'A319':'🔹','A320':'🔹','737-700':'🔸','737-800':'🔸','737-900':'🔸','737 MAX':'⭐','757':'🔷','767':'🔷','777':'💎','777-200':'💎','787-8':'🌟','777-300ER':'👑'};
-
-  document.getElementById('fleet-chips').innerHTML = typeOrder.map(t =>
-    `<div class="fleet-chip" data-action="filter-fleet-type" data-type="${t}">
-      <div style="font-size:14px">${icons[t]||'✈️'}</div>
-      <div class="count">${typeCounts[t]||0}</div>
-      <div class="label">${t}</div>
-    </div>`
-  ).join('');
 
   // Starlink progress — use live fleet stats if available
   const mainlineStarlink = STARLINK_FLEET_STATS ? STARLINK_FLEET_STATS.mainline : STARLINK_DB.filter(s => s.fleet === 'Mainline').length;
-  document.getElementById('starlink-progress').style.width = (mainlineStarlink / FLEET_DB.length * 100) + '%';
-  document.getElementById('starlink-pct').textContent = Math.round(mainlineStarlink / FLEET_DB.length * 100) + '% (' + mainlineStarlink + '/' + FLEET_DB.length + ')';
+  if (FLEET_DB.length > 0) {
+    document.getElementById('starlink-progress').style.width = (mainlineStarlink / FLEET_DB.length * 100) + '%';
+    document.getElementById('starlink-pct').textContent = Math.round(mainlineStarlink / FLEET_DB.length * 100) + '% (' + mainlineStarlink + '/' + FLEET_DB.length + ')';
+  }
 
   // Render fleet stats chips if live data available
   if (STARLINK_FLEET_STATS) {
     const statsEl = document.getElementById('starlink-fleet-stats');
     if (statsEl) {
       const fs = STARLINK_FLEET_STATS;
-      const chipStyle = 'display:inline-flex;flex-direction:column;align-items:center;padding:6px 12px;border-radius:4px;font-size:10px';
-      statsEl.style.display = 'flex';
-      statsEl.innerHTML =
-        `<div style="${chipStyle};background:rgba(34,197,94,.1);border:1px solid rgba(34,197,94,.2)"><span style="font-size:16px;font-weight:700;color:var(--ua-green)">${fs.total}</span><span style="color:var(--ua-muted)">Total</span></div>` +
-        `<div style="${chipStyle};background:rgba(0,93,170,.1);border:1px solid rgba(0,93,170,.2)"><span style="font-size:16px;font-weight:700;color:var(--ua-accent)">${fs.mainline}</span><span style="color:var(--ua-muted)">Mainline</span></div>` +
-        `<div style="${chipStyle};background:rgba(168,85,247,.1);border:1px solid rgba(168,85,247,.2)"><span style="font-size:16px;font-weight:700;color:#a855f7">${fs.express}</span><span style="color:var(--ua-muted)">Express</span></div>` +
-        (fs.mainlineTotal ? `<div style="${chipStyle};background:rgba(100,116,139,.08);border:1px solid rgba(100,116,139,.15)"><span style="font-size:16px;font-weight:700;color:var(--ua-text)">${Math.round(fs.mainline / fs.mainlineTotal * 100)}%</span><span style="color:var(--ua-muted)">Mainline Fleet</span></div>` : '');
+      // Note: all values are pre-sanitized integers from our own API
+      let chipsHtml = '';
+      chipsHtml += '<div class="fleet-starlink-chip" style="background:rgba(34,197,94,.1);border:1px solid rgba(34,197,94,.2)"><span class="fleet-starlink-chip-val" style="color:var(--ua-green)">' + fs.total + '</span><span class="fleet-starlink-chip-label">Total</span></div>';
+      chipsHtml += '<div class="fleet-starlink-chip" style="background:rgba(0,93,170,.1);border:1px solid rgba(0,93,170,.2)"><span class="fleet-starlink-chip-val" style="color:var(--ua-accent)">' + fs.mainline + '</span><span class="fleet-starlink-chip-label">Mainline</span></div>';
+      chipsHtml += '<div class="fleet-starlink-chip" style="background:rgba(168,85,247,.1);border:1px solid rgba(168,85,247,.2)"><span class="fleet-starlink-chip-val" style="color:#a855f7">' + fs.express + '</span><span class="fleet-starlink-chip-label">Express</span></div>';
+      if (fs.mainlineTotal) {
+        chipsHtml += '<div class="fleet-starlink-chip" style="background:rgba(100,116,139,.08);border:1px solid rgba(100,116,139,.15)"><span class="fleet-starlink-chip-val" style="color:var(--ua-text)">' + Math.round(fs.mainline / fs.mainlineTotal * 100) + '%</span><span class="fleet-starlink-chip-label">Mainline Fleet</span></div>';
+      }
+      statsEl.innerHTML = chipsHtml;
     }
   }
 
@@ -1796,35 +1785,114 @@ function initFleetTab() {
     const updatedEl = document.getElementById('starlink-updated');
     if (updatedEl) {
       const ago = Math.round((Date.now() - new Date(STARLINK_LAST_UPDATED).getTime()) / 60000);
-      updatedEl.textContent = ago < 60 ? `Updated ${ago}m ago` : ago < 1440 ? `Updated ${Math.round(ago/60)}h ago` : `Updated ${Math.round(ago/1440)}d ago`;
+      updatedEl.textContent = ago < 60 ? ('Updated ' + ago + 'm ago') : ago < 1440 ? ('Updated ' + Math.round(ago/60) + 'h ago') : ('Updated ' + Math.round(ago/1440) + 'd ago');
     }
   }
 
   // Populate filters
   const wifiTypes = [...new Set(FLEET_DB.map(a => normalizeWifi(a.w)).filter(Boolean))].sort();
-  document.getElementById('fleet-filter-type').innerHTML = '<option value="">All Types</option>' +
-    typeOrder.map(t => `<option value="${t}">${t} (${typeCounts[t]||0})</option>`).join('');
-  document.getElementById('fleet-filter-wifi').innerHTML = '<option value="">All WiFi</option>' +
-    wifiTypes.map(w => `<option value="${w}">${w}</option>`).join('');
+  const typeOptHtml = '<option value="">All Types</option>' +
+    typeOrder.map(t => '<option value="' + escapeHtml(t) + '">' + escapeHtml(t) + ' (' + (typeCounts[t]||0) + ')</option>').join('');
+  document.getElementById('fleet-filter-type').innerHTML = typeOptHtml;
+  const wifiOptHtml = '<option value="">All WiFi</option>' +
+    wifiTypes.map(w => '<option value="' + escapeHtml(w) + '">' + escapeHtml(w) + '</option>').join('');
+  document.getElementById('fleet-filter-wifi').innerHTML = wifiOptHtml;
 
   if (pendingFleetDeepLinkFilter) {
     applyFleetDeepLinkFilter(pendingFleetDeepLinkFilter, { render: false });
     pendingFleetDeepLinkFilter = null;
   }
 
+  renderFleetComposition();
   renderFleetTable();
   renderAgeChart();
   renderStarlinkTable();
   initStarlinkFilters();
   renderFleetHealth();
   renderSpecialAircraftPanel();
+  updateFleetSubtabCounts();
 
-  // Filter listeners
-  const debouncedFleetRender = debounce(renderFleetTable, 120);
+  // Filter listeners — sync variant cards + config when type dropdown changes
+  function onFleetFilterChange() {
+    renderFleetTable();
+    // Sync variant card highlight and config panel with type dropdown
+    const typeVal = document.getElementById('fleet-filter-type').value;
+    if (typeVal !== activeFleetType) {
+      // Deselect old card
+      document.querySelectorAll('.variant-card.active').forEach(c => c.classList.remove('active'));
+      activeFleetType = typeVal || null;
+      // Highlight new card if a type is selected
+      if (activeFleetType) {
+        document.querySelectorAll('.variant-card').forEach(c => {
+          if (c.dataset.type === activeFleetType) c.classList.add('active');
+        });
+        showConfigGallery(activeFleetType);
+      } else {
+        showConfigEmpty();
+      }
+    }
+  }
+  const debouncedFleetRender = debounce(onFleetFilterChange, 120);
   ['fleet-filter-type','fleet-filter-wifi','fleet-filter-status','fleet-search'].forEach(id => {
     document.getElementById(id).addEventListener('input', debouncedFleetRender);
     document.getElementById(id).addEventListener('change', debouncedFleetRender);
   });
+}
+
+// ═══ ZONE 2: FLEET COMPOSITION ═══
+function renderFleetComposition() {
+  const typeCounts = {};
+  FLEET_DB.forEach(a => { typeCounts[a.t] = (typeCounts[a.t] || 0) + 1; });
+
+  let html = '';
+  let widebodyDividerShown = false;
+
+  FLEET_FAMILIES.forEach(family => {
+    // Show widebody divider before first widebody family
+    if (family.widebody && !widebodyDividerShown) {
+      html += '<div class="fleet-widebody-divider">WIDEBODY · POLARIS</div>';
+      widebodyDividerShown = true;
+    }
+
+    // Count total aircraft in this family
+    let familyTotal = 0;
+    family.subgroups.forEach(sg => sg.types.forEach(t => { familyTotal += typeCounts[t] || 0; }));
+
+    html += '<div class="fleet-family" role="group" aria-label="' + escapeHtml(family.name) + ' family" id="family-' + family.id + '">';
+    html += '<div class="fleet-family-header">';
+    html += '<span class="fleet-family-name">' + escapeHtml(family.name) + '</span>';
+    html += '<span class="fleet-family-count">' + familyTotal + ' aircraft</span>';
+    html += '<span class="fleet-family-role">' + escapeHtml(family.role) + '</span>';
+    html += '</div>';
+
+    if (family.routeCallout) {
+      html += '<div class="fleet-family-route">' + escapeHtml(family.routeCallout) + '</div>';
+    }
+
+    html += '<div class="fleet-family-body">';
+    family.subgroups.forEach((sg, sgIdx) => {
+      if (sgIdx > 0) {
+        html += '<div class="fleet-subgroup-sep"></div>';
+      }
+      html += '<div class="fleet-subgroup">';
+      if (sg.label) {
+        html += '<div class="fleet-subgroup-label">' + escapeHtml(sg.label) + '</div>';
+      }
+      html += '<div class="fleet-subgroup-cards">';
+      sg.types.forEach(type => {
+        const count = typeCounts[type] || 0;
+        const isActive = activeFleetType === type;
+        html += '<div class="variant-card' + (isActive ? ' active' : '') + '" data-action="filter-fleet-type" data-type="' + escapeHtml(type) + '" tabindex="0" role="button" aria-pressed="' + isActive + '">';
+        html += '<div class="variant-count">' + count + '</div>';
+        html += '<div class="variant-name">' + escapeHtml(type) + '</div>';
+        html += '</div>';
+      });
+      html += '</div></div>';
+    });
+    html += '</div></div>';
+  });
+
+  document.getElementById('fleet-families').innerHTML = html;
 }
 
 let fleetSortCol = 'r', fleetSortAsc = true;
@@ -1853,31 +1921,45 @@ function renderFleetTable() {
     return fleetSortAsc ? (va > vb ? 1 : -1) : (va < vb ? 1 : -1);
   });
 
-  document.getElementById('fleet-tbody').innerHTML = data.map(a => {
+  const zeroEl = document.getElementById('fleet-zero-results');
+  if (data.length === 0 && (typeF || wifiF || statusF || searchF)) {
+    zeroEl.style.display = '';
+  } else {
+    zeroEl.style.display = 'none';
+  }
+
+  // Build rows using escapeHtml for all user-sourced data
+  const rows = data.map(a => {
     const isSL = STARLINK_TAILS.has(a.r);
     const special = isSpecialAircraft(a.r);
     const rowCls = a.s ? (a.s.toLowerCase().includes('stored') ? 'row-stored' : (special ? '' : 'row-maint')) : '';
-    return `<tr class="${rowCls}">
-      <td style="font-weight:700"><span class="ac-reg-link" data-action="aircraft-detail" data-reg="${escapeHtml(a.r)}">${escapeHtml(a.r)}</span>${special ? ' <span class="special-badge">⭐ ' + escapeHtml(special.name) + '</span>' : ''}</td>
-      <td>${escapeHtml(a.t)}</td><td>${escapeHtml(a.a)}</td><td>${escapeHtml(a.c)}</td>
-      <td>${escapeHtml(a.tot || '')}</td><td>${escapeHtml(normalizeWifi(a.w))}</td><td>${escapeHtml(a.i)}</td><td>${escapeHtml(a.d)}</td>
-      <td style="font-size:9px;max-width:120px;overflow:hidden;text-overflow:ellipsis">${escapeHtml(a.s)}</td>
-      <td>${isSL ? '<span class="starlink-badge">⚡</span>' : ''}</td>
-    </tr>`;
-  }).join('');
+    return '<tr class="' + rowCls + '">' +
+      '<td class="fleet-td-reg"><span class="ac-reg-link" data-action="aircraft-detail" data-reg="' + escapeHtml(a.r) + '">' + escapeHtml(a.r) + '</span>' + (special ? ' <span class="special-badge">' + escapeHtml(special.name) + '</span>' : '') + '</td>' +
+      '<td>' + escapeHtml(a.t) + '</td><td>' + escapeHtml(a.a) + '</td><td>' + escapeHtml(a.c) + '</td>' +
+      '<td>' + escapeHtml(a.tot || '') + '</td><td>' + escapeHtml(normalizeWifi(a.w)) + '</td><td>' + escapeHtml(a.i) + '</td><td>' + escapeHtml(a.d) + '</td>' +
+      '<td class="fleet-td-status">' + escapeHtml(a.s) + '</td>' +
+      '<td>' + (isSL ? '<span class="starlink-badge">SL</span>' : '') + '</td>' +
+    '</tr>';
+  });
+  document.getElementById('fleet-tbody').innerHTML = rows.join('');
+
+  updateFleetSubtabCounts();
 }
 
-// Sort handler
+// Sort handler for fleet table
 document.querySelectorAll('#fleet-table thead th[data-sort]').forEach(th => {
   th.addEventListener('click', () => {
     const col = th.dataset.sort;
     if (fleetSortCol === col) fleetSortAsc = !fleetSortAsc;
     else { fleetSortCol = col; fleetSortAsc = true; }
+    // Update aria-sort attributes
+    document.querySelectorAll('#fleet-table thead th[data-sort]').forEach(h => h.setAttribute('aria-sort', 'none'));
+    th.setAttribute('aria-sort', fleetSortAsc ? 'ascending' : 'descending');
     renderFleetTable();
   });
 });
 
-// ═══ FLEET HEALTH DASHBOARD ═══
+// ═══ FLEET HEALTH DASHBOARD (Zone 1 Right Panel) ═══
 function renderFleetHealth() {
   if (!FLEET_DB.length) return;
   const counts = {};
@@ -1889,34 +1971,34 @@ function renderFleetHealth() {
   const total = FLEET_DB.length;
   const nonActive = total - counts.active;
 
-  let html = `<div style="display:flex;align-items:center;gap:16px;margin-bottom:14px">`;
-  html += `<div class="big-number">${total}</div>`;
-  html += `<div><div class="big-number-label">Total Mainline Aircraft</div>`;
-  html += `<div style="font-size:10px;color:var(--ua-green);margin-top:2px">${counts.active} active (${(counts.active / total * 100).toFixed(1)}%) · ${nonActive} out of service</div></div>`;
-  html += `</div>`;
+  let html = '<div class="fleet-health-summary">';
+  html += '<div class="big-number">' + total + '</div>';
+  html += '<div><div class="big-number-label">Total Mainline Aircraft</div>';
+  html += '<div class="fleet-health-active-text">' + counts.active + ' active (' + (counts.active / total * 100).toFixed(1) + '%) · ' + nonActive + ' out of service</div></div>';
+  html += '</div>';
 
   FLEET_HEALTH_CATEGORIES.forEach(cat => {
     const count = counts[cat.key] || 0;
     if (count === 0) return;
     const pct = (count / total * 100).toFixed(1);
     const barWidth = total > 0 ? (count / total * 100) : 0;
-    html += `<div class="fleet-health-bar">`;
-    html += `<span class="fh-label"><span class="fh-legend-dot" style="background:${cat.color}"></span>${escapeHtml(cat.label)}</span>`;
-    html += `<div class="fh-track"><div class="fh-fill" style="width:${barWidth}%;background:${cat.color}"></div></div>`;
-    html += `<span class="fh-count">${count} <span style="font-size:9px;color:var(--ua-muted);font-weight:400">(${pct}%)</span></span>`;
-    html += `</div>`;
+    html += '<div class="fleet-health-bar" aria-label="' + escapeHtml(cat.label) + ': ' + count + ' of ' + total + ', ' + pct + '%">';
+    html += '<span class="fh-label"><span class="fh-legend-dot" style="background:' + cat.color + '"></span>' + escapeHtml(cat.label) + '</span>';
+    html += '<div class="fh-track"><div class="fh-fill" style="width:' + barWidth + '%;background:' + cat.color + '"></div></div>';
+    html += '<span class="fh-count">' + count + ' <span class="fh-pct">(' + pct + '%)</span></span>';
+    html += '</div>';
   });
 
   document.getElementById('fleet-health-content').innerHTML = html;
 }
 
-// ═══ SPECIAL AIRCRAFT TRACKER ═══
+// ═══ SPECIAL AIRCRAFT (Zone 3 - Special sub-tab) ═══
 function renderSpecialAircraftPanel() {
   if (!FLEET_DB.length) return;
   const specialRegs = Object.keys(SPECIAL_AIRCRAFT);
   if (!specialRegs.length) {
     document.getElementById('special-aircraft-content').innerHTML =
-      '<div style="color:var(--ua-muted);font-size:11px;text-align:center;padding:10px 0">No special aircraft found</div>';
+      '<div class="fleet-loading-text">No special aircraft found</div>';
     return;
   }
 
@@ -1929,44 +2011,191 @@ function renderSpecialAircraftPanel() {
       if (reg && SPECIAL_AIRCRAFT[reg]) {
         airborneSpecial[reg] = {
           flight: f.flightIATA || f.callsign || '',
-          route: (f.origin || '???') + '→' + (f.dest || '???')
+          route: (f.origin || '???') + ' > ' + (f.dest || '???')
         };
       }
     });
   }
 
-  let html = '<div class="special-aircraft-grid">';
+  let gridHtml = '<div class="special-aircraft-grid">';
   specialRegs.forEach(reg => {
     const special = SPECIAL_AIRCRAFT[reg];
     const ac = FLEET_BY_REG[reg];
     if (!ac) return;
     const airborne = airborneSpecial[reg];
 
-    html += `<div class="special-aircraft-item">`;
-    html += `<div>`;
-    html += `<div class="sa-name">${escapeHtml(special.name)}</div>`;
-    html += `<div><span class="sa-reg ac-reg-link" data-action="aircraft-detail" data-reg="${escapeHtml(reg)}">${escapeHtml(reg)}</span> <span class="sa-type">${escapeHtml(ac.t)} · Del ${escapeHtml(ac.d || '?')}</span></div>`;
-    html += `</div>`;
-    html += `<div class="sa-status">`;
+    gridHtml += '<div class="special-aircraft-item">';
+    gridHtml += '<div>';
+    gridHtml += '<div class="sa-name">' + escapeHtml(special.name) + '</div>';
+    gridHtml += '<div><span class="sa-reg ac-reg-link" data-action="aircraft-detail" data-reg="' + escapeHtml(reg) + '">' + escapeHtml(reg) + '</span> <span class="sa-type">' + escapeHtml(ac.t) + ' · Del ' + escapeHtml(ac.d || '?') + '</span></div>';
+    gridHtml += '</div>';
+    gridHtml += '<div class="sa-status">';
     if (airborne) {
-      html += `<span class="special-airborne-badge"><span class="pulse-dot" style="width:6px;height:6px;display:inline-block;margin-right:3px"></span>AIRBORNE</span>`;
-      html += `<div style="font-size:9px;color:var(--ua-green);margin-top:2px">${escapeHtml(airborne.flight)} ${escapeHtml(airborne.route)}</div>`;
+      gridHtml += '<span class="special-airborne-badge"><span class="pulse-dot"></span>AIRBORNE</span>';
+      gridHtml += '<div class="sa-flight-info">' + escapeHtml(airborne.flight) + ' ' + escapeHtml(airborne.route) + '</div>';
     } else {
-      html += `<span class="special-badge">${special.type === 'named' ? '★ NAMED' : '✦ LIVERY'}</span>`;
+      gridHtml += '<span class="special-badge">' + (special.type === 'named' ? 'NAMED' : 'LIVERY') + '</span>';
     }
-    html += `</div>`;
-    html += `</div>`;
+    gridHtml += '</div>';
+    gridHtml += '</div>';
   });
-  html += '</div>';
+  gridHtml += '</div>';
 
-  document.getElementById('special-aircraft-content').innerHTML = html;
+  document.getElementById('special-aircraft-content').innerHTML = gridHtml;
 }
 
+// ═══ ZONE 3: AIRBORNE TABLE ═══
+let airborneSortCol = 'type', airborneSortAsc = true;
+function renderAirborneTable() {
+  if (!allFlights.length) {
+    document.getElementById('airborne-tbody').innerHTML = '<tr><td colspan="8" class="fleet-loading-text">Loading live flight data...</td></tr>';
+    return;
+  }
+  const typeF = document.getElementById('fleet-filter-type').value;
+  const searchF = document.getElementById('fleet-search').value.toUpperCase();
+
+  const airborne = [];
+  allFlights.forEach(f => {
+    if (f.onGround) return;
+    const ac = matchAircraft(f);
+    if (!ac) return;
+    if (typeF && ac.t !== typeF) return;
+    if (searchF && !ac.r.toUpperCase().includes(searchF) && !ac.t.toUpperCase().includes(searchF)) return;
+    const routeStr = (f.origin || '???') + ' > ' + (f.dest || '???');
+    const phase = getPhase(f.alt, f.vr, f.spd);
+    const isStar = STARLINK_TAILS.has(ac.r) || STARLINK_TAILS.has(f.reg);
+    airborne.push({
+      reg: ac.r, type: ac.t,
+      flight: f.flightIATA || f.callsign,
+      route: routeStr,
+      alt: f.alt ? Math.round(f.alt * 3.28084).toLocaleString() + 'ft' : '--',
+      altRaw: f.alt || 0,
+      phase: phase.phase,
+      starlink: isStar,
+      special: isSpecialAircraft(ac.r)
+    });
+  });
+
+  airborne.sort((a, b) => {
+    let va, vb;
+    if (airborneSortCol === 'alt') { va = a.altRaw; vb = b.altRaw; }
+    else { va = a[airborneSortCol] || ''; vb = b[airborneSortCol] || ''; }
+    return airborneSortAsc ? (va > vb ? 1 : -1) : (va < vb ? 1 : -1);
+  });
+
+  const rowsHtml = airborne.map(a => {
+    return '<tr>' +
+      '<td class="fleet-td-reg"><span class="ac-reg-link" data-action="aircraft-detail" data-reg="' + escapeHtml(a.reg) + '">' + escapeHtml(a.reg) + '</span></td>' +
+      '<td>' + escapeHtml(a.type) + '</td><td>' + escapeHtml(a.flight) + '</td><td>' + escapeHtml(a.route) + '</td>' +
+      '<td>' + escapeHtml(a.alt) + '</td><td>' + escapeHtml(a.phase) + '</td>' +
+      '<td>' + (a.starlink ? '<span class="starlink-badge">SL</span>' : '') + '</td>' +
+      '<td>' + (a.special ? '<span class="special-badge">' + escapeHtml(a.special.name) + '</span>' : '') + '</td>' +
+    '</tr>';
+  });
+  document.getElementById('airborne-tbody').innerHTML = rowsHtml.join('');
+}
+
+// Sort handler for airborne table
+document.querySelectorAll('#airborne-table thead th[data-airborne-sort]').forEach(th => {
+  th.addEventListener('click', () => {
+    const col = th.getAttribute('data-airborne-sort');
+    if (airborneSortCol === col) airborneSortAsc = !airborneSortAsc;
+    else { airborneSortCol = col; airborneSortAsc = true; }
+    renderAirborneTable();
+  });
+});
+
+// ═══ FLEET SUB-TABS ═══
+function switchFleetView(view) {
+  activeFleetView = view;
+  // Update sub-tab buttons
+  document.querySelectorAll('.fleet-subtab').forEach(btn => {
+    const isActive = btn.dataset.view === view;
+    btn.classList.toggle('active', isActive);
+    btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
+  });
+  // Show/hide panels
+  document.querySelectorAll('.fleet-view-panel').forEach(panel => {
+    panel.classList.remove('active');
+    panel.style.display = 'none';
+  });
+  const activePanel = document.getElementById('fleet-view-' + view);
+  if (activePanel) {
+    activePanel.classList.add('active');
+    activePanel.style.display = '';
+  }
+  // Show/hide appropriate controls
+  const mainControls = document.getElementById('fleet-controls');
+  const starlinkControls = document.getElementById('fleet-controls-starlink');
+  const starlinkSource = document.getElementById('fleet-starlink-source');
+  if (view === 'starlink') {
+    mainControls.style.display = 'none';
+    starlinkControls.style.display = '';
+    if (starlinkSource) starlinkSource.style.display = '';
+  } else {
+    mainControls.style.display = '';
+    starlinkControls.style.display = 'none';
+    if (starlinkSource) starlinkSource.style.display = 'none';
+  }
+  // Render the active view
+  if (view === 'airborne') renderAirborneTable();
+  else if (view === 'starlink') renderStarlinkTable();
+  else if (view === 'special') renderSpecialAircraftPanel();
+  else renderFleetTable();
+}
+
+function updateFleetSubtabCounts() {
+  // All Aircraft count
+  const allCount = FLEET_DB.length;
+  const allEl = document.getElementById('fleet-subtab-count-all');
+  if (allEl) allEl.textContent = '(' + allCount + ')';
+
+  // Airborne count
+  const airborneCount = allFlights.filter(f => !f.onGround && matchAircraft(f)).length;
+  const airEl = document.getElementById('fleet-subtab-count-airborne');
+  if (airEl) airEl.textContent = '(' + airborneCount + ')';
+
+  // Starlink count
+  const slEl = document.getElementById('fleet-subtab-count-starlink');
+  if (slEl) slEl.textContent = '(' + STARLINK_DB.length + ')';
+
+  // Special count
+  const spEl = document.getElementById('fleet-subtab-count-special');
+  if (spEl) spEl.textContent = '(' + Object.keys(SPECIAL_AIRCRAFT).length + ')';
+}
+
+// ═══ CROSS-ZONE INTERACTION ═══
 function filterFleetType(type) {
-  document.getElementById('fleet-filter-type').value = type;
-  document.querySelectorAll('.fleet-chip').forEach(c => c.classList.toggle('active', c.dataset.type === type));
+  // Toggle: clicking the same type again deselects
+  if (activeFleetType === type) {
+    activeFleetType = '';
+    document.getElementById('fleet-filter-type').value = '';
+  } else {
+    activeFleetType = type;
+    document.getElementById('fleet-filter-type').value = type;
+  }
+
+  // Update variant card active states
+  document.querySelectorAll('.variant-card').forEach(c => {
+    const isActive = c.dataset.type === activeFleetType && activeFleetType !== '';
+    c.classList.toggle('active', isActive);
+    c.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+  });
+
   renderFleetTable();
-  showConfigGallery(type);
+
+  // Show config or reset to empty state
+  if (activeFleetType) {
+    showConfigGallery(activeFleetType);
+    // Smooth scroll to Zone 3
+    const lookupZone = document.getElementById('fleet-lookup-zone');
+    if (lookupZone) lookupZone.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  } else {
+    showConfigEmpty();
+  }
+
+  // Also re-render active sub-tab if it's airborne
+  if (activeFleetView === 'airborne') renderAirborneTable();
 }
 
 function showConfigGallery(type) {
@@ -1979,20 +2208,50 @@ function showConfigGallery(type) {
   });
 
   const colors = { J: '#2563eb', PP: '#0d9488', PE: '#0d9488', F: '#7c3aed', 'E+': '#16a34a', Y: '#475569', Domestic: '#6366f1' };
-  let html = `<div style="font-size:13px;font-weight:700;color:var(--ua-accent);margin-bottom:8px">${type} Configurations</div>`;
+  let html = '<div class="fleet-config-title">' + escapeHtml(type) + ' Configurations</div>';
 
   for (const [cfg, data] of Object.entries(configs)) {
-    html += `<div style="margin-bottom:8px;padding:8px;background:rgba(0,0,0,.2);border-radius:4px">`;
-    html += `<div style="font-size:10px;margin-bottom:4px"><strong>${cfg}</strong> <span style="color:var(--ua-muted)">(${data.count} aircraft, ${data.total} seats)</span></div>`;
-    html += `<div class="config-gallery">`;
-    for (const [cls, cnt] of Object.entries(data.seats)) {
-      const w = Math.max(30, cnt / 2);
-      html += `<div class="config-block" style="background:${colors[cls]||'#475569'};width:${w}px">${cnt}${cls}</div>`;
+    html += '<div class="fleet-config-item">';
+    html += '<div class="fleet-config-name"><strong>' + escapeHtml(cfg) + '</strong> <span class="fleet-config-meta">(' + data.count + ' aircraft, ' + (data.total || '?') + ' seats)</span></div>';
+    html += '<div class="config-gallery">';
+    if (data.seats) {
+      for (const [cls, cnt] of Object.entries(data.seats)) {
+        const w = Math.max(30, cnt / 2);
+        html += '<div class="config-block" style="background:' + (colors[cls]||'#475569') + ';width:' + w + 'px">' + cnt + cls + '</div>';
+      }
     }
-    html += `</div></div>`;
+    html += '</div></div>';
   }
 
   document.getElementById('config-display').innerHTML = html;
+  // Also show in Zone 3 seat config panel
+  document.getElementById('fleet-lookup-seat-config').innerHTML = html;
+}
+
+function showConfigEmpty() {
+  const emptyHtml = '<div class="fleet-config-empty" id="fleet-config-empty">' +
+    '<div class="fleet-config-empty-text">Select an aircraft type above to see cabin layout</div>' +
+    '<div class="fleet-config-quick-links">' +
+      '<span class="fleet-config-quick" data-action="filter-fleet-type" data-type="737-800">737-800</span>' +
+      '<span class="fleet-config-quick" data-action="filter-fleet-type" data-type="A321neo">A321neo</span>' +
+      '<span class="fleet-config-quick" data-action="filter-fleet-type" data-type="777-300ER">777-300ER</span>' +
+    '</div></div>';
+  document.getElementById('config-display').innerHTML = emptyHtml;
+  document.getElementById('fleet-lookup-seat-config').innerHTML = '';
+}
+
+function clearFleetFilters() {
+  document.getElementById('fleet-filter-type').value = '';
+  document.getElementById('fleet-filter-wifi').value = '';
+  document.getElementById('fleet-filter-status').value = '';
+  document.getElementById('fleet-search').value = '';
+  activeFleetType = '';
+  document.querySelectorAll('.variant-card').forEach(c => {
+    c.classList.remove('active');
+    c.setAttribute('aria-pressed', 'false');
+  });
+  showConfigEmpty();
+  renderFleetTable();
 }
 
 function renderAgeChart() {
@@ -2675,7 +2934,6 @@ function updateAnalytics() {
 // ═══ LIVE FLEET PANEL ═══
 function updateLiveFleetPanel() {
   if (!allFlights.length) return;
-  const airborne = [];
   const typeOrder = ["A319","A320","A321neo","737-700","737-800","737-900","737-900ER","737 MAX 8","737 MAX 9","757-200","757-300","767-300ER","767-400ER","777-200","777-200ER","777-300ER","787-8","787-9","787-10"];
   const typeCounts = {}; typeOrder.forEach(t => typeCounts[t] = { airborne: 0, total: 0 });
   FLEET_DB.forEach(a => { if (typeCounts[a.t]) typeCounts[a.t].total++; });
@@ -2687,50 +2945,51 @@ function updateLiveFleetPanel() {
     if (!ac) { unmatched++; return; }
     matched++;
     if (typeCounts[ac.t]) typeCounts[ac.t].airborne++;
-    // Use FR24's real route data
-    const routeStr = (f.origin || '???') + '→' + (f.dest || '???');
-    const phase = getPhase(f.alt, f.vr, f.spd);
-    const isStar = STARLINK_TAILS.has(ac.r) || STARLINK_TAILS.has(f.reg);
-    airborne.push({
-      reg: ac.r, type: ac.t,
-      flight: f.flightIATA || f.callsign,
-      route: routeStr,
-      alt: f.alt ? Math.round(f.alt * 3.28084).toLocaleString() + 'ft' : '--',
-      phase: phase.phase,
-      starlink: isStar
-    });
   });
-
-  airborne.sort((a, b) => a.type.localeCompare(b.type) || a.reg.localeCompare(b.reg));
 
   const totalAirborne = allFlights.filter(f => !f.onGround).length;
-  let html = `<div style="display:flex;align-items:center;gap:16px;margin-bottom:12px">`;
-  html += `<div><div class="big-number" style="display:flex;align-items:center;gap:8px"><span class="pulse-dot"></span>${totalAirborne}</div>`;
-  html += `<div class="big-number-label">${matched} matched to fleet DB · ${unmatched} regional/partner</div></div>`;
-  html += `</div>`;
 
-  html += `<div class="type-breakdown">`;
-  typeOrder.forEach(t => {
-    const d = typeCounts[t];
-    if (!d.total) return;
-    const pct = d.total > 0 ? Math.round(d.airborne / d.total * 100) : 0;
-    html += `<div class="type-bar"><span>${t}</span><span><span class="airborne">${d.airborne}</span><span class="total">/${d.total}</span> <span style="color:var(--ua-muted);font-size:9px">${pct}%</span></span></div>`;
-  });
-  html += `</div>`;
+  // Update Zone 1 left panel — airborne count
+  const countEl = document.getElementById('fleet-airborne-count');
+  if (countEl) countEl.textContent = totalAirborne;
 
-  if (airborne.length) {
-    html += `<div class="live-table-wrap"><table><thead><tr><th>Reg</th><th>Type</th><th>Flight</th><th>Route</th><th>Alt</th><th>Phase</th><th></th></tr></thead><tbody>`;
-    airborne.forEach(a => {
-      const sp = isSpecialAircraft(a.reg);
-      html += `<tr><td style="font-weight:700"><span class="ac-reg-link" data-action="aircraft-detail" data-reg="${escapeHtml(a.reg)}">${escapeHtml(a.reg)}</span>${sp ? ' <span class="special-badge">⭐</span>' : ''}</td><td>${escapeHtml(a.type)}</td><td>${escapeHtml(a.flight)}</td><td>${escapeHtml(a.route)}</td><td>${escapeHtml(a.alt)}</td><td>${escapeHtml(a.phase)}</td><td>${a.starlink ? '⚡' : ''}</td></tr>`;
-    });
-    html += `</tbody></table></div>`;
+  const subtitleEl = document.getElementById('fleet-pulse-subtitle');
+  if (subtitleEl) subtitleEl.textContent = matched + ' mainline matched · ' + unmatched + ' regional/partner';
+
+  // Fleet utilization percentage
+  const utilEl = document.getElementById('fleet-pulse-util');
+  if (utilEl && FLEET_DB.length > 0) {
+    const utilPct = Math.round(matched / FLEET_DB.length * 100);
+    utilEl.textContent = utilPct + '% fleet utilization (' + matched + '/' + FLEET_DB.length + ')';
   }
 
-  document.getElementById('fleet-live-content').innerHTML = html;
-  document.getElementById('fleet-live-time').textContent = 'Updated ' + new Date().toUTCString().slice(17, 25) + 'Z';
-  document.getElementById('live-fleet-panel').style.display = '';
+  // Per-type utilization bars
+  const utilBarsEl = document.getElementById('fleet-type-utilization');
+  if (utilBarsEl) {
+    let barsHtml = '';
+    typeOrder.forEach(t => {
+      const d = typeCounts[t];
+      if (!d.total || d.airborne === 0) return;
+      const pct = Math.round(d.airborne / d.total * 100);
+      barsHtml += '<div class="type-util-row">' +
+        '<span class="type-util-label">' + escapeHtml(t) + '</span>' +
+        '<div class="type-util-track"><div class="type-util-fill" style="width:' + pct + '%"></div></div>' +
+        '<span class="type-util-count">' + d.airborne + '/' + d.total + ' ' + pct + '%</span>' +
+      '</div>';
+    });
+    utilBarsEl.innerHTML = barsHtml;
+  }
+
+  // Update time
+  const timeEl = document.getElementById('fleet-live-time');
+  if (timeEl) timeEl.textContent = 'Updated ' + new Date().toUTCString().slice(17, 25) + 'Z';
+
+  // Update sub-tab counts and re-render special aircraft (may have airborne status changes)
+  updateFleetSubtabCounts();
   renderSpecialAircraftPanel();
+
+  // If currently viewing airborne tab, re-render it
+  if (activeFleetView === 'airborne') renderAirborneTable();
 }
 
 // ═══ WEATHER EXPLAINERS ═══
@@ -3621,14 +3880,7 @@ const ICAO_TO_FLEET_TYPE = {
 const CABIN_RANK = { 'J': 4, 'F': 3, 'PP': 2, 'PE': 2, 'E+': 1, 'Y': 0 };
 
 // WiFi display name normalization (raw data → clean labels)
-const WIFI_DISPLAY = {
-  'Sat KA': 'Satellite Ka', 'Satl Ka': 'Satellite Ka',
-  'Satl Ka US': 'Satellite Ka (US)',
-  'Satl KU': 'Satellite Ku', 'Satl Ku': 'Satellite Ku',
-  'ViaSatKA': 'ViaSat Ka',
-  'Starlink': 'Starlink', 'NO': 'NO'
-};
-function normalizeWifi(raw) { return WIFI_DISPLAY[raw] || raw; }
+// WIFI_DISPLAY and normalizeWifi imported from ../lib/fleet-utils.js
 
 // WiFi quality ranking: higher = better (uses normalized names)
 const WIFI_RANK = { 'Starlink': 3, 'ViaSat Ka': 2, 'Satellite Ka': 1, 'Satellite Ka (US)': 1, 'Satellite Ku': 1, 'NO': 0 };
@@ -5184,6 +5436,12 @@ document.addEventListener('click', function(e) {
     case 'filter-fleet-type':
       filterFleetType(actionEl.dataset.type);
       break;
+    case 'fleet-subtab':
+      switchFleetView(actionEl.dataset.view);
+      break;
+    case 'fleet-clear-filters':
+      clearFleetFilters();
+      break;
     case 'switch-tab':
       switchToTab(actionEl.dataset.tab);
       if (actionEl.dataset.closeGlobal) hideGlobalSearchResults();
@@ -5435,7 +5693,9 @@ async function initApp() {
     initFleetTab();
     var onboardingEl = document.getElementById('onboarding-overlay');
     if (acDeepLink && FLEET_DB.length > 0 && (!onboardingEl || onboardingEl.style.display === 'none')) setTimeout(function() { showAircraftDetail(acDeepLink); }, 500);
-    showConfigGallery('737-800');
+    // Show config for deep-linked type, otherwise show empty state
+    if (activeFleetType) showConfigGallery(activeFleetType);
+    else showConfigEmpty();
   };
   if (acDeepLink) {
     // Deep link needs fleet data now

--- a/src/lib/fleet-utils.js
+++ b/src/lib/fleet-utils.js
@@ -1,0 +1,132 @@
+// ═══ FLEET UTILITIES ═══
+// Pure data functions extracted from src/dashboard/main.js for testability.
+
+// ─── Fleet Health Categorization ───
+export const FLEET_HEALTH_CATEGORIES = [
+  { key: 'active',          label: 'Active',           color: '#22c55e' },
+  { key: 'maintenance',     label: 'Maintenance',      color: '#eab308' },
+  { key: 'stored',          label: 'Stored',            color: '#ef4444' },
+  { key: 'next_retrofit',   label: 'NEXT Retrofit',     color: '#8b5cf6' },
+  { key: 'painting',        label: 'Painting',          color: '#06b6d4' },
+  { key: 'starlink_install',label: 'Starlink Install',  color: '#10b981' },
+  { key: 'future_gum',      label: 'Future GUM',        color: '#f97316' }
+];
+
+export function categorizeFleetStatus(s) {
+  if (!s) return 'active';
+  if (s.startsWith('*')) return 'active';
+  if (/100 Year Sticker|Eco Demonstrator/i.test(s)) return 'active';
+  if (/stored/i.test(s)) return 'stored';
+  if (/\bpaint\b/i.test(s)) return 'painting';
+  if (/starlink/i.test(s)) return 'starlink_install';
+  if (/\bmod\s*next\b/i.test(s)) return 'next_retrofit';
+  if (/future\s*gum/i.test(s)) return 'future_gum';
+  if (/maint|induction/i.test(s)) return 'maintenance';
+  // Notes about NEXT status (Partial NEXT, NEXT???, Confirmed w.o NEXT) — aircraft is active
+  if (/next/i.test(s)) return 'active';
+  // Remaining non-empty statuses are likely maintenance at MRO locations
+  if (s.trim()) return 'maintenance';
+  return 'active';
+}
+
+// ─── Fleet Families ───
+export const FLEET_FAMILIES = [
+  { id: 'boeing-737', name: 'BOEING 737', role: 'Domestic backbone', subgroups: [
+    { label: 'NG', types: ['737-700','737-800','737-900','737-900ER'] },
+    { label: 'MAX', types: ['737 MAX 8','737 MAX 9'] }
+  ]},
+  { id: 'airbus-a320', name: 'A320 FAMILY', role: 'Domestic fleet', subgroups: [
+    { label: 'Legacy', types: ['A319','A320'] },
+    { label: 'Neo', types: ['A321neo'] }
+  ]},
+  { id: 'boeing-757', name: 'BOEING 757', role: 'Premium transcon & Hawaii', routeCallout: 'ORD-LAX · EWR-SFO · West Coast-HNL', subgroups: [
+    { label: null, types: ['757-200','757-300'] }
+  ]},
+  { id: 'boeing-767', name: 'BOEING 767', role: 'Transatlantic', routeCallout: 'EWR & IAD to Europe', widebody: true, subgroups: [
+    { label: null, types: ['767-300ER','767-400ER'] }
+  ]},
+  { id: 'boeing-777', name: 'BOEING 777', role: 'Flagship long-haul · Polaris', widebody: true, subgroups: [
+    { label: null, types: ['777-200','777-200ER','777-300ER'] }
+  ]},
+  { id: 'boeing-787', name: '787 DREAMLINER', role: 'Long-haul · newest widebody', widebody: true, subgroups: [
+    { label: null, types: ['787-8','787-9','787-10'] }
+  ]}
+];
+
+// ─── WiFi Normalization ───
+export const WIFI_DISPLAY = {
+  'Sat KA': 'Satellite Ka', 'Satl Ka': 'Satellite Ka',
+  'Satl Ka US': 'Satellite Ka (US)',
+  'Satl KU': 'Satellite Ku', 'Satl Ku': 'Satellite Ku',
+  'ViaSatKA': 'ViaSat Ka',
+  'Starlink': 'Starlink', 'NO': 'NO'
+};
+
+export function normalizeWifi(raw) {
+  return WIFI_DISPLAY[raw] || raw;
+}
+
+// ─── Fleet Sort ───
+// Numeric column keys that should be compared as integers
+const NUMERIC_SORT_COLS = new Set(['tot', 'd', 'a']);
+
+export function sortFleetData(data, sortCol, sortAsc) {
+  return [...data].sort((a, b) => {
+    let va = a[sortCol] || '', vb = b[sortCol] || '';
+    if (NUMERIC_SORT_COLS.has(sortCol)) {
+      va = parseInt(va) || 0;
+      vb = parseInt(vb) || 0;
+    }
+    return sortAsc ? (va > vb ? 1 : -1) : (va < vb ? 1 : -1);
+  });
+}
+
+// ─── Fleet Table Filtering ───
+export function filterFleetData(fleetDb, { type, wifi, status, search, starlinkTails, specialAircraftSet }) {
+  const searchUpper = search ? search.toUpperCase() : '';
+  return fleetDb.filter(a => {
+    if (type && a.t !== type) return false;
+    if (wifi && normalizeWifi(a.w) !== wifi) return false;
+    if (status === 'active' && a.s) return false;
+    if (status === 'stored' && !a.s) return false;
+    if (status === 'starlink' && !(starlinkTails && starlinkTails.has(a.r))) return false;
+    if (status === 'special' && !(specialAircraftSet && specialAircraftSet.has(a.r))) return false;
+    if (searchUpper && !a.r.toUpperCase().includes(searchUpper) && !a.c.toUpperCase().includes(searchUpper) && !a.t.toUpperCase().includes(searchUpper)) return false;
+    return true;
+  });
+}
+
+// ─── Deep Link Parsing ───
+export const TAB_MAP = {
+  'myflight': 'tab-myflight',
+  'live': 'tab-live',
+  'schedule': 'tab-schedule',
+  'fleet': 'tab-fleet',
+  'weather': 'tab-weather',
+  'irops': 'tab-weather',
+  'stats': 'tab-analytics',
+  'sources': 'tab-sources'
+};
+
+export const VALID_FLEET_VIEWS = ['starlink', 'airborne', 'special'];
+
+/**
+ * Parse fleet-related deep link parameters from a URL search string.
+ * Returns { tab, tabId, fleetFilter, fleetView } or null if no tab param found.
+ */
+export function parseFleetDeepLink(searchString) {
+  const params = new URLSearchParams(searchString);
+  const tab = params.get('tab');
+  if (!tab) return null;
+
+  const tabId = TAB_MAP[tab] || null;
+  const fleetFilter = params.get('type') || params.get('filter') || null;
+  const fleetView = params.get('view');
+
+  return {
+    tab,
+    tabId,
+    fleetFilter: tab === 'fleet' ? fleetFilter : null,
+    fleetView: (tab === 'fleet' && fleetView && VALID_FLEET_VIEWS.includes(fleetView)) ? fleetView : null,
+  };
+}

--- a/tests/fleet-tab.test.js
+++ b/tests/fleet-tab.test.js
@@ -1,0 +1,417 @@
+import { describe, it, expect } from 'vitest';
+import {
+  categorizeFleetStatus,
+  FLEET_HEALTH_CATEGORIES,
+  FLEET_FAMILIES,
+  normalizeWifi,
+  WIFI_DISPLAY,
+  sortFleetData,
+  filterFleetData,
+  parseFleetDeepLink,
+  TAB_MAP,
+  VALID_FLEET_VIEWS,
+} from '../src/lib/fleet-utils.js';
+
+// ═══════════════════════════════════════════════
+// 1. categorizeFleetStatus
+// ═══════════════════════════════════════════════
+describe('categorizeFleetStatus', () => {
+  it('returns "active" for null / undefined / empty string', () => {
+    expect(categorizeFleetStatus(null)).toBe('active');
+    expect(categorizeFleetStatus(undefined)).toBe('active');
+    expect(categorizeFleetStatus('')).toBe('active');
+  });
+
+  it('returns "active" for named aircraft (starts with *)', () => {
+    expect(categorizeFleetStatus('*Ship 1926*')).toBe('active');
+    expect(categorizeFleetStatus('*Our United Journey*')).toBe('active');
+  });
+
+  it('returns "active" for 100 Year Sticker livery', () => {
+    expect(categorizeFleetStatus('100 Year Sticker')).toBe('active');
+    expect(categorizeFleetStatus('100 year sticker')).toBe('active');
+  });
+
+  it('returns "active" for Eco Demonstrator', () => {
+    expect(categorizeFleetStatus('Eco Demonstrator Explorer')).toBe('active');
+    expect(categorizeFleetStatus('eco demonstrator')).toBe('active');
+  });
+
+  it('returns "stored" when status contains "stored"', () => {
+    expect(categorizeFleetStatus('Stored at VCV')).toBe('stored');
+    expect(categorizeFleetStatus('stored')).toBe('stored');
+    expect(categorizeFleetStatus('STORED')).toBe('stored');
+  });
+
+  it('returns "painting" when status contains "paint" as a word', () => {
+    expect(categorizeFleetStatus('In paint shop')).toBe('painting');
+    expect(categorizeFleetStatus('Paint')).toBe('painting');
+    // "repaint" should NOT match because \bpaint\b requires word boundary
+    expect(categorizeFleetStatus('repaint')).not.toBe('painting');
+  });
+
+  it('returns "starlink_install" when status contains "starlink"', () => {
+    expect(categorizeFleetStatus('Starlink install')).toBe('starlink_install');
+    expect(categorizeFleetStatus('Getting STARLINK mod')).toBe('starlink_install');
+  });
+
+  it('returns "next_retrofit" for "mod next" statuses', () => {
+    expect(categorizeFleetStatus('Mod NEXT retrofit')).toBe('next_retrofit');
+    expect(categorizeFleetStatus('MOD NEXT')).toBe('next_retrofit');
+    expect(categorizeFleetStatus('mod next')).toBe('next_retrofit');
+  });
+
+  it('returns "future_gum" when status contains "future gum"', () => {
+    expect(categorizeFleetStatus('Future GUM delivery')).toBe('future_gum');
+    expect(categorizeFleetStatus('future gum')).toBe('future_gum');
+  });
+
+  it('returns "maintenance" for maint or induction statuses', () => {
+    expect(categorizeFleetStatus('Heavy maint at TPA')).toBe('maintenance');
+    expect(categorizeFleetStatus('Induction check')).toBe('maintenance');
+    expect(categorizeFleetStatus('MAINT')).toBe('maintenance');
+  });
+
+  it('returns "active" for NEXT notes that are not "mod next"', () => {
+    expect(categorizeFleetStatus('Partial NEXT')).toBe('active');
+    expect(categorizeFleetStatus('NEXT???')).toBe('active');
+    expect(categorizeFleetStatus('Confirmed w.o NEXT')).toBe('active');
+  });
+
+  it('returns "maintenance" for other non-empty strings (MRO locations)', () => {
+    expect(categorizeFleetStatus('TPA')).toBe('maintenance');
+    expect(categorizeFleetStatus('SAN check')).toBe('maintenance');
+    expect(categorizeFleetStatus('HGR')).toBe('maintenance');
+  });
+
+  it('returns "active" for whitespace-only strings', () => {
+    expect(categorizeFleetStatus('   ')).toBe('active');
+  });
+});
+
+// ═══════════════════════════════════════════════
+// 2. FLEET_FAMILIES — deriving counts from a mock fleet
+// ═══════════════════════════════════════════════
+describe('FLEET_FAMILIES structure and count derivation', () => {
+  const MOCK_FLEET = [
+    { r: 'N101UA', t: '737-800', c: '160/Y', w: 'Starlink', s: '' },
+    { r: 'N102UA', t: '737-800', c: '160/Y', w: 'Starlink', s: '' },
+    { r: 'N103UA', t: '737 MAX 9', c: '179/Y', w: 'Starlink', s: '' },
+    { r: 'N201UA', t: 'A321neo', c: '196/Y', w: 'Starlink', s: '' },
+    { r: 'N301UA', t: '787-9', c: '257/J+PY+Y', w: 'ViaSatKA', s: '' },
+    { r: 'N302UA', t: '787-10', c: '318/J+PY+Y', w: 'ViaSatKA', s: '' },
+    { r: 'N401UA', t: '777-300ER', c: '366/J+PY+Y', w: 'Satl Ka', s: '' },
+  ];
+
+  it('has 6 families covering all mainline fleet types', () => {
+    expect(FLEET_FAMILIES).toHaveLength(6);
+    const allTypes = FLEET_FAMILIES.flatMap(f => f.subgroups.flatMap(sg => sg.types));
+    // Every type in the mock fleet should exist in FLEET_FAMILIES
+    MOCK_FLEET.forEach(a => {
+      expect(allTypes).toContain(a.t);
+    });
+  });
+
+  it('correctly derives family totals from a mock fleet', () => {
+    const typeCounts = {};
+    MOCK_FLEET.forEach(a => { typeCounts[a.t] = (typeCounts[a.t] || 0) + 1; });
+
+    const familyTotals = FLEET_FAMILIES.map(family => {
+      const total = family.subgroups.reduce((sum, sg) =>
+        sum + sg.types.reduce((s, t) => s + (typeCounts[t] || 0), 0), 0);
+      return { id: family.id, total };
+    });
+
+    expect(familyTotals.find(f => f.id === 'boeing-737').total).toBe(3);  // 2x 737-800 + 1x MAX 9
+    expect(familyTotals.find(f => f.id === 'airbus-a320').total).toBe(1); // 1x A321neo
+    expect(familyTotals.find(f => f.id === 'boeing-787').total).toBe(2);  // 1x 787-9 + 1x 787-10
+    expect(familyTotals.find(f => f.id === 'boeing-777').total).toBe(1);  // 1x 777-300ER
+    expect(familyTotals.find(f => f.id === 'boeing-757').total).toBe(0);  // none in mock
+    expect(familyTotals.find(f => f.id === 'boeing-767').total).toBe(0);  // none in mock
+  });
+
+  it('correctly derives subgroup totals', () => {
+    const typeCounts = {};
+    MOCK_FLEET.forEach(a => { typeCounts[a.t] = (typeCounts[a.t] || 0) + 1; });
+
+    const boeing737 = FLEET_FAMILIES.find(f => f.id === 'boeing-737');
+    const ngCount = boeing737.subgroups.find(sg => sg.label === 'NG').types.reduce((s, t) => s + (typeCounts[t] || 0), 0);
+    const maxCount = boeing737.subgroups.find(sg => sg.label === 'MAX').types.reduce((s, t) => s + (typeCounts[t] || 0), 0);
+    expect(ngCount).toBe(2);  // 2x 737-800
+    expect(maxCount).toBe(1); // 1x MAX 9
+  });
+
+  it('marks widebody families correctly', () => {
+    const widebodies = FLEET_FAMILIES.filter(f => f.widebody);
+    const widebodyIds = widebodies.map(f => f.id);
+    expect(widebodyIds).toContain('boeing-767');
+    expect(widebodyIds).toContain('boeing-777');
+    expect(widebodyIds).toContain('boeing-787');
+    expect(widebodyIds).not.toContain('boeing-737');
+    expect(widebodyIds).not.toContain('airbus-a320');
+  });
+});
+
+// ═══════════════════════════════════════════════
+// 3. sortFleetData
+// ═══════════════════════════════════════════════
+describe('sortFleetData', () => {
+  const MOCK = [
+    { r: 'N103UA', t: '737 MAX 9', d: '2023', tot: '150' },
+    { r: 'N101UA', t: '737-800',   d: '2015', tot: '320' },
+    { r: 'N102UA', t: '737-800',   d: '2019', tot: '210' },
+  ];
+
+  it('sorts strings ascending (registration column)', () => {
+    const sorted = sortFleetData(MOCK, 'r', true);
+    expect(sorted.map(a => a.r)).toEqual(['N101UA', 'N102UA', 'N103UA']);
+  });
+
+  it('sorts strings descending (registration column)', () => {
+    const sorted = sortFleetData(MOCK, 'r', false);
+    expect(sorted.map(a => a.r)).toEqual(['N103UA', 'N102UA', 'N101UA']);
+  });
+
+  it('sorts numeric columns ascending (total seats)', () => {
+    const sorted = sortFleetData(MOCK, 'tot', true);
+    expect(sorted.map(a => a.tot)).toEqual(['150', '210', '320']);
+  });
+
+  it('sorts numeric columns descending (total seats)', () => {
+    const sorted = sortFleetData(MOCK, 'tot', false);
+    expect(sorted.map(a => a.tot)).toEqual(['320', '210', '150']);
+  });
+
+  it('sorts delivery year as numeric', () => {
+    const sorted = sortFleetData(MOCK, 'd', true);
+    expect(sorted.map(a => a.d)).toEqual(['2015', '2019', '2023']);
+  });
+
+  it('does not mutate the original array', () => {
+    const original = [...MOCK];
+    sortFleetData(MOCK, 'r', true);
+    expect(MOCK).toEqual(original);
+  });
+
+  it('handles missing values gracefully', () => {
+    const data = [
+      { r: 'N100UA', tot: '' },
+      { r: 'N200UA', tot: '120' },
+      { r: 'N300UA' },
+    ];
+    const sorted = sortFleetData(data, 'tot', true);
+    // empty/missing parse to 0, then 120
+    expect(sorted[0].tot ?? '').toBeFalsy();
+    expect(sorted[sorted.length - 1].tot).toBe('120');
+  });
+});
+
+// ═══════════════════════════════════════════════
+// 4. parseFleetDeepLink
+// ═══════════════════════════════════════════════
+describe('parseFleetDeepLink', () => {
+  it('returns null when no tab param is present', () => {
+    expect(parseFleetDeepLink('')).toBeNull();
+    expect(parseFleetDeepLink('?foo=bar')).toBeNull();
+  });
+
+  it('maps ?tab=fleet to tab-fleet', () => {
+    const result = parseFleetDeepLink('?tab=fleet');
+    expect(result.tab).toBe('fleet');
+    expect(result.tabId).toBe('tab-fleet');
+  });
+
+  it('maps ?tab=fleet&view=starlink to starlink sub-tab', () => {
+    const result = parseFleetDeepLink('?tab=fleet&view=starlink');
+    expect(result.fleetView).toBe('starlink');
+  });
+
+  it('maps ?tab=fleet&view=airborne to airborne sub-tab', () => {
+    const result = parseFleetDeepLink('?tab=fleet&view=airborne');
+    expect(result.fleetView).toBe('airborne');
+  });
+
+  it('maps ?tab=fleet&view=special to special sub-tab', () => {
+    const result = parseFleetDeepLink('?tab=fleet&view=special');
+    expect(result.fleetView).toBe('special');
+  });
+
+  it('rejects invalid fleet views', () => {
+    const result = parseFleetDeepLink('?tab=fleet&view=invalid');
+    expect(result.fleetView).toBeNull();
+  });
+
+  it('maps ?tab=fleet&type=737-800 to the type filter', () => {
+    const result = parseFleetDeepLink('?tab=fleet&type=737-800');
+    expect(result.fleetFilter).toBe('737-800');
+  });
+
+  it('uses ?filter= as fallback when ?type= is absent', () => {
+    const result = parseFleetDeepLink('?tab=fleet&filter=stored');
+    expect(result.fleetFilter).toBe('stored');
+  });
+
+  it('prefers ?type= over ?filter= when both are present', () => {
+    const result = parseFleetDeepLink('?tab=fleet&type=A321neo&filter=stored');
+    expect(result.fleetFilter).toBe('A321neo');
+  });
+
+  it('handles combined params: type + view', () => {
+    const result = parseFleetDeepLink('?tab=fleet&type=787-9&view=starlink');
+    expect(result.fleetFilter).toBe('787-9');
+    expect(result.fleetView).toBe('starlink');
+    expect(result.tabId).toBe('tab-fleet');
+  });
+
+  it('ignores fleet-specific params for non-fleet tabs', () => {
+    const result = parseFleetDeepLink('?tab=weather&type=737-800&view=starlink');
+    expect(result.tab).toBe('weather');
+    expect(result.tabId).toBe('tab-weather');
+    expect(result.fleetFilter).toBeNull();
+    expect(result.fleetView).toBeNull();
+  });
+
+  it('returns null tabId for unknown tab values', () => {
+    const result = parseFleetDeepLink('?tab=nonexistent');
+    expect(result.tabId).toBeNull();
+  });
+
+  it('maps known tabs correctly', () => {
+    expect(parseFleetDeepLink('?tab=live').tabId).toBe('tab-live');
+    expect(parseFleetDeepLink('?tab=schedule').tabId).toBe('tab-schedule');
+    expect(parseFleetDeepLink('?tab=irops').tabId).toBe('tab-weather');
+    expect(parseFleetDeepLink('?tab=stats').tabId).toBe('tab-analytics');
+    expect(parseFleetDeepLink('?tab=sources').tabId).toBe('tab-sources');
+  });
+});
+
+// ═══════════════════════════════════════════════
+// 5. filterFleetData
+// ═══════════════════════════════════════════════
+describe('filterFleetData', () => {
+  const MOCK_FLEET = [
+    { r: 'N101UA', t: '737-800', c: '160/Y', w: 'Starlink', s: '',          i: 'AVOD' },
+    { r: 'N102UA', t: '737-800', c: '160/Y', w: 'Sat KA',   s: 'Stored at VCV', i: 'PDE' },
+    { r: 'N103UA', t: '737 MAX 9', c: '179/Y', w: 'Starlink', s: '',        i: 'AVOD' },
+    { r: 'N201UA', t: 'A321neo', c: '196/Y', w: 'Starlink', s: '',          i: 'AVOD' },
+    { r: 'N301UA', t: '787-9',  c: '257/J+PY+Y', w: 'ViaSatKA', s: 'Heavy maint', i: 'AVOD' },
+    { r: 'N401UA', t: '777-300ER', c: '366/J+PY+Y', w: 'Satl Ka', s: '', i: 'AVOD' },
+  ];
+
+  const starlinkTails = new Set(['N101UA', 'N103UA', 'N201UA']);
+  const specialAircraftSet = new Set(['N101UA']);
+
+  it('returns all aircraft when no filters are set', () => {
+    const result = filterFleetData(MOCK_FLEET, {});
+    expect(result).toHaveLength(6);
+  });
+
+  it('filters by type', () => {
+    const result = filterFleetData(MOCK_FLEET, { type: '737-800' });
+    expect(result).toHaveLength(2);
+    expect(result.every(a => a.t === '737-800')).toBe(true);
+  });
+
+  it('filters by WiFi (normalized)', () => {
+    const result = filterFleetData(MOCK_FLEET, { wifi: 'Starlink' });
+    expect(result).toHaveLength(3); // N101UA, N103UA, N201UA
+    expect(result.every(a => normalizeWifi(a.w) === 'Starlink')).toBe(true);
+  });
+
+  it('filters by WiFi using non-normalized input that matches after normalizing', () => {
+    // 'ViaSat Ka' is the normalized form of 'ViaSatKA'
+    const result = filterFleetData(MOCK_FLEET, { wifi: 'ViaSat Ka' });
+    expect(result).toHaveLength(1);
+    expect(result[0].r).toBe('N301UA');
+  });
+
+  it('filters by status "active" (only aircraft with empty/null status)', () => {
+    const result = filterFleetData(MOCK_FLEET, { status: 'active' });
+    // Active = no status string set
+    expect(result.every(a => !a.s)).toBe(true);
+    expect(result).toHaveLength(4);
+  });
+
+  it('filters by status "stored" (only aircraft with non-empty status)', () => {
+    const result = filterFleetData(MOCK_FLEET, { status: 'stored' });
+    // "stored" filter in the original code means: only show aircraft that HAVE a status
+    expect(result.every(a => !!a.s)).toBe(true);
+    expect(result).toHaveLength(2); // N102UA (Stored at VCV) and N301UA (Heavy maint)
+  });
+
+  it('filters by status "starlink" using provided starlinkTails set', () => {
+    const result = filterFleetData(MOCK_FLEET, { status: 'starlink', starlinkTails });
+    expect(result).toHaveLength(3);
+    expect(result.map(a => a.r).sort()).toEqual(['N101UA', 'N103UA', 'N201UA']);
+  });
+
+  it('filters by status "special" using provided specialAircraftSet', () => {
+    const result = filterFleetData(MOCK_FLEET, { status: 'special', specialAircraftSet });
+    expect(result).toHaveLength(1);
+    expect(result[0].r).toBe('N101UA');
+  });
+
+  it('filters by search string (case-insensitive, matches reg/config/type)', () => {
+    const result = filterFleetData(MOCK_FLEET, { search: 'n101' });
+    expect(result).toHaveLength(1);
+    expect(result[0].r).toBe('N101UA');
+  });
+
+  it('search matches aircraft type', () => {
+    const result = filterFleetData(MOCK_FLEET, { search: 'MAX' });
+    expect(result).toHaveLength(1);
+    expect(result[0].t).toBe('737 MAX 9');
+  });
+
+  it('search matches configuration string', () => {
+    const result = filterFleetData(MOCK_FLEET, { search: '366' });
+    expect(result).toHaveLength(1);
+    expect(result[0].r).toBe('N401UA');
+  });
+
+  it('combines type + WiFi filters', () => {
+    const result = filterFleetData(MOCK_FLEET, { type: '737-800', wifi: 'Starlink' });
+    expect(result).toHaveLength(1);
+    expect(result[0].r).toBe('N101UA');
+  });
+
+  it('combines type + search filters', () => {
+    const result = filterFleetData(MOCK_FLEET, { type: '737-800', search: 'N102' });
+    expect(result).toHaveLength(1);
+    expect(result[0].r).toBe('N102UA');
+  });
+
+  it('returns empty array when no aircraft match', () => {
+    const result = filterFleetData(MOCK_FLEET, { type: 'A380' });
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns empty starlink filter results when no starlinkTails provided', () => {
+    const result = filterFleetData(MOCK_FLEET, { status: 'starlink' });
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ═══════════════════════════════════════════════
+// Bonus: normalizeWifi
+// ═══════════════════════════════════════════════
+describe('normalizeWifi', () => {
+  it('normalizes known abbreviations', () => {
+    expect(normalizeWifi('Sat KA')).toBe('Satellite Ka');
+    expect(normalizeWifi('Satl Ka')).toBe('Satellite Ka');
+    expect(normalizeWifi('Satl Ka US')).toBe('Satellite Ka (US)');
+    expect(normalizeWifi('Satl KU')).toBe('Satellite Ku');
+    expect(normalizeWifi('Satl Ku')).toBe('Satellite Ku');
+    expect(normalizeWifi('ViaSatKA')).toBe('ViaSat Ka');
+  });
+
+  it('passes through already-normalized values', () => {
+    expect(normalizeWifi('Starlink')).toBe('Starlink');
+    expect(normalizeWifi('NO')).toBe('NO');
+  });
+
+  it('returns the raw value if not in the lookup table', () => {
+    expect(normalizeWifi('Unknown Wifi')).toBe('Unknown Wifi');
+    expect(normalizeWifi('')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Redesigns the Fleet tab from 7 flat same-weight cards into 3 clear visual zones with information hierarchy. Fixes a CSS bug that collapsed the Live Fleet Status panel, replaces 19 emoji-based type chips with 6 aviation-expert family groupings (Boeing 737 NG/MAX, A320 Legacy/Neo, 757, 767, 777, 787 Dreamliner), and merges the Aircraft Database, Starlink Tracker, and Special Aircraft into a unified lookup with sub-tabs.

- **Zone 1 (Fleet Pulse):** Side-by-side live airborne count + fleet health bars
- **Zone 2 (Fleet Composition):** Family-grouped variant cards with route callouts
- **Zone 3 (Aircraft Lookup):** Sub-tabs (All Aircraft | Airborne Now | Starlink | Special) with shared filters
- **55 new unit tests** for extracted fleet utilities (`src/lib/fleet-utils.js`)

## Test plan

- [ ] Verify Zone 1 renders health bars immediately, live data populates when flights load
- [ ] Click variant cards in Zone 2 → Zone 3 filters and shows seat config
- [ ] Switch between sub-tabs in Zone 3 (All Aircraft, Airborne Now, Starlink, Special)
- [ ] Deep link `?tab=fleet&type=A321neo` shows correct config and table filter
- [ ] Deep link `?tab=fleet&view=starlink` opens Starlink sub-tab
- [ ] Mobile responsive at 375px width — zones stack, sub-tabs scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)