### PR TITLE
Update United Fleet Site links to new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Curated United Airlines news hub with individual article pages, source links, an
 | [Flightradar24](https://flightradar24.com) | Live positions, schedules, flight lookup | ~15s–60s | Server-side proxy with caching |
 | [Aviation Weather Center](https://aviationweather.gov) | METAR observations | ~5min | NOAA/CORS proxy, batched |
 | [FAA NAS Status](https://nasstatus.faa.gov) | Delays & ground stops | ~5min | XML→JSON proxy |
-| [United Fleet Site](https://sites.google.com/site/unitedfleetsite/) | Fleet database | Daily | Community-maintained |
+| [United Fleet Site](https://unitedfleetsite.com/) | Fleet database | Daily | Community-maintained |
 | [Starlink Tracker](https://unitedstarlinktracker.com) | WiFi-equipped aircraft | Daily | [@martinamps](https://github.com/martinamps/ua-starlink-tracker) |
 | [Iowa State NEXRAD](https://mesonet.agron.iastate.edu) | Radar imagery | ~5min | Direct tile server |
 | [Supabase](https://supabase.com) | Waitlist, schedule snapshots, notifications | Real-time | Postgres with RLS |

--- a/public/index.html
+++ b/public/index.html
@@ -481,7 +481,7 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
   <div class="fleet-lookup-zone" id="fleet-lookup-zone">
     <div class="fleet-lookup-header">
       <h3 class="zone-title">Aircraft Lookup</h3>
-      <div class="fleet-data-source">Fleet data via <a href="https://sites.google.com/site/unitedfleetsite/mainline-fleet-tracking" target="_blank" rel="noopener noreferrer" class="fleet-source-link">United Fleet Site</a>, updated daily</div>
+      <div class="fleet-data-source">Fleet data via <a href="https://unitedfleetsite.com/" target="_blank" rel="noopener noreferrer" class="fleet-source-link">United Fleet Site</a>, updated daily</div>
     </div>
     <div class="fleet-subtab-bar" id="fleet-subtab-bar" role="tablist" aria-label="Aircraft lookup views">
       <button class="fleet-subtab active" role="tab" aria-selected="true" data-action="fleet-subtab" data-view="all" id="fleet-subtab-all">All Aircraft <span class="fleet-subtab-count" id="fleet-subtab-count-all"></span></button>
@@ -635,7 +635,7 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
     <div>
       <div class="source-name">Fleet Database — United Fleet Site <span class="freshness fresh-daily">DAILY</span></div>
       <div class="source-desc">Comprehensive fleet data: mainline aircraft with type, config, WiFi, IFE, seats, delivery year.</div>
-      <a class="source-link" href="https://sites.google.com/site/unitedfleetsite/" target="_blank" rel="noopener noreferrer">United Fleet Site →</a>
+      <a class="source-link" href="https://unitedfleetsite.com/" target="_blank" rel="noopener noreferrer">United Fleet Site →</a>
       <a class="source-link" href="https://docs.google.com/spreadsheets/d/1ZlYgN_IZmd6CSx_nXnuP0L0PiodapDRx3RmNkIpxXAo" target="_blank" rel="noopener noreferrer" style="margin-left:12px">Google Sheet →</a>
     </div>
   </div>

--- a/src/pages/fleet/index.astro
+++ b/src/pages/fleet/index.astro
@@ -442,7 +442,7 @@ p{margin-bottom:12px}
 
   <!-- DATA SOURCES -->
   <h3>About This Data</h3>
-  <p>Fleet data sourced from <a href="https://sites.google.com/site/unitedfleetsite/mainline-fleet-tracking" target="_blank" rel="noopener noreferrer">United Fleet Site</a> and updated daily. Starlink equipment data via <a href="https://unitedstarlinktracker.com" target="_blank" rel="noopener noreferrer">unitedstarlinktracker.com</a>. Live flight data from <a href="https://www.flightradar24.com" target="_blank" rel="noopener noreferrer">Flightradar24</a>.</p>
+  <p>Fleet data sourced from <a href="https://unitedfleetsite.com/" target="_blank" rel="noopener noreferrer">United Fleet Site</a> and updated daily. Starlink equipment data via <a href="https://unitedstarlinktracker.com" target="_blank" rel="noopener noreferrer">unitedstarlinktracker.com</a>. Live flight data from <a href="https://www.flightradar24.com" target="_blank" rel="noopener noreferrer">Flightradar24</a>.</p>
   <p style="color:var(--ua-muted);font-size:11px">The Blue Board is an independent project — not affiliated with United Airlines, Inc. Data may be delayed or incomplete. Do not use for operational decisions.</p>
 </div>
 


### PR DESCRIPTION
## Summary
- United Fleet Site moved from Google Sites to `unitedfleetsite.com`
- Updated all 4 attribution links across `public/index.html`, `src/pages/fleet/index.astro`, and `README.md`
- Verified the underlying Google Sheet data source is unchanged and still accessible — no impact to the fleet data pipeline