### PR TITLE
fix: address 9 critical codex review findings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,3 +16,4 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm test
+      - run: npm run build

--- a/api/delay-explain.ts
+++ b/api/delay-explain.ts
@@ -41,7 +41,7 @@ function sanitize(val: string | undefined, maxLen: number): string {
 function getCacheKey(ctx: DelayContext): string {
   const inboundKey = ctx.inbound ? ctx.inbound.slice(0, 100) : '';
   const weatherKey = (ctx.weather || '').slice(0, 40) + '|' + (ctx.destWeather || '').slice(0, 40);
-  return `${ctx.flight}:${ctx.riskScore}:${(ctx.factors || []).join(',')}:${inboundKey}:${weatherKey}`;
+  return `${ctx.flight}:${ctx.route || ''}:${ctx.status || ''}:${ctx.riskScore}:${(ctx.factors || []).join(',')}:${ctx.otp || ''}:${ctx.hub || ''}:${ctx.irops || ''}:${inboundKey}:${weatherKey}`;
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -50,7 +50,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   const origin = req.headers?.origin || '';
-  if (origin && origin !== 'https://theblueboard.co' && !/^http:\/\/localhost(:\d+)?$/.test(origin)) {
+  const referer = req.headers?.referer || '';
+  // Require a valid origin or referer — blocks direct curl/non-browser abuse
+  const isAllowedOrigin = origin === 'https://theblueboard.co' || /^http:\/\/localhost(:\d+)?$/.test(origin);
+  const isAllowedReferer = referer.startsWith('https://theblueboard.co/') || /^http:\/\/localhost(:\d+)?\//.test(referer);
+  if (!isAllowedOrigin && !isAllowedReferer) {
     return res.status(403).json({ error: 'Forbidden' });
   }
 

--- a/api/irops.ts
+++ b/api/irops.ts
@@ -134,14 +134,33 @@ export function computeMetrics(flightsByHub: Record<string, any[]>) {
 export function getStartOfDayForHub(hub: string): number {
   const tz = HUB_TZ[hub] || 'America/New_York';
   const now = new Date();
-  const parts = new Intl.DateTimeFormat('en-US', {
+  const fmt = new Intl.DateTimeFormat('en-US', {
     timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit',
     hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false
-  }).formatToParts(now);
+  });
+  const parts = fmt.formatToParts(now);
   const get = (type: string) => parseInt(parts.find(p => p.type === type)?.value || '0');
   const hour = get('hour'), minute = get('minute'), second = get('second');
-  const secondsSinceMidnight = hour * 3600 + minute * 60 + second;
-  const startOfToday = Math.floor((now.getTime() / 1000) - secondsSinceMidnight);
+
+  // DST-safe midnight calculation: compute an approximate midnight, then verify
+  // and adjust. The naive formula (now - localSecondsSinceMidnight) can be off by
+  // ±1 hour across DST transitions because the UTC offset at midnight may differ
+  // from the current offset.
+  const localSecsSinceMidnight = hour * 3600 + minute * 60 + second;
+  const approxMidnight = Math.floor(now.getTime() / 1000) - localSecsSinceMidnight;
+
+  // Verify: what local time does our guess correspond to?
+  const verifyParts = fmt.formatToParts(new Date(approxMidnight * 1000));
+  const vH = parseInt(verifyParts.find(p => p.type === 'hour')?.value || '0');
+  const vM = parseInt(verifyParts.find(p => p.type === 'minute')?.value || '0');
+  const vS = parseInt(verifyParts.find(p => p.type === 'second')?.value || '0');
+  const drift = vH * 3600 + vM * 60 + vS;
+
+  // Correct for DST drift (typically ±3600s on transition days)
+  const startOfToday = drift > 43200
+    ? approxMidnight + (86400 - drift)  // Went past midnight into previous day
+    : approxMidnight - drift;            // Fine-tune forward to exact midnight
+
   // Before 6 AM local: no flights have departed yet, show yesterday's data
   if (hour < 6) return startOfToday - 86400;
   return startOfToday;

--- a/api/news-notify.ts
+++ b/api/news-notify.ts
@@ -24,6 +24,23 @@ import { supabase } from './_supabase.js';
 const FROM_ADDRESS = 'Jonah @ The Blue Board <hello@theblueboard.co>';
 const BASE_URL = 'https://theblueboard.co';
 
+/** Rollback a claimed slug to the previous value so future attempts can retry */
+async function rollbackClaim(previousSlug: string | undefined) {
+  try {
+    if (previousSlug) {
+      await supabase
+        .from('news_notifications')
+        .update({ slug: previousSlug, sent_at: new Date().toISOString() })
+        .eq('key', 'last_sent');
+    } else {
+      // First-run case: delete the row so the next attempt starts fresh
+      await supabase.from('news_notifications').delete().eq('key', 'last_sent');
+    }
+  } catch (e) {
+    console.error('news-notify: rollback failed (manual intervention may be needed):', e);
+  }
+}
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
@@ -127,11 +144,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     });
 
     if (createErr || !broadcast?.id) {
+      // Rollback claim so future attempts can retry
+      await rollbackClaim(existing?.slug);
       throw new Error(`Broadcast create failed: ${createErr?.message || 'no broadcast ID returned'}`);
     }
 
     const { error: sendErr } = await resend.broadcasts.send(broadcast.id);
     if (sendErr) {
+      // Rollback claim so future attempts can retry
+      await rollbackClaim(existing?.slug);
       throw new Error(`Broadcast send failed: ${sendErr.message}`);
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -151,14 +151,14 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
 </div>
 
 <!-- HUB HEALTH BAR -->
-<div id="hub-health-bar" aria-live="polite" title="On-Time Performance: % of operated flights departing within 30 min of schedule. 🟢 >70% · 🟡 50-70% · 🔴 <50%"><span class="hh-label">Hub Health</span><span class="hh-explainer">ON-TIME %</span><span class="hh-info">?<span class="hh-tooltip">% of operated flights departing within 30 min of schedule. 🟢 &gt;70% · 🟡 50–70% · 🔴 &lt;50%</span></span><span style="color:var(--ua-muted)">Loading…</span></div>
+<div id="hub-health-bar" aria-live="polite" title="On-Time Performance: % of operated flights within 30 min of schedule (departures + arrivals). 🟢 >70% · 🟡 50-70% · 🔴 <50%"><span class="hh-label">Hub Health</span><span class="hh-explainer">ON-TIME %</span><span class="hh-info">?<span class="hh-tooltip">% of operated flights within 30 min of schedule (departures &amp; arrivals). 🟢 &gt;70% · 🟡 50–70% · 🔴 &lt;50%</span></span><span style="color:var(--ua-muted)">Loading…</span></div>
 
 <!-- TIP STRIP -->
 <div id="tip-strip" style="display:none"><span class="tip-badge">Tip</span><span class="tip-text" id="tip-text"></span><button class="tip-dismiss" data-action="dismiss-tips" aria-label="Dismiss tips">&times;</button></div>
 
 <!-- WATCH NOTIFICATION BANNER -->
 <div id="watch-notification" aria-live="polite" role="status"><span id="wn-text"></span><button class="wn-dismiss" data-action="dismiss-watch-notification">Dismiss</button></div>
-<div id="push-prompt">🔔 Get push alerts for watched flights?<div style="display:flex;gap:6px"><button class="pp-enable" data-action="enable-push">Enable</button><button class="pp-dismiss" data-action="dismiss-push">No thanks</button></div></div>
+<div id="push-prompt">🔔 Get desktop notifications for watched flights?<div style="display:flex;gap:6px"><button class="pp-enable" data-action="enable-push">Enable</button><button class="pp-dismiss" data-action="dismiss-push">No thanks</button></div></div>
 
 <!-- HEADER -->
 <div id="header">

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -2751,6 +2751,67 @@ async function initWeatherTab() {
     }, {root: document.getElementById('wx-detail-panel'), threshold: 0.1});
     observer.observe(document.getElementById('hub-cards'));
   }
+
+  // Refresh weather + FAA data every 5 minutes so the tab stays current
+  setInterval(async () => {
+    try {
+      const [newMetar, newFaa] = await Promise.allSettled([
+        fetchMetarBatch(allStations),
+        fetch('/api/faa').then(r => r.ok ? r.json() : Promise.reject(new Error(`faa-${r.status}`)))
+      ]);
+      const freshMetar = newMetar.status === 'fulfilled' ? newMetar.value : [];
+      const freshFaa = newFaa.status === 'fulfilled' ? newFaa.value : [];
+      if (!Array.isArray(freshMetar) || freshMetar.length === 0) return;
+
+      // Rebuild METAR index
+      const freshMetarByHub = {};
+      freshMetar.forEach(m => {
+        const h = stationToHub[m.icaoId || m.stationId] || stationToHub[m.id];
+        if (h) freshMetarByHub[h] = m;
+      });
+
+      // Rebuild FAA index
+      const freshFaaIndex = {};
+      if (Array.isArray(freshFaa)) freshFaa.forEach(d => {
+        const code = d.airportCode || d.airport;
+        if (!code) return;
+        if (!freshFaaIndex[code]) freshFaaIndex[code] = { delays: [] };
+        freshFaaIndex[code].delays.push(...(d.delays || []));
+        if (d.type === 'ground_stop') freshFaaIndex[code].groundStop = true;
+        else if (d.type === 'ground_delay') { freshFaaIndex[code].groundDelay = true; freshFaaIndex[code].avgDelay = d.avgDelay; }
+        else if (d.type === 'departure_delay') { freshFaaIndex[code].departureDelay = true; freshFaaIndex[code].minDelay = d.minDelay; freshFaaIndex[code].maxDelay = d.maxDelay; }
+        else if (d.type === 'arrival_delay') { freshFaaIndex[code].arrivalDelay = true; }
+        else if (d.type === 'closure') freshFaaIndex[code].closure = true;
+      });
+      faaDelayIndex = freshFaaIndex;
+
+      // Update weatherOpsByHub + hub card colors/statuses
+      hubs.forEach(hub => {
+        const data = freshMetarByHub[hub];
+        if (!data) return;
+        const raw = data.rawOb || '';
+        const apiCat = data.fltCat || data.fltcat || 'UNK';
+        const localCat = computeFlightCategory(raw);
+        const catRank = {LIFR:0,IFR:1,MVFR:2,VFR:3,UNK:3};
+        const cat = localCat && (catRank[localCat] ?? 3) < (catRank[apiCat] ?? 3) ? localCat : apiCat;
+        const ops = computeOpsImpact(raw, cat);
+        weatherOpsByHub[hub] = { level: ops.level, reasons: ops.reasons, fltCat: cat,
+          hasThunderstorms: ops.hasThunderstorms, hasFreezingPrecip: ops.hasFreezingPrecip,
+          hasSnow: ops.hasSnow, hasFog: ops.hasFog, gustKt: ops.gustKt || 0, tempC: ops.tempC };
+        // Update radar hub marker color
+        if (radarHubMarkers[hub]) {
+          const catColor = CAT_COLORS[cat] || '#64748b';
+          const borderColor = ops.level !== 'normal' ? ops.color : catColor;
+          radarHubMarkers[hub].setStyle({color: borderColor, fillColor: borderColor});
+        }
+      });
+      // Update radar timestamp
+      const radarTitle = document.getElementById('radar-title');
+      if (radarTitle) radarTitle.textContent = `🌧 NEXRAD Radar — ${new Date().toUTCString().slice(17,25)}Z`;
+    } catch (e) {
+      console.warn('Weather refresh failed:', e);
+    }
+  }, 5 * 60 * 1000);
 }
 
 // ═══ ANALYTICS TAB ═══
@@ -3503,10 +3564,11 @@ function getFilteredScheduleFlights() {
     if (riskFilter) {
       const status = classifySchedStatus(fl);
       if (['scheduled', 'estimated', 'delayed'].includes(status.key)) {
-        const risk = computeDelayRisk(fl, schedCurrentHub);
-        if (riskFilter === 'high' && risk.label !== 'HIGH') return false;
-        if (riskFilter === 'moderate' && risk.label === 'LOW') return false;
-        if (riskFilter === 'low' && risk.label !== 'LOW') return false;
+        const risk = computeDelayRiskForScheduleFlight(fl, schedCurrentHub);
+        const riskLabel = risk ? risk.label : 'LOW';
+        if (riskFilter === 'high' && riskLabel !== 'HIGH') return false;
+        if (riskFilter === 'moderate' && riskLabel === 'LOW') return false;
+        if (riskFilter === 'low' && riskLabel !== 'LOW') return false;
       } else if (riskFilter === 'high' || riskFilter === 'moderate') {
         return false;
       }

--- a/src/pages/fleet/index.astro
+++ b/src/pages/fleet/index.astro
@@ -273,7 +273,7 @@ p{margin-bottom:12px}
     <div class="stat-card"><div class="val">1,078</div><div class="label">Mainline Aircraft</div></div>
     <div class="stat-card"><div class="val">19</div><div class="label">Aircraft Types</div></div>
     <div class="stat-card"><div class="val">258</div><div class="label">Starlink Equipped</div></div>
-    <div class="stat-card"><div class="val">96</div><div class="label">Widebody Aircraft</div></div>
+    <div class="stat-card"><div class="val">230</div><div class="label">Widebody Aircraft</div></div>
   </div>
 
   <!-- AIRCRAFT TYPE GUIDES -->


### PR DESCRIPTION
## Summary

Full codex audit of the project surfaced 9 critical (P1) findings. This PR fixes all of them:

- **Security:** update
- **Data correctness:** Fleet page widebody count fixed from 96 (just 777s) to 230 (777+787+767). Delay-risk filter was calling the wrong scorer function (`computeDelayRisk` instead of `computeDelayRiskForScheduleFlight`), causing silent null-deref crashes — now fixed with null guard.
- **Reliability:** `getStartOfDayForHub` is now DST-safe via verify-and-adjust pattern. Weather tab refreshes METAR/FAA data every 5 minutes instead of being one-shot. CI workflow now runs `npm run build` to catch Astro/Vite build breaks.
- **Labels:** Hub health tooltip clarified to say "departures & arrivals" (matching actual behavior). "Push alerts" renamed to "desktop notifications" (honest about what `Notification` API does).

## Test plan
- [x] All 61 existing tests pass (delay-risk, fleet-tab, faa)
- [ ] Verify delay-risk filter dropdown works on schedule tab
- [ ] Verify weather tab updates after 5 minutes
- [ ] Verify delay-explain modal still opens from dashboard
- [ ] Check fleet page shows "230 Widebody Aircraft"

🤖 Generated with [Claude Code](https://claude.com/claude-code)