### PR TITLE
Mobile UX polish: weather, popups, icons, supporters

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -82,8 +82,10 @@ main{flex:1;min-height:0;display:flex;flex-direction:column;overflow:hidden}
 .leaflet-popup-content-wrapper{background:rgba(17,24,39,.96)!important;color:var(--ua-text)!important;border:1px solid var(--ua-border)!important;border-radius:8px!important;box-shadow:0 8px 32px rgba(0,0,0,.6)!important;backdrop-filter:blur(12px)!important;font-family:var(--mono)!important}
 .leaflet-popup-tip{background:rgba(17,24,39,.96)!important}
 .leaflet-popup-content{margin:0!important;font-size:11px!important;min-width:280px!important}
+.leaflet-popup-close-button{top:4px!important;right:4px!important;font-size:18px!important;color:var(--ua-muted)!important;width:44px!important;height:44px!important;display:flex!important;align-items:center;justify-content:center;z-index:10}
+.leaflet-popup-close-button:hover{color:var(--ua-text)!important}
 .popup-card{padding:12px}
-.popup-header{display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:8px;padding-bottom:8px;border-bottom:1px solid var(--ua-border)}
+.popup-header{display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:8px;padding-bottom:8px;border-bottom:1px solid var(--ua-border);padding-right:20px}
 .popup-callsign{font-size:18px;font-weight:700;color:var(--ua-accent)}
 .popup-route{font-size:13px;color:#fff;margin-top:2px}
 .popup-route-est{font-size:9px;color:var(--ua-muted);font-style:italic}
@@ -130,7 +132,7 @@ main{flex:1;min-height:0;display:flex;flex-direction:column;overflow:hidden}
 .ac-seat-bar{display:flex;height:18px;border-radius:4px;overflow:hidden;margin-top:4px}
 .ac-seat-bar>div{display:flex;align-items:center;justify-content:center;font-size:8px;font-weight:700;min-width:20px}
 .ac-modal-footer{padding:10px 20px;border-top:1px solid var(--ua-border);display:flex;gap:8px;flex-wrap:wrap;align-items:center;flex-shrink:0}
-.ac-action-btn{background:rgba(0,93,170,.15);border:1px solid rgba(0,93,170,.3);color:var(--ua-accent);padding:4px 10px;border-radius:4px;font-size:10px;font-family:var(--font-mono);cursor:pointer;text-decoration:none;transition:background .2s}
+.ac-action-btn{background:rgba(0,93,170,.15);border:1px solid rgba(0,93,170,.3);color:var(--ua-accent);padding:4px 10px;border-radius:4px;font-size:10px;font-family:var(--font-mono);cursor:pointer;text-decoration:none;transition:background .2s;display:inline-flex;align-items:center;gap:4px}
 .ac-action-btn:hover{background:rgba(0,93,170,.25)}
 .delay-explain-text{font-size:12px;line-height:1.8;color:var(--ua-text);padding:12px 14px;background:rgba(0,93,170,.06);border:1px solid rgba(0,93,170,.12);border-radius:6px;margin-bottom:12px}
 .delay-explain-factors{padding-top:10px;margin-top:10px}
@@ -155,9 +157,9 @@ main{flex:1;min-height:0;display:flex;flex-direction:column;overflow:hidden}
 .popup-times .time-delta.ontime{color:var(--ua-muted)}
 .popup-times-loading{font-size:10px;color:var(--ua-muted);text-align:center;padding:6px;animation:pulse 1.5s ease-in-out infinite}
 @keyframes pulse{0%,100%{opacity:1}50%{opacity:.4}}
-.popup-links{display:flex;gap:8px;margin-top:8px;padding-top:8px;border-top:1px solid var(--ua-border)}
-.popup-links a{color:var(--ua-accent);text-decoration:none;font-size:10px;opacity:.7;transition:opacity .2s}
-.popup-links a:hover{opacity:1}
+.popup-links{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px;padding-top:8px;border-top:1px solid var(--ua-border);align-items:center}
+.popup-links a{color:var(--ua-accent);text-decoration:none;font-size:10px;padding:3px 8px;background:rgba(0,93,170,.1);border:1px solid rgba(0,93,170,.2);border-radius:3px;transition:background .15s,border-color .15s;display:inline-flex;align-items:center;gap:4px}
+.popup-links a:hover{background:rgba(0,93,170,.2);border-color:rgba(0,93,170,.4)}
 .hub-tooltip{background:rgba(10,14,20,.85)!important;border:1px solid var(--ua-blue)!important;color:var(--ua-accent)!important;font-size:10px!important;font-weight:700!important;padding:2px 6px!important;border-radius:3px!important;font-family:var(--mono)!important}
 
 /* ═══ MY FLIGHTS ═══ */
@@ -678,12 +680,12 @@ tbody td{padding:5px 8px;white-space:nowrap}
 .faa-delay-context{font-size:9px;color:#f59e0b;font-style:italic;margin-top:2px;opacity:.85}
 
 /* Flight Watch */
-.watch-btn{background:none;border:1px solid var(--ua-border);color:var(--ua-muted);padding:2px 6px;border-radius:3px;cursor:pointer;font-size:10px;font-family:var(--font-ui);transition:border-color .15s cubic-bezier(.4,0,.2,1),color .15s cubic-bezier(.4,0,.2,1),background-color .15s cubic-bezier(.4,0,.2,1)}
-.watch-btn:hover{border-color:var(--ua-accent);color:var(--ua-accent)}
-.watch-btn.watching{border-color:#f59e0b;color:#f59e0b;background:rgba(245,158,11,.1)}
-.share-btn{background:none;border:1px solid var(--ua-border);color:var(--ua-muted);padding:2px 6px;border-radius:3px;cursor:pointer;font-size:10px;font-family:var(--font-ui);transition:border-color .15s cubic-bezier(.4,0,.2,1),color .15s cubic-bezier(.4,0,.2,1)}
-.share-btn:hover{border-color:var(--ua-accent);color:var(--ua-accent)}
-.share-btn.copied{border-color:#22c55e;color:#22c55e}
+.watch-btn{background:none;border:1px solid var(--ua-border);color:var(--ua-muted);padding:3px 8px;border-radius:3px;cursor:pointer;font-size:10px;font-family:var(--font-mono);transition:border-color .15s cubic-bezier(.4,0,.2,1),color .15s cubic-bezier(.4,0,.2,1),background-color .15s cubic-bezier(.4,0,.2,1);display:inline-flex;align-items:center;gap:4px}
+.watch-btn:hover{border-color:var(--ua-accent);color:var(--ua-accent);background:rgba(0,93,170,.06)}
+.watch-btn.watching{border-color:var(--ua-blue);color:var(--ua-accent);background:var(--ua-blue-soft)}
+.share-btn{background:none;border:1px solid var(--ua-border);color:var(--ua-muted);padding:3px 8px;border-radius:3px;cursor:pointer;font-size:10px;font-family:var(--font-mono);transition:border-color .15s cubic-bezier(.4,0,.2,1),color .15s cubic-bezier(.4,0,.2,1),background-color .15s cubic-bezier(.4,0,.2,1);display:inline-flex;align-items:center;gap:4px}
+.share-btn:hover{border-color:var(--ua-accent);color:var(--ua-accent);background:rgba(0,93,170,.06)}
+.share-btn.copied{border-color:#22c55e;color:#22c55e;background:rgba(34,197,94,.06)}
 #push-prompt{position:fixed;bottom:20px;left:50%;transform:translateX(-50%);background:rgba(17,24,39,.97);border:1px solid var(--ua-border);border-radius:8px;padding:12px 16px;font-size:11px;color:var(--ua-text);z-index:10001;display:none;align-items:center;gap:10px;backdrop-filter:blur(12px);box-shadow:0 8px 32px rgba(0,0,0,.5);max-width:400px;font-family:var(--font-ui)}
 #push-prompt.show{display:flex}
 #push-prompt button{padding:4px 10px;border-radius:3px;cursor:pointer;font-family:var(--font-ui);font-size:10px;border:1px solid}

--- a/public/index.html
+++ b/public/index.html
@@ -722,12 +722,28 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
       <p style="margin-bottom:12px"><strong>Open Source:</strong> This project is open source. <a href="https://github.com/notjbg/the-blue-board" target="_blank" rel="noopener noreferrer" style="color:var(--ua-accent)">View on GitHub →</a> · <a href="https://x.com/theblueboard" target="_blank" rel="noopener noreferrer" style="color:var(--ua-accent)">Follow on X →</a></p>
       <p style="margin-bottom:12px"><strong>Support:</strong> Built by a United flyer, not a corporation. If Blue Board saved you a headache today, consider <a href="https://buymeacoffee.com/notjbg" target="_blank" rel="noopener noreferrer" style="color:var(--ua-accent)">supporting our site ☕</a>, <a href="https://buymeacoffee.com/notjbg/membership" target="_blank" rel="noopener noreferrer" style="color:var(--ua-accent)">become a monthly supporter →</a>, or <a href="https://github.com/notjbg/the-blue-board/issues" target="_blank" rel="noopener noreferrer" style="color:var(--ua-accent)">suggest a feature →</a></p>
       <!-- Supporters Wall — update periodically from BMAC CSV exports -->
-      <div style="margin-bottom:12px">
-        <p style="margin-bottom:8px"><strong>✈️ Supporters</strong></p>
-        <div style="display:flex;flex-wrap:wrap;gap:4px 8px;font-size:10px;color:var(--ua-muted);line-height:1.6">
-          <span>Greeby</span><span>·</span><span>natto</span><span>·</span><span>u/WrldDriftR</span><span>·</span><span>Leo</span><span>·</span><span>FlyerTalk JCG1005</span><span>·</span><span>@paytonwolfee</span><span>·</span><span>@misadventurelab</span><span>·</span><span>@MissLynsey</span><span>·</span><span>Danny</span><span>·</span><span>K2</span><span>·</span><span>James W</span><span>·</span><span>Aaron</span><span>·</span><span>@pconrad0</span><span>·</span><span>Stephen R</span><span>·</span><span>ML</span>
+      <div style="margin:16px 0 12px;padding:14px 16px;background:rgba(0,93,170,.06);border:1px solid rgba(0,93,170,.15);border-radius:6px">
+        <p style="margin-bottom:10px;font-size:10px;font-family:var(--font-mono);font-weight:600;text-transform:uppercase;letter-spacing:1px;color:var(--ua-amber)">Supporters</p>
+        <div style="display:flex;flex-wrap:wrap;gap:6px;font-size:10px;font-family:var(--font-mono);color:var(--ua-text)">
+          <span style="padding:3px 8px;background:rgba(0,93,170,.08);border:1px solid rgba(0,93,170,.15);border-radius:3px">@LinBros88</span>
+          <span style="padding:3px 8px;background:rgba(0,93,170,.08);border:1px solid rgba(0,93,170,.15);border-radius:3px">Greeby</span>
+          <span style="padding:3px 8px;background:rgba(0,93,170,.08);border:1px solid rgba(0,93,170,.15);border-radius:3px">u/WrldDriftR</span>
+          <span style="padding:3px 8px;background:rgba(0,93,170,.08);border:1px solid rgba(0,93,170,.15);border-radius:3px">LoveBlueBoard</span>
+          <span style="padding:3px 8px;background:rgba(0,93,170,.08);border:1px solid rgba(0,93,170,.15);border-radius:3px">@paytonwolfee</span>
+          <span style="padding:3px 8px;background:rgba(0,93,170,.08);border:1px solid rgba(0,93,170,.15);border-radius:3px">Danny</span>
+          <span style="padding:3px 8px;background:rgba(0,93,170,.08);border:1px solid rgba(0,93,170,.15);border-radius:3px">@misadventurelab</span>
+          <span style="padding:3px 8px;background:rgba(0,93,170,.08);border:1px solid rgba(0,93,170,.15);border-radius:3px">natto</span>
+          <span style="padding:3px 8px;background:rgba(0,93,170,.08);border:1px solid rgba(0,93,170,.15);border-radius:3px">@MissLynsey</span>
+          <span style="padding:3px 8px;background:rgba(0,93,170,.08);border:1px solid rgba(0,93,170,.15);border-radius:3px">K2</span>
+          <span style="padding:3px 8px;background:rgba(0,93,170,.08);border:1px solid rgba(0,93,170,.15);border-radius:3px">James W</span>
+          <span style="padding:3px 8px;background:rgba(0,93,170,.08);border:1px solid rgba(0,93,170,.15);border-radius:3px">Aaron</span>
+          <span style="padding:3px 8px;background:rgba(0,93,170,.08);border:1px solid rgba(0,93,170,.15);border-radius:3px">@pconrad0</span>
+          <span style="padding:3px 8px;background:rgba(0,93,170,.08);border:1px solid rgba(0,93,170,.15);border-radius:3px">Stephen R</span>
+          <span style="padding:3px 8px;background:rgba(0,93,170,.08);border:1px solid rgba(0,93,170,.15);border-radius:3px">FlyerTalk JCG1005</span>
+          <span style="padding:3px 8px;background:rgba(0,93,170,.08);border:1px solid rgba(0,93,170,.15);border-radius:3px">ML</span>
+          <span style="padding:3px 8px;background:rgba(0,93,170,.08);border:1px solid rgba(0,93,170,.15);border-radius:3px">Leo</span>
         </div>
-        <p style="margin-top:6px;font-size:10px;color:var(--ua-muted)">Want to see your name here? <a href="https://buymeacoffee.com/notjbg" target="_blank" rel="noopener noreferrer" style="color:var(--ua-accent)">☕ Buy me a coffee</a></p>
+        <p style="margin-top:10px;font-size:10px;color:var(--ua-muted)">Want to see your name here? <a href="https://buymeacoffee.com/notjbg" target="_blank" rel="noopener noreferrer" style="color:var(--ua-accent)">Support the project</a></p>
       </div>
     </div>
     <button data-action="hide-disclaimer" style="margin-top:16px;background:var(--ua-blue);color:white;border:none;padding:8px 24px;font-family:var(--font-ui);font-size:11px;cursor:pointer;border-radius:4px;width:100%">Got it</button>

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -3,6 +3,14 @@ import { normalizeMetarPayload } from '../lib/metar.js';
 import { categorizeFleetStatus, FLEET_HEALTH_CATEGORIES, FLEET_FAMILIES, normalizeWifi, WIFI_DISPLAY, sortFleetData, filterFleetData, parseFleetDeepLink, TAB_MAP, VALID_FLEET_VIEWS } from '../lib/fleet-utils.js';
 
 // ═══════════════════════════════════════════════
+// SVG ICON CONSTANTS — clean icons for buttons
+// ═══════════════════════════════════════════════
+const ICO_WATCH = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>';
+const ICO_WATCHING = '<svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3" fill="var(--ua-dark)"/></svg>';
+const ICO_SHARE = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px"><path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/><polyline points="16 6 12 2 8 6"/><line x1="12" y1="2" x2="12" y2="15"/></svg>';
+const ICO_EXTLINK = '<svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>';
+
+// ═══════════════════════════════════════════════
 // HUB LIST — CANONICAL REFERENCE
 // All 9 United hubs: ORD, DEN, IAH, EWR, SFO, IAD, LAX, NRT, GUM
 // When adding/removing a hub, update ALL of these locations:
@@ -1240,16 +1248,16 @@ function showFlightPopup(f, marker) {
 
   html += `<div class="popup-links">`;
   const fltLink = flightNum.replace(/^UA/, '');
-  if (fltLink) html += `<a href="https://flightaware.com/live/flight/UAL${encodeURIComponent(fltLink)}" target="_blank" rel="noopener noreferrer">FlightAware ↗</a>`;
+  if (fltLink) html += `<a href="https://flightaware.com/live/flight/UAL${encodeURIComponent(fltLink)}" target="_blank" rel="noopener noreferrer">FlightAware ${ICO_EXTLINK}</a>`;
   const regLink = aircraft?.r || f.reg;
-  if (regLink) html += `<a href="https://www.planespotters.net/search?q=${encodeURIComponent(regLink)}" target="_blank" rel="noopener noreferrer">Planespotters ↗</a>`;
-  html += `<a href="https://globe.adsbexchange.com/?icao=${encodeURIComponent(f.icao24)}" target="_blank" rel="noopener noreferrer">ADS-B ↗</a>`;
+  if (regLink) html += `<a href="https://www.planespotters.net/search?q=${encodeURIComponent(regLink)}" target="_blank" rel="noopener noreferrer">Planespotters ${ICO_EXTLINK}</a>`;
+  html += `<a href="https://globe.adsbexchange.com/?icao=${encodeURIComponent(f.icao24)}" target="_blank" rel="noopener noreferrer">ADS-B ${ICO_EXTLINK}</a>`;
   // Watch button in popup
   const popupFlt = displayFlight;
   const popupRoute = (f.origin||'?') + '→' + (f.dest||'?');
   const popupWatched = isFlightWatched(popupFlt);
-  html += `<button class="watch-btn${popupWatched ? ' watching' : ''}" data-action="toggle-watch-flight" data-flight="${escapeHtml(popupFlt)}" data-route="${escapeHtml(popupRoute)}" data-status="airborne" aria-label="${popupWatched ? 'Unwatch flight' : 'Watch flight'}" style="margin-left:auto">${popupWatched ? '👁️ Watching' : '👁 Watch'}</button>`;
-  html += `<button class="share-btn" data-action="share-flight" data-flight="${escapeHtml(popupFlt)}" aria-label="Share flight link" title="Copy shareable link">📤 Share</button>`;
+  html += `<button class="watch-btn${popupWatched ? ' watching' : ''}" data-action="toggle-watch-flight" data-flight="${escapeHtml(popupFlt)}" data-route="${escapeHtml(popupRoute)}" data-status="airborne" aria-label="${popupWatched ? 'Unwatch flight' : 'Watch flight'}" style="margin-left:auto">${popupWatched ? ICO_WATCHING + ' Watching' : ICO_WATCH + ' Watch'}</button>`;
+  html += `<button class="share-btn" data-action="share-flight" data-flight="${escapeHtml(popupFlt)}" aria-label="Share flight link" title="Copy shareable link">${ICO_SHARE} Share</button>`;
   html += `</div></div>`;
 
   if (marker.getPopup()) marker.unbindPopup();
@@ -2607,7 +2615,8 @@ async function initWeatherTab() {
 
   // Initialize radar map IMMEDIATELY — don't wait for data fetches
   const basemapTileOptions = getBasemapTileOptions();
-  const radarMap = L.map('radar-map', {center:[39,-98],zoom:4,zoomControl:true,attributionControl:false});
+  const radarMap = L.map('radar-map', {center:[39,-97],zoom:3,zoomControl:false,attributionControl:false});
+  L.control.zoom({ position: 'bottomleft' }).addTo(radarMap);
   L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', basemapTileOptions).addTo(radarMap);
   L.tileLayer('https://mesonet.agron.iastate.edu/cache/tile.py/1.0.0/nexrad-n0q-900913/{z}/{x}/{y}.png',{opacity:0.6}).addTo(radarMap);
   setTimeout(() => radarMap.invalidateSize(), 200);
@@ -3763,7 +3772,7 @@ function renderScheduleTable() {
     const origCode = fl.airport?.origin?.code?.iata || '?';
     const destCode = fl.airport?.destination?.code?.iata || '?';
     const watchRoute = `${origCode}→${destCode}`;
-    const watchBtn = ident !== '—' ? `<button class="watch-btn${isWatched ? ' watching' : ''}" data-action="toggle-watch-flight" data-flight="${escapeHtml(ident)}" data-route="${escapeHtml(watchRoute)}" data-status="${escapeHtml(status.text)}" data-stop-prop="1" aria-label="${isWatched ? 'Unwatch flight' : 'Watch flight'}" title="${isWatched ? 'Unwatch' : 'Watch'} this flight">${isWatched ? '👁️' : '👁'}</button>` : '';
+    const watchBtn = ident !== '—' ? `<button class="watch-btn${isWatched ? ' watching' : ''}" data-action="toggle-watch-flight" data-flight="${escapeHtml(ident)}" data-route="${escapeHtml(watchRoute)}" data-status="${escapeHtml(status.text)}" data-stop-prop="1" aria-label="${isWatched ? 'Unwatch flight' : 'Watch flight'}" title="${isWatched ? 'Unwatch' : 'Watch'} this flight">${isWatched ? ICO_WATCHING : ICO_WATCH}</button>` : '';
 
     // Delay risk scoring
     const dRisk = computeDelayRiskForScheduleFlight(fl, hub);
@@ -4534,7 +4543,7 @@ function renderWatchPanel() {
   const watched = getWatchedFlights();
   const list = document.getElementById('watch-panel-list');
   if (watched.length === 0) {
-    list.innerHTML = '<div style="padding:20px;text-align:center;color:var(--ua-muted);font-size:10px">No watched flights<br>Click 👁️ on any flight to watch it</div>';
+    list.innerHTML = '<div style="padding:20px;text-align:center;color:var(--ua-muted);font-size:10px">No watched flights<br>Click the watch icon on any flight to track it</div>';
     return;
   }
   list.innerHTML = watched.map(w => `<div class="watch-flight-item">
@@ -5451,10 +5460,12 @@ document.addEventListener('click', function(e) {
       const shareUrl = new URL(window.location);
       shareUrl.searchParams.set('flight', flightId);
       shareUrl.hash = '';
+      // ICO_SHARE is a hardcoded SVG constant — safe for innerHTML
+      const shareResetHtml = ICO_SHARE + ' Share';
       navigator.clipboard.writeText(shareUrl.toString()).then(() => {
         actionEl.classList.add('copied');
-        actionEl.textContent = '✓ Copied!';
-        setTimeout(() => { actionEl.classList.remove('copied'); actionEl.textContent = '📤 Share'; }, 2000);
+        actionEl.textContent = '\u2713 Copied!';
+        setTimeout(() => { actionEl.classList.remove('copied'); actionEl.innerHTML = shareResetHtml; }, 2000);
       }).catch(() => {
         // Fallback for older browsers
         const ta = document.createElement('textarea');
@@ -5464,8 +5475,8 @@ document.addEventListener('click', function(e) {
         document.execCommand('copy');
         document.body.removeChild(ta);
         actionEl.classList.add('copied');
-        actionEl.textContent = '✓ Copied!';
-        setTimeout(() => { actionEl.classList.remove('copied'); actionEl.textContent = '📤 Share'; }, 2000);
+        actionEl.textContent = '\u2713 Copied!';
+        setTimeout(() => { actionEl.classList.remove('copied'); actionEl.innerHTML = shareResetHtml; }, 2000);
       });
       break;
     }
@@ -5600,9 +5611,11 @@ document.addEventListener('click', function(e) {
       if (shareReg) {
         const shareUrl = new URL(window.location);
         shareUrl.searchParams.set('aircraft', shareReg);
+        // ICO_SHARE is a hardcoded SVG constant — safe for innerHTML
+        const acShareResetHtml = ICO_SHARE + ' Share';
         navigator.clipboard.writeText(shareUrl.toString()).then(function() {
-          actionEl.textContent = '✓ Copied!';
-          setTimeout(function() { actionEl.textContent = '📤 Share'; }, 2000);
+          actionEl.textContent = '\u2713 Copied!';
+          setTimeout(function() { actionEl.innerHTML = acShareResetHtml; }, 2000);
         }).catch(function() {
           const ta = document.createElement('textarea');
           ta.value = shareUrl.toString();
@@ -5610,8 +5623,8 @@ document.addEventListener('click', function(e) {
           ta.select();
           document.execCommand('copy');
           document.body.removeChild(ta);
-          actionEl.textContent = '✓ Copied!';
-          setTimeout(function() { actionEl.textContent = '📤 Share'; }, 2000);
+          actionEl.textContent = '\u2713 Copied!';
+          setTimeout(function() { actionEl.innerHTML = acShareResetHtml; }, 2000);
         });
       }
       break;
@@ -6220,7 +6233,7 @@ function showAircraftDetail(reg) {
       '<div style="text-align:center;padding:20px;color:var(--ua-muted);font-size:11px">' +
       'This aircraft is not in the United mainline fleet database.<br>It may be a United Express (regional) aircraft.</div>' +
       '</div><div class="ac-modal-footer">' +
-      '<a class="ac-action-btn" href="https://www.planespotters.net/search?q=' + encodeURIComponent(reg) + '" target="_blank" rel="noopener noreferrer">Planespotters ↗</a>' +
+      '<a class="ac-action-btn" href="https://www.planespotters.net/search?q=' + encodeURIComponent(reg) + '" target="_blank" rel="noopener noreferrer">Planespotters ' + ICO_EXTLINK + '</a>' +
       '</div></div>';
     return;
   }
@@ -6340,11 +6353,11 @@ function buildAircraftDetailHTML(ac, reg) {
     var watchFlt = liveFlight.flightIATA || liveFlight.callsign || '';
     var watchRoute = (liveFlight.origin || '?') + '→' + (liveFlight.dest || '?');
     var watched = watchFlt ? isFlightWatched(watchFlt) : false;
-    html += '<button class="ac-action-btn watch-btn' + (watched ? ' watching' : '') + '" data-action="toggle-watch-flight" data-flight="' + escapeHtml(watchFlt) + '" data-route="' + escapeHtml(watchRoute) + '" data-status="airborne">' + (watched ? '👁️ Watching' : '👁 Watch') + '</button>';
+    html += '<button class="ac-action-btn watch-btn' + (watched ? ' watching' : '') + '" data-action="toggle-watch-flight" data-flight="' + escapeHtml(watchFlt) + '" data-route="' + escapeHtml(watchRoute) + '" data-status="airborne">' + (watched ? ICO_WATCHING + ' Watching' : ICO_WATCH + ' Watch') + '</button>';
   }
-  html += '<a class="ac-action-btn" href="https://www.planespotters.net/search?q=' + encodeURIComponent(reg) + '" target="_blank" rel="noopener noreferrer">Planespotters ↗</a>';
-  html += '<a class="ac-action-btn" href="https://flightaware.com/resources/registration/' + encodeURIComponent(reg) + '" target="_blank" rel="noopener noreferrer">FlightAware ↗</a>';
-  html += '<button class="ac-action-btn" data-action="share-aircraft" data-reg="' + escapeHtml(reg) + '">📤 Share</button>';
+  html += '<a class="ac-action-btn" href="https://www.planespotters.net/search?q=' + encodeURIComponent(reg) + '" target="_blank" rel="noopener noreferrer">Planespotters ' + ICO_EXTLINK + '</a>';
+  html += '<a class="ac-action-btn" href="https://flightaware.com/resources/registration/' + encodeURIComponent(reg) + '" target="_blank" rel="noopener noreferrer">FlightAware ' + ICO_EXTLINK + '</a>';
+  html += '<button class="ac-action-btn" data-action="share-aircraft" data-reg="' + escapeHtml(reg) + '">' + ICO_SHARE + ' Share</button>';
   html += '</div>';
 
   html += '</div>'; // end card
@@ -6456,7 +6469,7 @@ function renderFR24Modal(f, source, cached) {
   // Footer
   html += '<div style="padding:10px 20px;border-top:1px solid var(--ua-border);display:flex;justify-content:space-between;align-items:center">';
   html += '<div style="font-size:8px;color:var(--ua-muted)">Powered by Flightradar24 Official API' + (cached ? ' • cached' : '') + '</div>';
-  html += '<button class="share-btn" data-action="share-flight" data-flight="' + escapeHtml(f.flightNumber || '') + '" aria-label="Share flight link" title="Copy shareable link">📤 Share</button>';
+  html += '<button class="share-btn" data-action="share-flight" data-flight="' + escapeHtml(f.flightNumber || '') + '" aria-label="Share flight link" title="Copy shareable link">' + ICO_SHARE + ' Share</button>';
   html += '</div>';
   html += '</div>';
 


### PR DESCRIPTION
## Summary
- **Weather radar**: Zoomed out to show full US, moved zoom controls to bottom-left so they don't overlap the next-radar tile
- **Flight popup overlap**: Added padding-right on popup header so cruise/descent/ascend badges don't collide with the close button; increased close button to 44px touch target per DESIGN.md
- **SVG icons**: Replaced emoji Watch/Share/external-link with clean inline SVG icons across flight popups, schedule table, aircraft detail, and FR24 modal
- **External links restyled**: FlightAware, Planespotters, and ADS-B links now render as pill buttons instead of plain text links
- **Supporter wall updated**: Added current BMAC supporters (LinBros88, LoveBlueBoard, paytonwolfee, etc.), switched chips from amber to blue tint per DESIGN.md amber-usage rules

## Test plan
- [ ] Open weather tab — radar should show full continental US at zoom level 3, zoom controls at bottom-left
- [ ] Click a flight on the map — close button should not overlap phase badges, external links should be pill buttons with arrow icons
- [ ] Verify Watch/Share buttons show SVG icons (not emoji) in popup, schedule table, and aircraft detail
- [ ] Open About popup — supporters wall should list 17 names in blue-tinted chips
- [ ] Test on mobile — 44px close button touch target, no overlapping elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)