### PR TITLE
feat: TSA wait times page with live checkpoint data

### DIFF
--- a/api/cron/refresh-tsa.ts
+++ b/api/cron/refresh-tsa.ts
@@ -1,0 +1,45 @@
+import type { VercelRequest, VercelResponse } from '../types.js';
+
+/**
+ * Cron job to warm the TSA wait times cache every 5 minutes.
+ * Calls the /api/tsa endpoint internally to trigger a fresh fetch.
+ */
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  // Verify cron secret
+  const authHeader = req.headers['authorization'];
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  try {
+    const baseUrl = process.env.VERCEL_URL
+      ? `https://${process.env.VERCEL_URL}`
+      : 'http://localhost:3000';
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 25_000);
+
+    const resp = await fetch(`${baseUrl}/api/tsa`, {
+      signal: controller.signal,
+      headers: { origin: 'https://theblueboard.co' },
+    });
+    clearTimeout(timeout);
+
+    if (!resp.ok) {
+      console.error('TSA cache warm failed:', resp.status, await resp.text());
+      return res.status(502).json({ error: 'Cache warm failed', status: resp.status });
+    }
+
+    const data = await resp.json();
+    const hubCount = data.hubs ? Object.keys(data.hubs).length : 0;
+    console.log(`TSA cache warmed: ${hubCount} hubs, refreshed at ${data.lastRefreshed}`);
+
+    return res.status(200).json({ ok: true, hubs: hubCount, refreshed: data.lastRefreshed });
+  } catch (e: any) {
+    console.error('TSA cron error:', e);
+    if (e.name === 'AbortError') {
+      return res.status(504).json({ error: 'TSA cache warm timed out' });
+    }
+    return res.status(500).json({ error: 'Internal error' });
+  }
+}

--- a/api/tsa.ts
+++ b/api/tsa.ts
@@ -1,0 +1,155 @@
+import type { VercelRequest, VercelResponse } from './types.js';
+import { createRateLimiter } from './_rate-limit.js';
+import { CacheStore } from './_cache.js';
+
+const isRateLimited = createRateLimiter('tsa', 30);
+
+// 5-minute TTL, 10-minute stale grace
+const cache = new CacheStore<TsaResponse>('tsa', { defaultTTL: 300_000 });
+const STALE_GRACE_MS = 600_000;
+
+// United hub IATA codes
+const UNITED_HUBS = ['ORD', 'DEN', 'IAH', 'EWR', 'SFO', 'IAD', 'LAX'];
+const CACHE_KEY = 'all-hubs';
+
+interface TsaResponse {
+  hubs: Record<string, {
+    standardWait: number | null;
+    precheckWait: number | null;
+    lastUpdated: string | null;
+    reports: Array<{ wait: number; precheck: boolean; created: string }>;
+  }>;
+  lastRefreshed: string;
+}
+
+/**
+ * Fetch wait times from the MyTSA government API for all United hubs.
+ * The API returns crowdsourced wait time reports in 10-minute buckets.
+ * We fetch both standard and PreCheck wait times per hub.
+ */
+async function fetchMyTsaData(): Promise<TsaResponse> {
+  const hubs: TsaResponse['hubs'] = {};
+  const now = new Date().toISOString();
+
+  // Fetch all hubs in parallel — standard and precheck for each
+  const fetches = UNITED_HUBS.flatMap((code) => [
+    fetchHubWaitTimes(code, false),
+    fetchHubWaitTimes(code, true),
+  ]);
+
+  const results = await Promise.allSettled(fetches);
+
+  for (let i = 0; i < UNITED_HUBS.length; i++) {
+    const code = UNITED_HUBS[i];
+    const standardResult = results[i * 2];
+    const precheckResult = results[i * 2 + 1];
+
+    const standardReports = standardResult.status === 'fulfilled' ? standardResult.value : [];
+    const precheckReports = precheckResult.status === 'fulfilled' ? precheckResult.value : [];
+
+    // Get the most recent report for each type
+    const latestStandard = standardReports.length > 0 ? standardReports[0] : null;
+    const latestPrecheck = precheckReports.length > 0 ? precheckReports[0] : null;
+
+    const allReports = [
+      ...standardReports.map((r) => ({ wait: r.waitMinutes, precheck: false, created: r.createdAt })),
+      ...precheckReports.map((r) => ({ wait: r.waitMinutes, precheck: true, created: r.createdAt })),
+    ].sort((a, b) => new Date(b.created).getTime() - new Date(a.created).getTime());
+
+    hubs[code] = {
+      standardWait: latestStandard?.waitMinutes ?? null,
+      precheckWait: latestPrecheck?.waitMinutes ?? null,
+      lastUpdated: allReports.length > 0 ? allReports[0].created : null,
+      reports: allReports.slice(0, 5), // Keep last 5 reports
+    };
+  }
+
+  return { hubs, lastRefreshed: now };
+}
+
+/**
+ * Fetch wait time reports from MyTSA for a single airport.
+ * The API returns the last 25 reported wait times.
+ * Wait time values: 0 = no wait, 1 = 1-10 min, 2 = 11-20 min, etc.
+ */
+async function fetchHubWaitTimes(
+  airportCode: string,
+  precheck: boolean
+): Promise<Array<{ waitMinutes: number; createdAt: string }>> {
+  const params = new URLSearchParams({
+    ap: airportCode,
+    output: 'json',
+  });
+  if (precheck) params.set('pc', '1');
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+
+  try {
+    const resp = await fetch(
+      `https://apps.tsa.dhs.gov/MyTSAWebService/GetTSOWaitTimes.ashx?${params}`,
+      { signal: controller.signal }
+    );
+    clearTimeout(timeout);
+
+    if (!resp.ok) return [];
+
+    const data = await resp.json();
+
+    // The API returns an array of wait time objects
+    // Each has: Created_Datetime, Wait_Time (0-based bucket), Airport_Code
+    if (!Array.isArray(data)) return [];
+
+    return data
+      .filter((entry: any) => entry && Number.isInteger(entry.Wait_Time) && entry.Wait_Time >= 0)
+      .map((entry: any) => ({
+        // Convert bucket to midpoint minutes: 0=0, 1=5, 2=15, 3=25, etc.
+        waitMinutes: entry.Wait_Time === 0 ? 0 : entry.Wait_Time * 10 - 5,
+        createdAt: entry.Created_Datetime || new Date().toISOString(),
+      }));
+  } catch {
+    clearTimeout(timeout);
+    return [];
+  }
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const origin = req.headers?.origin || '';
+  if (origin && origin !== 'https://theblueboard.co' && !/^http:\/\/localhost(:\d+)?$/.test(origin)) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  if (isRateLimited(req)) {
+    return res.status(429).json({ error: 'Rate limited — try again shortly' });
+  }
+
+  // Try fresh cache first
+  const cached = cache.get(CACHE_KEY);
+  if (cached) {
+    res.setHeader('Cache-Control', 's-maxage=60, stale-while-revalidate=300');
+    return res.status(200).json(cached);
+  }
+
+  try {
+    const data = await fetchMyTsaData();
+    cache.set(CACHE_KEY, data);
+    res.setHeader('Cache-Control', 's-maxage=60, stale-while-revalidate=300');
+    return res.status(200).json(data);
+  } catch (e: any) {
+    console.error('TSA API error:', e);
+
+    // Try stale cache as fallback
+    const stale = cache.getStale(CACHE_KEY, STALE_GRACE_MS);
+    if (stale) {
+      res.setHeader('X-TSA-Data-Stale', 'true');
+      res.setHeader('Cache-Control', 's-maxage=30, stale-while-revalidate=60');
+      return res.status(200).json(stale);
+    }
+
+    return res.status(502).json({ error: 'TSA data temporarily unavailable' });
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -181,6 +181,7 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
   <p><strong>The Blue Board</strong> is an independent United Airlines flight tracker and operations dashboard with live status, hub delays, fleet data, and Starlink coverage.</p>
   <nav class="brand-links" aria-label="Primary site links">
     <a href="/news">News</a>
+    <a href="/tsa">TSA Wait Times</a>
     <a href="/hubs">United Hub Pages</a>
     <a href="/fleet">Fleet Database</a>
     <a href="https://x.com/theblueboard" target="_blank" rel="noopener noreferrer">Follow @theblueboard</a>

--- a/src/data/tsa/united-terminals.js
+++ b/src/data/tsa/united-terminals.js
@@ -1,0 +1,509 @@
+/**
+ * United Airlines terminal-to-checkpoint mapping for all 7 domestic hubs.
+ * Includes checkpoint hours, lane types (Standard, Pre✓, CLEAR, Priority),
+ * and United-specific tips.
+ *
+ * Data sources: airport websites, TSA.gov PreCheck schedule, CLEAR locations.
+ * Last verified: 2026-03-22
+ */
+
+export const unitedTerminals = {
+  ORD: {
+    iata: 'ORD',
+    name: "Chicago O'Hare International Airport",
+    city: 'Chicago, IL',
+    terminals: 'Terminal 1 (Concourses B & C)',
+    terminalNote: 'United Express regional flights from Terminal 2 (Concourses E & F)',
+    checkpoints: [
+      {
+        name: 'Checkpoint 1 (CP1)',
+        terminal: 'Terminal 1',
+        hours: '4:00 AM – 8:30 PM',
+        lanes: {
+          standard: true,
+          precheck: false,
+          clear: true,
+          priority: false,
+        },
+        precheckHours: null,
+        clearHours: '4:30 AM – 8:00 PM',
+      },
+      {
+        name: 'Checkpoint 2 (CP2)',
+        terminal: 'Terminal 1',
+        hours: '4:15 AM – 8:30 PM',
+        lanes: {
+          standard: true,
+          precheck: true,
+          clear: true,
+          priority: false,
+        },
+        precheckHours: '4:00 AM – 8:30 PM',
+        clearHours: '4:30 AM – 8:00 PM',
+      },
+      {
+        name: 'Checkpoint 3 (CP3)',
+        terminal: 'Terminal 1',
+        hours: '4:00 AM – 6:00 PM',
+        lanes: {
+          standard: true,
+          precheck: false,
+          clear: false,
+          priority: false,
+        },
+        precheckHours: null,
+        clearHours: null,
+      },
+    ],
+    tips: [
+      'CP2 has both Pre✓ and CLEAR — it\'s your best bet for expedited screening.',
+      'CP3 closes at 6 PM — avoid if you have an evening flight.',
+      'Terminal 2 (United Express) uses CP5 with Pre✓ available 3:30 AM – 8:00 PM.',
+    ],
+    faq: [
+      {
+        question: 'Which TSA checkpoint should I use for United at ORD?',
+        answer: 'United Airlines operates from Terminal 1 at O\'Hare. Checkpoint 2 (CP2) is recommended — it has both TSA Pre✓ and CLEAR lanes, and is open from 4:15 AM to 8:30 PM. If you don\'t have Pre✓ or CLEAR, CP1 and CP3 serve standard lanes.',
+      },
+      {
+        question: 'Does United\'s terminal at O\'Hare have TSA PreCheck?',
+        answer: 'Yes. TSA PreCheck is available at Checkpoint 2 (CP2) in Terminal 1, open from 4:00 AM to 8:30 PM. United Express passengers using Terminal 2 can access Pre✓ at Checkpoint 5 (CP5).',
+      },
+      {
+        question: 'Is CLEAR available at United\'s O\'Hare terminal?',
+        answer: 'Yes. CLEAR+ lanes are available at Checkpoints 1 and 2 in Terminal 1, operating from 4:30 AM to 8:00 PM. CLEAR is also available in Terminals 2 and 5.',
+      },
+      {
+        question: 'What are the busiest times at O\'Hare TSA for United flights?',
+        answer: 'Peak screening times at Terminal 1 are 6:00–9:00 AM (morning bank) and 3:00–5:00 PM (afternoon bank). Early morning (before 5:30 AM) and midday (11 AM–1 PM) typically have the shortest waits.',
+      },
+      {
+        question: 'How early should I arrive for United flights at ORD?',
+        answer: 'For domestic flights, arrive 2 hours early. For international flights from Terminal 1, arrive 3 hours early. If you have TSA PreCheck or CLEAR, you can often clear security in under 10 minutes, but allow buffer time during peak hours and holidays.',
+      },
+    ],
+  },
+
+  DEN: {
+    iata: 'DEN',
+    name: 'Denver International Airport',
+    city: 'Denver, CO',
+    terminals: 'Concourse B (via Jeppesen Terminal)',
+    terminalNote: 'All passengers clear security in the main terminal before taking the train to Concourse B',
+    checkpoints: [
+      {
+        name: 'East Security',
+        terminal: 'Jeppesen Terminal',
+        hours: '4:00 AM – 8:45 PM',
+        lanes: {
+          standard: true,
+          precheck: true,
+          clear: true,
+          priority: false,
+        },
+        precheckHours: '4:00 AM – 8:45 PM',
+        clearHours: '4:00 AM – 8:45 PM',
+      },
+      {
+        name: 'West Security',
+        terminal: 'Jeppesen Terminal',
+        hours: '4:00 AM – 8:45 PM',
+        lanes: {
+          standard: true,
+          precheck: true,
+          clear: true,
+          priority: false,
+        },
+        precheckHours: '4:00 AM – 8:45 PM',
+        clearHours: '4:00 AM – 8:45 PM',
+      },
+      {
+        name: 'Bridge Security',
+        terminal: 'Jeppesen Terminal',
+        hours: '4:30 AM – 6:00 PM',
+        lanes: {
+          standard: true,
+          precheck: false,
+          clear: true,
+          priority: false,
+        },
+        precheckHours: null,
+        clearHours: '4:30 AM – 6:00 PM',
+      },
+    ],
+    tips: [
+      'East and West checkpoints have identical lane options — choose based on shorter line.',
+      'Bridge Security offers scenic views but closes at 6 PM and has no Pre✓.',
+      'DEN has a single security zone — once through, you can reach any concourse via train.',
+    ],
+    faq: [
+      {
+        question: 'Which TSA checkpoint is best for United at Denver?',
+        answer: 'United operates from Concourse B at DEN, but all passengers clear security in the main Jeppesen Terminal first. East and West Security checkpoints both have Pre✓ and CLEAR lanes. Pick whichever has the shorter line — both provide access to all concourses via the underground train.',
+      },
+      {
+        question: 'Does Denver airport have TSA PreCheck for United flights?',
+        answer: 'Yes. Both East and West Security checkpoints in the Jeppesen Terminal have TSA PreCheck lanes, open from 4:00 AM to 8:45 PM. Bridge Security does not have Pre✓.',
+      },
+      {
+        question: 'Is CLEAR available at Denver airport?',
+        answer: 'Yes. CLEAR+ lanes are available at East Security, West Security, and Bridge Security checkpoints. CLEAR at Bridge Security operates from 4:30 AM to 6:00 PM.',
+      },
+      {
+        question: 'How long does TSA take at Denver for United flights?',
+        answer: 'Average TSA wait times at DEN range from 5–15 minutes. Peak times are 5:00–8:00 AM and 2:00–5:00 PM. With TSA PreCheck, waits are typically under 5 minutes. DEN\'s new East checkpoint (opened August 2025) has helped reduce congestion significantly.',
+      },
+      {
+        question: 'How early should I arrive for United flights at DEN?',
+        answer: 'Arrive 2 hours before domestic flights and 3 hours before international flights. After clearing security, you\'ll take the train to Concourse B — allow an extra 5–10 minutes for the train ride. Pre✓ or CLEAR members can arrive 90 minutes early for domestic flights.',
+      },
+    ],
+  },
+
+  IAH: {
+    iata: 'IAH',
+    name: 'George Bush Intercontinental Airport',
+    city: 'Houston, TX',
+    terminals: 'Terminal C (domestic) & Terminal E (international)',
+    terminalNote: 'Terminal C serves most United domestic flights; Terminal E handles international departures',
+    checkpoints: [
+      {
+        name: 'Terminal C North',
+        terminal: 'Terminal C',
+        hours: '4:00 AM – 10:00 PM',
+        lanes: {
+          standard: true,
+          precheck: true,
+          clear: true,
+          priority: false,
+        },
+        precheckHours: '4:00 AM – 10:00 PM',
+        clearHours: 'Sun–Fri 4:00 AM – 7:00 PM, Sat 4:00 AM – 6:00 PM',
+      },
+      {
+        name: 'Terminal C South',
+        terminal: 'Terminal C',
+        hours: '4:00 AM – 7:30 PM',
+        lanes: {
+          standard: true,
+          precheck: false,
+          clear: false,
+          priority: false,
+        },
+        precheckHours: null,
+        clearHours: null,
+      },
+      {
+        name: 'Terminal E',
+        terminal: 'Terminal E',
+        hours: '4:00 AM – 12:00 AM',
+        lanes: {
+          standard: true,
+          precheck: true,
+          clear: false,
+          priority: false,
+        },
+        precheckHours: '4:00 AM – 8:00 PM',
+        clearHours: null,
+      },
+    ],
+    tips: [
+      'Terminal C North is the only checkpoint with both Pre✓ and CLEAR — use it when available.',
+      'Terminal C South closes at 7:30 PM and has standard lanes only.',
+      'Terminal E Pre✓ closes at 8 PM — arrive early for evening international departures.',
+      'The Subway train connects Terminals C and E airside. No need to re-clear security.',
+    ],
+    faq: [
+      {
+        question: 'Which TSA checkpoint should I use for United at IAH?',
+        answer: 'For domestic United flights, use Terminal C North — it has TSA Pre✓ and CLEAR, open until 10 PM. Terminal C South is standard lanes only and closes at 7:30 PM. For international flights, Terminal E has Pre✓ until 8 PM.',
+      },
+      {
+        question: 'Does United at Houston IAH have TSA PreCheck?',
+        answer: 'Yes. TSA PreCheck is available at Terminal C North (open until 10 PM) and Terminal E (open until 8 PM). Terminal C South does not have Pre✓ lanes.',
+      },
+      {
+        question: 'Is CLEAR available at United\'s IAH terminals?',
+        answer: 'CLEAR is available at Terminal C North only. Hours are Sunday–Friday 4:00 AM – 7:00 PM and Saturday 4:00 AM – 6:00 PM. Terminal E does not have CLEAR.',
+      },
+      {
+        question: 'What are the busiest times at IAH TSA for United?',
+        answer: 'Peak times at Terminal C are 5:30–8:30 AM (morning banks to East Coast) and 3:00–6:00 PM. Terminal E peaks around 4:00–7:00 PM for evening European departures. Summer thunderstorm season (May–September) can cause cascading delays that back up security lines.',
+      },
+      {
+        question: 'How early should I arrive for United flights at IAH?',
+        answer: 'Arrive 2 hours before domestic flights and 3 hours before international flights. IAH is a large airport — allow extra time to navigate between terminals if connecting. The Subway people mover connects all terminals airside.',
+      },
+    ],
+  },
+
+  EWR: {
+    iata: 'EWR',
+    name: 'Newark Liberty International Airport',
+    city: 'Newark, NJ',
+    terminals: 'Terminal C & Terminal A',
+    terminalNote: 'Terminal C is United\'s primary hub. The new Terminal A (opened 2023) handles some United flights',
+    checkpoints: [
+      {
+        name: 'Terminal C Main',
+        terminal: 'Terminal C',
+        hours: '24 hours',
+        lanes: {
+          standard: true,
+          precheck: true,
+          clear: true,
+          priority: true,
+        },
+        precheckHours: '24 hours',
+        clearHours: '4:00 AM – 10:00 PM',
+      },
+      {
+        name: 'Terminal C North Satellite',
+        terminal: 'Terminal C',
+        hours: 'Variable (peak hours)',
+        lanes: {
+          standard: true,
+          precheck: true,
+          clear: false,
+          priority: false,
+        },
+        precheckHours: 'Variable',
+        clearHours: null,
+      },
+      {
+        name: 'Terminal A',
+        terminal: 'Terminal A',
+        hours: '24 hours',
+        lanes: {
+          standard: true,
+          precheck: true,
+          clear: true,
+          priority: false,
+        },
+        precheckHours: '24 hours',
+        clearHours: 'Sun–Fri 4:30 AM – 8:00 PM, Sat 4:30 AM – 7:00 PM',
+      },
+    ],
+    tips: [
+      'Terminal C Main is the only EWR checkpoint with all 4 lane types including Priority.',
+      'EWR is the most delay-prone major US airport — TSA lines can exceed 90 minutes during peak.',
+      'CLEAR closes at 10 PM in Terminal C — if you have a red-eye, Pre✓ is your best option.',
+      'The Terminal C North Satellite checkpoint opens during peak hours and usually has shorter lines.',
+    ],
+    faq: [
+      {
+        question: 'Which TSA checkpoint should I use for United at Newark?',
+        answer: 'Terminal C Main is United\'s primary checkpoint at EWR — it\'s the only one with Standard, Pre✓, CLEAR, and Priority lanes, and it\'s open 24 hours. For shorter lines during peak hours, check if the Terminal C North Satellite checkpoint is open.',
+      },
+      {
+        question: 'Does Newark Terminal C have TSA PreCheck?',
+        answer: 'Yes. TSA PreCheck is available 24/7 at Terminal C Main, with two dedicated lanes. The North Satellite checkpoint also has a Pre✓ lane when open. Terminal A has Pre✓ 24/7 as well.',
+      },
+      {
+        question: 'Is CLEAR available at United\'s Newark terminal?',
+        answer: 'Yes. CLEAR+ lanes are available at Terminal C Main from 4:00 AM to 10:00 PM, and at Terminal A from 4:30 AM to 8:00 PM (7:00 PM Saturdays).',
+      },
+      {
+        question: 'How bad are TSA wait times at Newark for United?',
+        answer: 'EWR is notorious for long TSA lines. Peak evening departure times (4:00–7:00 PM) for European flights can see standard lanes exceed 60–90 minutes. TSA PreCheck averages around 7 minutes. Always allow extra time at EWR — it consistently ranks as the most delay-prone major US airport.',
+      },
+      {
+        question: 'How early should I arrive for United flights at EWR?',
+        answer: 'Arrive at least 2.5 hours before domestic flights and 3.5 hours before international flights. EWR\'s security lines are unpredictable and can spike suddenly. With Pre✓ or CLEAR, 2 hours domestic / 3 hours international is usually sufficient.',
+      },
+    ],
+  },
+
+  SFO: {
+    iata: 'SFO',
+    name: 'San Francisco International Airport',
+    city: 'San Francisco, CA',
+    terminals: 'Terminal 3 (domestic) & International Terminal G',
+    terminalNote: 'Terminal 3 serves United domestic; International Terminal boarding area G serves United international',
+    checkpoints: [
+      {
+        name: 'Terminal 3 Checkpoint',
+        terminal: 'Terminal 3',
+        hours: '4:00 AM – 11:00 PM',
+        lanes: {
+          standard: true,
+          precheck: true,
+          clear: true,
+          priority: false,
+        },
+        precheckHours: '4:00 AM – 10:00 PM',
+        clearHours: '4:00 AM – 10:00 PM',
+      },
+      {
+        name: 'International Terminal (G Gates)',
+        terminal: 'International Terminal',
+        hours: '24 hours',
+        lanes: {
+          standard: true,
+          precheck: true,
+          clear: true,
+          priority: false,
+        },
+        precheckHours: '4:30 AM – 10:00 PM',
+        clearHours: '7:00 AM – 10:00 PM',
+      },
+    ],
+    tips: [
+      'Terminal 3 connects airside to International Terminal G — clear security once.',
+      'Checkpoint F in Terminal 3 may be closed for construction — check before arriving.',
+      'CLEAR opens later at the International Terminal (7 AM vs 4 AM at Terminal 3).',
+    ],
+    faq: [
+      {
+        question: 'Which TSA checkpoint should I use for United at SFO?',
+        answer: 'United domestic flights use Terminal 3 — the main checkpoint has Pre✓ and CLEAR lanes. For international flights, use the International Terminal checkpoint (boarding area G). Both terminals are connected airside.',
+      },
+      {
+        question: 'Does SFO have TSA PreCheck for United flights?',
+        answer: 'Yes. TSA PreCheck is available at Terminal 3 (4:00 AM – 10:00 PM) and the International Terminal (4:30 AM – 10:00 PM).',
+      },
+      {
+        question: 'Is CLEAR available at SFO for United passengers?',
+        answer: 'Yes. CLEAR+ lanes are at Terminal 3 (4:00 AM – 10:00 PM) and the International Terminal (7:00 AM – 10:00 PM). Note CLEAR opens 3 hours later at the International Terminal.',
+      },
+      {
+        question: 'How long does TSA take at SFO for United flights?',
+        answer: 'Average TSA wait times at SFO Terminal 3 are 10–20 minutes. Peak times are 6:00–9:00 AM and 3:00–6:00 PM. With Pre✓, waits are typically 5 minutes or less. SFO fog can cause flight delays that back up the terminal.',
+      },
+      {
+        question: 'How early should I arrive for United flights at SFO?',
+        answer: 'Arrive 2 hours before domestic flights and 3 hours before international flights. SFO is compact and efficient, but Bay Area traffic to the airport can be unpredictable.',
+      },
+    ],
+  },
+
+  IAD: {
+    iata: 'IAD',
+    name: 'Washington Dulles International Airport',
+    city: 'Washington, DC',
+    terminals: 'Main Terminal (shared facility)',
+    terminalNote: 'All airlines share the main terminal. United uses Concourses C and D (via AeroTrain)',
+    checkpoints: [
+      {
+        name: 'East Checkpoint',
+        terminal: 'Main Terminal',
+        hours: '3:45 AM – 10:30 PM',
+        lanes: {
+          standard: true,
+          precheck: true,
+          clear: true,
+          priority: false,
+        },
+        precheckHours: '4:30 AM – 9:00 PM',
+        clearHours: '4:30 AM – 9:30 PM',
+      },
+      {
+        name: 'West Checkpoint',
+        terminal: 'Main Terminal',
+        hours: '4:45 AM – 9:00 PM',
+        lanes: {
+          standard: true,
+          precheck: true,
+          clear: true,
+          priority: false,
+        },
+        precheckHours: '4:30 AM – 9:00 PM',
+        clearHours: '4:30 AM – 9:30 PM',
+      },
+    ],
+    tips: [
+      'East Checkpoint opens an hour earlier than West — best for early flights.',
+      'Both checkpoints have identical Pre✓ and CLEAR availability.',
+      'After security, take the AeroTrain to Concourse C (domestic) or D (international).',
+      'IAD\'s security is generally efficient — typically 10–15 min for standard lanes.',
+    ],
+    faq: [
+      {
+        question: 'Which TSA checkpoint should I use for United at Dulles?',
+        answer: 'Dulles has East and West checkpoints in the main terminal — both have Pre✓ and CLEAR. Choose whichever has the shorter line. The East Checkpoint opens an hour earlier (3:45 AM vs 4:45 AM).',
+      },
+      {
+        question: 'Does Dulles have TSA PreCheck for United flights?',
+        answer: 'Yes. Both East and West checkpoints have TSA PreCheck lanes, available from 4:30 AM to 9:00 PM.',
+      },
+      {
+        question: 'Is CLEAR available at Dulles airport?',
+        answer: 'Yes. CLEAR+ lanes are at both East and West checkpoints, open from 4:30 AM to 9:30 PM. CLEAR kiosks are located near each checkpoint on the Departures level.',
+      },
+      {
+        question: 'How long does TSA take at Dulles for United flights?',
+        answer: 'TSA wait times at IAD average 10–15 minutes. Peak times are 5:00–8:00 AM and 3:00–6:00 PM. PreCheck averages about 3 minutes. IAD is generally one of the more efficient airports for security screening.',
+      },
+      {
+        question: 'How early should I arrive for United flights at IAD?',
+        answer: 'Arrive 2 hours before domestic flights and 3 hours before international flights. After clearing security, you\'ll take the AeroTrain to your concourse — allow 5–10 minutes for the ride.',
+      },
+    ],
+  },
+
+  LAX: {
+    iata: 'LAX',
+    name: 'Los Angeles International Airport',
+    city: 'Los Angeles, CA',
+    terminals: 'Terminals 7 & 8',
+    terminalNote: 'United uses a shared security checkpoint at Terminal 7 serving both Terminals 7 and 8',
+    checkpoints: [
+      {
+        name: 'Terminal 7 Checkpoint',
+        terminal: 'Terminal 7',
+        hours: '4:00 AM – 12:00 AM',
+        lanes: {
+          standard: true,
+          precheck: true,
+          clear: true,
+          priority: false,
+        },
+        precheckHours: '4:00 AM – 10:30 PM',
+        clearHours: '4:00 AM – 10:30 PM',
+      },
+    ],
+    tips: [
+      'There\'s only one checkpoint serving both Terminals 7 and 8 — lines can build up fast.',
+      'LAX Fast Lane is free for all passengers departing T7/T8, available 5:00 AM – 1:00 PM.',
+      'Pre✓ and CLEAR share the same checkpoint — combine them for fastest screening.',
+      'LAX traffic is unpredictable — allow extra time for the drive to the airport.',
+    ],
+    faq: [
+      {
+        question: 'Which TSA checkpoint does United use at LAX?',
+        answer: 'United uses the Terminal 7 checkpoint, which serves both Terminals 7 and 8. It\'s a 12-lane checkpoint open from 4:00 AM to midnight. Pre✓, CLEAR, and the free LAX Fast Lane are all available.',
+      },
+      {
+        question: 'Does LAX have TSA PreCheck for United flights?',
+        answer: 'Yes. TSA PreCheck lanes are available at the Terminal 7 checkpoint from 4:00 AM to 10:30 PM.',
+      },
+      {
+        question: 'Is CLEAR available at United\'s LAX terminal?',
+        answer: 'Yes. CLEAR+ lanes are at the Terminal 7 checkpoint from 4:00 AM to 10:30 PM.',
+      },
+      {
+        question: 'What is the LAX Fast Lane for United passengers?',
+        answer: 'LAX Fast Lane is a free expedited screening service available to all passengers at Terminals 7 and 8 from 5:00 AM to 1:00 PM daily. It\'s separate from Pre✓ and CLEAR — anyone can use it during operating hours.',
+      },
+      {
+        question: 'How early should I arrive for United flights at LAX?',
+        answer: 'Arrive 2.5 hours before domestic flights and 3.5 hours before international flights. LAX is one of the busiest airports in the US, and LA traffic to the airport is notoriously unpredictable. With Pre✓ or CLEAR, 2 hours domestic / 3 hours international is usually enough.',
+      },
+    ],
+  },
+};
+
+/** Ordered list of hub IATA codes (matches hubOrder from src/data/hubs/index.js) */
+export const tsaHubOrder = ['ORD', 'DEN', 'IAH', 'EWR', 'SFO', 'IAD', 'LAX'];
+
+/** Flat list of all FAQ entries with hub context for structured data */
+export function getAllFaqEntries() {
+  return tsaHubOrder.flatMap((code) => {
+    const hub = unitedTerminals[code];
+    return hub.faq.map((entry) => ({
+      hub: code,
+      hubName: hub.name,
+      ...entry,
+    }));
+  });
+}

--- a/src/layouts/HubLayout.astro
+++ b/src/layouts/HubLayout.astro
@@ -267,6 +267,13 @@ nav.jump-nav a:hover{border-color:var(--ua-accent);color:var(--ua-accent);text-d
 
   <Fragment set:html={data.contentHtml} />
 
+  <!-- TSA Cross-link (domestic hubs only) -->
+  {['ord','den','iah','ewr','sfo','iad','lax'].includes(iataLower) && (
+    <div style="background:var(--ua-panel);border-left:3px solid var(--ua-amber);padding:10px 14px;border-radius:0 6px 6px 0;font-size:12px;color:var(--ua-text);margin-bottom:24px">
+      <span style="color:var(--ua-amber);font-family:var(--font-ui);font-weight:600">TSA Wait Times</span> — Check live checkpoint wait times at United terminals. <a href={`/tsa#${iataLower}`} style="color:var(--ua-accent)">View {iata} TSA status &rarr;</a>
+    </div>
+  )}
+
   <!-- Other Hubs -->
   <div class="section">
     <h2 id="all-hubs">All United Hubs</h2>

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -30,6 +30,7 @@ export function GET() {
   const fleetKeys = fleetOrder as Array<keyof typeof fleetTypes>;
   const urls = [
     renderUrl('/', getLastModified(homeLastmodPaths), 'daily', '1.0'),
+    renderUrl('/tsa', new Date().toISOString().split('T')[0], 'hourly', '0.9'),
     renderUrl('/fleet', getLastModified(fleetIndexLastmodPaths), 'daily', '0.9'),
     ...fleetKeys.map((key) =>
       renderUrl(

--- a/src/pages/tsa.astro
+++ b/src/pages/tsa.astro
@@ -1,0 +1,503 @@
+---
+import { unitedTerminals, tsaHubOrder, getAllFaqEntries } from '../data/tsa/united-terminals.js';
+import Footer from '../components/Footer.astro';
+
+const faqEntries = getAllFaqEntries();
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="theme-color" content="#0B1018">
+<link rel="icon" href="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%2064%2064%27%3E%3Crect%20width%3D%2764%27%20height%3D%2764%27%20rx%3D%2712%27%20fill%3D%27%230a0e14%27/%3E%3Ctext%20x%3D%2732%27%20y%3D%2742%27%20font-size%3D%2736%27%20text-anchor%3D%27middle%27%20fill%3D%27%23005DAA%27%20font-family%3D%27Arial%2C%20sans-serif%27%3EB%3C/text%3E%3C/svg%3E">
+<title>United Airlines TSA Wait Times — Checkpoint Status at All 7 Hubs | The Blue Board</title>
+<meta name="description" content="Live TSA checkpoint wait times at United Airlines terminals. Pre✓, CLEAR, and standard lane status at ORD, DEN, IAH, EWR, SFO, IAD, and LAX. Checkpoint hours, tips, and security line info — updated every 5 minutes.">
+<meta name="author" content="The Blue Board">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://theblueboard.co/tsa">
+<meta property="og:type" content="website">
+<meta property="og:locale" content="en_US">
+<meta property="og:title" content="United Airlines TSA Wait Times — All 7 Hubs | The Blue Board">
+<meta property="og:description" content="Live TSA checkpoint wait times at United terminals. Pre✓, CLEAR, standard lanes at ORD, DEN, IAH, EWR, SFO, IAD, LAX.">
+<meta property="og:url" content="https://theblueboard.co/tsa">
+<meta property="og:site_name" content="The Blue Board">
+<meta property="og:image" content="https://theblueboard.co/og-image.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="The Blue Board — United Airlines TSA Wait Times">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:creator" content="@theblueboard">
+<meta name="twitter:title" content="United Airlines TSA Wait Times — All 7 Hubs | The Blue Board">
+<meta name="twitter:description" content="Live TSA checkpoint wait times at United terminals. Pre✓, CLEAR, standard lanes at all 7 domestic hubs.">
+<meta name="twitter:image" content="https://theblueboard.co/og-image.png">
+<meta name="twitter:site" content="@theblueboard">
+
+<!-- Schema: BreadcrumbList -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {"@type": "ListItem", "position": 1, "name": "The Blue Board", "item": "https://theblueboard.co"},
+    {"@type": "ListItem", "position": 2, "name": "TSA Wait Times", "item": "https://theblueboard.co/tsa"}
+  ]
+}
+</script>
+
+<!-- Schema: FAQPage -->
+<script type="application/ld+json" set:html={JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": faqEntries.map((e) => ({
+    "@type": "Question",
+    "name": e.question,
+    "acceptedAnswer": { "@type": "Answer", "text": e.answer }
+  }))
+})} />
+
+<link rel="stylesheet" href="/css/style.css">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<style>
+  /* TSA page-specific styles */
+  .tsa-page { max-width: 900px; margin: 0 auto; padding: 20px 16px 0; }
+  .tsa-breadcrumb { font-family: var(--font-ui); font-size: 11px; font-weight: 500; color: var(--ua-muted); margin-bottom: 20px; }
+  .tsa-breadcrumb a { color: var(--ua-accent); text-decoration: none; }
+  .tsa-breadcrumb a:hover { text-decoration: underline; }
+
+  .tsa-hero { margin-bottom: 32px; }
+  .tsa-hero h1 { font-family: var(--font-ui); font-size: 22px; font-weight: 700; letter-spacing: -0.5px; color: var(--ua-text); margin: 0 0 8px; }
+  .tsa-hero p { font-family: var(--font-body); font-size: 13px; color: var(--ua-muted); line-height: 1.7; margin: 0; }
+
+  .tsa-jump-nav { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 32px; }
+  .tsa-jump-pill { font-family: var(--font-mono); font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.8px; color: var(--ua-muted); background: var(--ua-panel); border: 1px solid var(--ua-border); border-radius: 20px; padding: 6px 14px; text-decoration: none; transition: all 150ms ease; }
+  .tsa-jump-pill:hover { color: var(--ua-blue); border-color: var(--ua-blue); background: rgba(0,93,170,0.08); transform: translateY(-1px); }
+
+  .tsa-hub-card { background: linear-gradient(180deg, var(--ua-panel) 0%, rgba(17,26,39,0.6) 100%); border: 1px solid var(--ua-border); border-radius: 6px; padding: 20px; margin-bottom: 24px; }
+  .tsa-hub-label { font-family: var(--font-mono); font-size: 10px; font-weight: 600; letter-spacing: 1.5px; text-transform: uppercase; color: var(--ua-amber); margin-bottom: 6px; }
+  .tsa-hub-title { font-family: var(--font-ui); font-size: 16px; font-weight: 700; color: var(--ua-text); margin: 0 0 4px; }
+  .tsa-hub-subtitle { font-family: var(--font-body); font-size: 12px; color: var(--ua-muted); margin: 0 0 16px; }
+
+  .tsa-wait-summary { display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 20px; padding-bottom: 16px; border-bottom: 1px solid var(--ua-border-subtle, var(--ua-border)); }
+  .tsa-wait-stat { flex: 1; min-width: 120px; }
+  .tsa-wait-stat-label { font-family: var(--font-mono); font-size: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--ua-muted); margin-bottom: 4px; }
+  .tsa-wait-stat-value { font-family: var(--font-mono); font-size: 22px; font-weight: 700; color: var(--ua-amber); }
+  .tsa-wait-stat-value.tsa-blurred { filter: blur(8px); user-select: none; pointer-events: none; }
+  .tsa-wait-unit { font-size: 12px; font-weight: 500; color: var(--ua-muted); margin-left: 2px; }
+  .tsa-wait-no-data { font-family: var(--font-mono); font-size: 11px; color: var(--ua-dim); }
+  .tsa-wait-green { color: #22C55E; }
+  .tsa-wait-amber { color: #C4A35A; }
+  .tsa-wait-yellow { color: #EAB308; }
+  .tsa-wait-red { color: #EF4444; }
+
+  .tsa-live-dot { display: inline-block; width: 6px; height: 6px; border-radius: 50%; background: #22C55E; margin-right: 6px; animation: tsa-pulse 2s ease-in-out infinite; }
+  @keyframes tsa-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.3; } }
+  .tsa-stale-dot { background: #EAB308; animation: none; }
+
+  .tsa-checkpoint-table { width: 100%; border-collapse: collapse; margin-bottom: 16px; }
+  .tsa-checkpoint-table th { font-family: var(--font-mono); font-size: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--ua-muted); text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--ua-border); }
+  .tsa-checkpoint-table td { font-family: var(--font-body); font-size: 12px; color: var(--ua-text); padding: 8px 10px; border-bottom: 1px solid var(--ua-border-subtle, var(--ua-border)); vertical-align: middle; }
+  .tsa-checkpoint-table tr:last-child td { border-bottom: none; }
+  .tsa-checkpoint-name { font-family: var(--font-ui); font-weight: 600; font-size: 13px; }
+
+  .tsa-lane-badge { font-family: var(--font-mono); font-size: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.3px; padding: 3px 8px; border-radius: 3px; display: inline-block; margin: 2px 4px 2px 0; white-space: nowrap; }
+  .tsa-lane-standard { background: rgba(226,232,240,0.1); color: var(--ua-text); }
+  .tsa-lane-precheck { background: rgba(34,197,94,0.1); color: #22C55E; border: 1px solid rgba(34,197,94,0.2); }
+  .tsa-lane-clear { background: rgba(107,170,237,0.1); color: var(--ua-accent); border: 1px solid rgba(107,170,237,0.2); }
+  .tsa-lane-priority { background: rgba(196,163,90,0.1); color: var(--ua-amber); border: 1px solid rgba(196,163,90,0.2); }
+  .tsa-lane-na { opacity: 0.35; text-decoration: line-through; }
+
+  .tsa-tip { background: var(--ua-panel); border-left: 3px solid var(--ua-amber); padding: 10px 14px; border-radius: 0 6px 6px 0; font-size: 12px; color: var(--ua-text); margin-bottom: 8px; }
+  .tsa-tip-icon { margin-right: 6px; }
+
+  .tsa-hub-footer { font-family: var(--font-mono); font-size: 10px; color: var(--ua-dim); margin-top: 12px; }
+  .tsa-hub-crosslink { font-family: var(--font-ui); font-size: 11px; margin-top: 8px; }
+  .tsa-hub-crosslink a { color: var(--ua-accent); text-decoration: none; }
+  .tsa-hub-crosslink a:hover { text-decoration: underline; }
+
+  .tsa-faq-section { margin-top: 40px; padding-top: 24px; border-top: 1px solid var(--ua-border); }
+  .tsa-faq-section h2 { font-family: var(--font-ui); font-size: 16px; font-weight: 700; color: var(--ua-text); margin: 0 0 16px; }
+  .tsa-faq-item { margin-bottom: 16px; }
+  .tsa-faq-q { font-family: var(--font-ui); font-size: 13px; font-weight: 600; color: var(--ua-text); margin: 0 0 4px; }
+  .tsa-faq-a { font-family: var(--font-body); font-size: 12px; color: var(--ua-muted); line-height: 1.7; margin: 0; }
+  .tsa-faq-hub-label { font-family: var(--font-mono); font-size: 9px; font-weight: 600; color: var(--ua-amber); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; }
+
+  /* Email gate modal */
+  .tsa-gate-overlay { position: fixed; inset: 0; background: rgba(11,16,24,0.85); z-index: 1000; display: flex; align-items: center; justify-content: center; padding: 20px; }
+  .tsa-gate-overlay.tsa-hidden { display: none; }
+  .tsa-gate-modal { background: var(--ua-panel); border: 1px solid var(--ua-border); border-radius: 10px; padding: 32px 28px; max-width: 420px; width: 100%; text-align: center; }
+  .tsa-gate-logo { font-family: var(--font-mono); font-size: 10px; font-weight: 600; letter-spacing: 1.5px; text-transform: uppercase; color: var(--ua-blue); margin-bottom: 16px; }
+  .tsa-gate-title { font-family: var(--font-ui); font-size: 18px; font-weight: 700; color: var(--ua-text); margin: 0 0 8px; }
+  .tsa-gate-text { font-family: var(--font-body); font-size: 13px; color: var(--ua-muted); line-height: 1.6; margin: 0 0 20px; }
+  .tsa-gate-input { width: 100%; padding: 10px 14px; font-family: var(--font-body); font-size: 14px; background: var(--ua-panel-elevated, #152032); border: 1px solid var(--ua-border); border-radius: 6px; color: var(--ua-text); outline: none; box-sizing: border-box; margin-bottom: 12px; }
+  .tsa-gate-input:focus { border-color: var(--ua-blue); }
+  .tsa-gate-input::placeholder { color: var(--ua-dim); }
+  .tsa-gate-btn { width: 100%; padding: 10px; font-family: var(--font-ui); font-size: 14px; font-weight: 600; background: var(--ua-blue); color: white; border: none; border-radius: 6px; cursor: pointer; transition: opacity 150ms ease; }
+  .tsa-gate-btn:hover { opacity: 0.9; }
+  .tsa-gate-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+  .tsa-gate-privacy { font-family: var(--font-body); font-size: 9px; color: var(--ua-dim); margin-top: 10px; }
+  .tsa-gate-dismiss { font-family: var(--font-body); font-size: 11px; color: var(--ua-dim); text-decoration: underline; text-underline-offset: 2px; background: none; border: none; cursor: pointer; margin-top: 14px; transition: color 150ms ease; }
+  .tsa-gate-dismiss:hover { color: var(--ua-muted); }
+  .tsa-gate-error { font-family: var(--font-body); font-size: 11px; color: var(--ua-red); margin-top: 8px; display: none; }
+
+  @media (max-width: 600px) {
+    .tsa-hero h1 { font-size: 18px; }
+    .tsa-hub-card { padding: 16px; }
+    .tsa-wait-stat-value { font-size: 18px; }
+    .tsa-checkpoint-table { font-size: 11px; }
+    .tsa-checkpoint-table th, .tsa-checkpoint-table td { padding: 6px 6px; }
+    .tsa-wait-summary { flex-direction: column; gap: 12px; }
+  }
+</style>
+</head>
+<body>
+<main class="tsa-page">
+
+  <!-- Breadcrumb -->
+  <nav class="tsa-breadcrumb" aria-label="Breadcrumb">
+    <a href="/">&larr; The Blue Board</a> / TSA Wait Times
+  </nav>
+
+  <!-- Hero -->
+  <div class="tsa-hero">
+    <h1>TSA Security Wait Times</h1>
+    <p>Live checkpoint wait times at United Airlines terminals across all 7 domestic hubs. Standard, Pre✓, CLEAR, and Priority lane availability — updated every 5 minutes.</p>
+  </div>
+
+  <!-- Jump nav -->
+  <nav class="tsa-jump-nav" aria-label="Hub navigation">
+    {tsaHubOrder.map((code) => (
+      <a class="tsa-jump-pill" href={`#${code.toLowerCase()}`}>{code}</a>
+    ))}
+  </nav>
+
+  <!-- Hub cards -->
+  {tsaHubOrder.map((code) => {
+    const hub = unitedTerminals[code];
+    return (
+      <section class="tsa-hub-card" id={code.toLowerCase()}>
+        <div class="tsa-hub-label">TSA Wait Times</div>
+        <h2 class="tsa-hub-title">{code} — {hub.name.replace(/Airport$/i, '').replace(/International$/i, 'Intl').trim()}</h2>
+        <p class="tsa-hub-subtitle">{hub.terminals}{hub.terminalNote ? ` · ${hub.terminalNote}` : ''}</p>
+
+        <!-- Wait time summary (filled by JS) -->
+        <div class="tsa-wait-summary" data-hub={code}>
+          <div class="tsa-wait-stat">
+            <div class="tsa-wait-stat-label">Standard Wait</div>
+            <div class="tsa-wait-stat-value tsa-blurred" data-wait-type="standard" data-hub-code={code}>
+              --<span class="tsa-wait-unit">min</span>
+            </div>
+          </div>
+          <div class="tsa-wait-stat">
+            <div class="tsa-wait-stat-label">Pre✓ Wait</div>
+            <div class="tsa-wait-stat-value tsa-blurred" data-wait-type="precheck" data-hub-code={code}>
+              --<span class="tsa-wait-unit">min</span>
+            </div>
+          </div>
+          <div class="tsa-wait-stat">
+            <div class="tsa-wait-stat-label">Status</div>
+            <div class="tsa-wait-stat-value" style="font-size:12px" data-wait-type="status" data-hub-code={code}>
+              <span class="tsa-wait-no-data">Loading...</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Checkpoint table -->
+        <table class="tsa-checkpoint-table">
+          <thead>
+            <tr>
+              <th>Checkpoint</th>
+              <th>Hours</th>
+              <th>Lanes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {hub.checkpoints.map((cp) => (
+              <tr>
+                <td>
+                  <div class="tsa-checkpoint-name">{cp.name}</div>
+                  <div style="font-size:10px;color:var(--ua-dim)">{cp.terminal}</div>
+                </td>
+                <td>
+                  <div style="font-family:var(--font-mono);font-size:11px">{cp.hours}</div>
+                  {cp.precheckHours && cp.precheckHours !== cp.hours && (
+                    <div style="font-size:10px;color:var(--ua-dim)">Pre✓: {cp.precheckHours}</div>
+                  )}
+                </td>
+                <td>
+                  <span class="tsa-lane-badge tsa-lane-standard">Standard</span>
+                  <span class={`tsa-lane-badge tsa-lane-precheck ${cp.lanes.precheck ? '' : 'tsa-lane-na'}`}>Pre✓</span>
+                  <span class={`tsa-lane-badge tsa-lane-clear ${cp.lanes.clear ? '' : 'tsa-lane-na'}`}>CLEAR</span>
+                  {cp.lanes.priority && (
+                    <span class="tsa-lane-badge tsa-lane-priority">Priority</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        <!-- Tips -->
+        {hub.tips.slice(0, 2).map((tip) => (
+          <div class="tsa-tip"><span class="tsa-tip-icon">💡</span>{tip}</div>
+        ))}
+
+        <!-- Footer -->
+        <div class="tsa-hub-footer" data-last-updated={code}>
+          <span class="tsa-live-dot" style="display:none" data-live-dot={code}></span>
+          <span data-timestamp={code}>Waiting for data...</span>
+        </div>
+        <div class="tsa-hub-crosslink">
+          <a href={`/hubs/${code.toLowerCase()}`}>View {code} hub status &rarr;</a>
+        </div>
+      </section>
+    );
+  })}
+
+  <!-- FAQ Section -->
+  <section class="tsa-faq-section">
+    <h2>Frequently Asked Questions</h2>
+    {tsaHubOrder.map((code) => {
+      const hub = unitedTerminals[code];
+      return (
+        <div style="margin-bottom:24px">
+          <div class="tsa-faq-hub-label">{code} — {hub.city}</div>
+          {hub.faq.slice(0, 3).map((entry) => (
+            <div class="tsa-faq-item">
+              <h3 class="tsa-faq-q">{entry.question}</h3>
+              <p class="tsa-faq-a">{entry.answer}</p>
+            </div>
+          ))}
+        </div>
+      );
+    })}
+  </section>
+
+</main>
+
+<Footer />
+
+<!-- Email gate modal -->
+<div class="tsa-gate-overlay tsa-hidden" id="tsa-gate">
+  <div class="tsa-gate-modal">
+    <div class="tsa-gate-logo">The Blue Board</div>
+    <h2 class="tsa-gate-title">Unlock Live TSA Wait Times</h2>
+    <p class="tsa-gate-text">Enter your email for live checkpoint wait times at United terminals — plus delay alerts, fleet updates, and hub intel.</p>
+    <input class="tsa-gate-input" type="email" id="tsa-gate-email" placeholder="you@airline.com" autocomplete="email">
+    <button class="tsa-gate-btn" id="tsa-gate-submit">Get Free Access &rarr;</button>
+    <div class="tsa-gate-error" id="tsa-gate-error"></div>
+    <div class="tsa-gate-privacy">No spam. Unsubscribe anytime.</div>
+    <button class="tsa-gate-dismiss" id="tsa-gate-dismiss">No thanks, I'll just guess</button>
+  </div>
+</div>
+
+<script>
+(function() {
+  'use strict';
+
+  var STORAGE_KEY = 'tsa_email_unlocked';
+  var DISMISS_KEY = 'tsa_gate_dismissed';
+  var REFRESH_INTERVAL = 60000;
+
+  var isUnlocked = localStorage.getItem(STORAGE_KEY) === 'true';
+  var isDismissed = localStorage.getItem(DISMISS_KEY) === 'true';
+
+  function unblurAll() {
+    var els = document.querySelectorAll('.tsa-blurred');
+    for (var i = 0; i < els.length; i++) els[i].classList.remove('tsa-blurred');
+  }
+
+  function showGate() {
+    var overlay = document.getElementById('tsa-gate');
+    if (overlay) overlay.classList.remove('tsa-hidden');
+  }
+
+  function hideGate() {
+    var overlay = document.getElementById('tsa-gate');
+    if (overlay) overlay.classList.add('tsa-hidden');
+  }
+
+  if (isUnlocked) {
+    unblurAll();
+  } else if (!isDismissed) {
+    setTimeout(showGate, 2000);
+  }
+
+  // Submit email
+  var submitBtn = document.getElementById('tsa-gate-submit');
+  var emailInput = document.getElementById('tsa-gate-email');
+  var errorEl = document.getElementById('tsa-gate-error');
+
+  if (submitBtn && emailInput) {
+    submitBtn.addEventListener('click', function() {
+      var email = emailInput.value.trim();
+      if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+        errorEl.textContent = 'Please enter a valid email address.';
+        errorEl.style.display = 'block';
+        return;
+      }
+
+      submitBtn.disabled = true;
+      submitBtn.textContent = 'Signing up...';
+      errorEl.style.display = 'none';
+
+      fetch('/api/waitlist', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: email, source: 'tsa-page' }),
+      })
+        .then(function(resp) {
+          if (resp.ok || resp.status === 409) {
+            localStorage.setItem(STORAGE_KEY, 'true');
+            isUnlocked = true;
+            unblurAll();
+            hideGate();
+          } else {
+            return resp.json().catch(function() { return {}; }).then(function(data) {
+              errorEl.textContent = data.error || 'Something went wrong. Try again.';
+              errorEl.style.display = 'block';
+              submitBtn.disabled = false;
+              submitBtn.textContent = 'Get Free Access \u2192';
+            });
+          }
+        })
+        .catch(function() {
+          errorEl.textContent = 'Network error. Please try again.';
+          errorEl.style.display = 'block';
+          submitBtn.disabled = false;
+          submitBtn.textContent = 'Get Free Access \u2192';
+        });
+    });
+
+    emailInput.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter') submitBtn.click();
+    });
+  }
+
+  // Dismiss gate
+  var dismissBtn = document.getElementById('tsa-gate-dismiss');
+  if (dismissBtn) {
+    dismissBtn.addEventListener('click', function() {
+      localStorage.setItem(DISMISS_KEY, 'true');
+      isDismissed = true;
+      unblurAll();
+      hideGate();
+    });
+  }
+
+  // --- Live data ---
+  function getWaitColor(minutes) {
+    if (minutes === null || minutes === undefined) return '';
+    if (minutes < 10) return 'tsa-wait-green';
+    if (minutes <= 20) return 'tsa-wait-amber';
+    if (minutes <= 30) return 'tsa-wait-yellow';
+    return 'tsa-wait-red';
+  }
+
+  function setWaitValue(el, minutes) {
+    if (minutes === null || minutes === undefined) {
+      el.textContent = '';
+      var noData = document.createElement('span');
+      noData.className = 'tsa-wait-no-data';
+      noData.textContent = 'No data';
+      el.appendChild(noData);
+      return;
+    }
+    el.textContent = '';
+    var val = minutes === 0 ? '< 1' : minutes >= 120 ? '2+' : String(minutes);
+    el.appendChild(document.createTextNode(val));
+    var unit = document.createElement('span');
+    unit.className = 'tsa-wait-unit';
+    unit.textContent = minutes >= 120 ? 'hrs' : 'min';
+    el.appendChild(unit);
+  }
+
+  function isStale(lastUpdated) {
+    if (!lastUpdated) return true;
+    return (Date.now() - new Date(lastUpdated).getTime()) > 600000;
+  }
+
+  function fetchTsaData() {
+    return fetch('/api/tsa').then(function(r) {
+      if (!r.ok) throw new Error('API error');
+      return r.json();
+    }).catch(function() { return null; });
+  }
+
+  function updateUI(data) {
+    if (!data || !data.hubs) return;
+
+    var codes = Object.keys(data.hubs);
+    for (var i = 0; i < codes.length; i++) {
+      var code = codes[i];
+      var hub = data.hubs[code];
+
+      // Standard wait
+      var stdEl = document.querySelector('[data-wait-type="standard"][data-hub-code="' + code + '"]');
+      if (stdEl) {
+        var stdColor = getWaitColor(hub.standardWait);
+        stdEl.className = 'tsa-wait-stat-value' + (stdColor ? ' ' + stdColor : '');
+        if (!isUnlocked && !isDismissed) stdEl.classList.add('tsa-blurred');
+        setWaitValue(stdEl, hub.standardWait);
+      }
+
+      // PreCheck wait
+      var preEl = document.querySelector('[data-wait-type="precheck"][data-hub-code="' + code + '"]');
+      if (preEl) {
+        var preColor = getWaitColor(hub.precheckWait);
+        preEl.className = 'tsa-wait-stat-value' + (preColor ? ' ' + preColor : '');
+        if (!isUnlocked && !isDismissed) preEl.classList.add('tsa-blurred');
+        setWaitValue(preEl, hub.precheckWait);
+      }
+
+      // Status
+      var statusEl = document.querySelector('[data-wait-type="status"][data-hub-code="' + code + '"]');
+      if (statusEl) {
+        statusEl.textContent = '';
+        if (hub.standardWait !== null || hub.precheckWait !== null) {
+          var stale = isStale(hub.lastUpdated);
+          var dot = document.createElement('span');
+          dot.className = stale ? 'tsa-live-dot tsa-stale-dot' : 'tsa-live-dot';
+          statusEl.appendChild(dot);
+          var label = document.createElement('span');
+          label.style.cssText = 'font-family:var(--font-mono);font-size:11px;color:var(--ua-muted)';
+          label.textContent = stale ? 'Stale' : 'Live';
+          statusEl.appendChild(label);
+        } else {
+          var nd = document.createElement('span');
+          nd.className = 'tsa-wait-no-data';
+          nd.textContent = 'No data available';
+          statusEl.appendChild(nd);
+        }
+      }
+
+      // Live dot in footer
+      var liveDot = document.querySelector('[data-live-dot="' + code + '"]');
+      if (liveDot && (hub.standardWait !== null || hub.precheckWait !== null)) {
+        liveDot.style.display = 'inline-block';
+        if (isStale(hub.lastUpdated)) liveDot.classList.add('tsa-stale-dot');
+        else liveDot.classList.remove('tsa-stale-dot');
+      }
+
+      // Timestamp
+      var tsEl = document.querySelector('[data-timestamp="' + code + '"]');
+      if (tsEl && hub.lastUpdated) {
+        var d = new Date(hub.lastUpdated);
+        var timeStr = d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true });
+        var ago = Math.round((Date.now() - d.getTime()) / 60000);
+        tsEl.textContent = ago <= 1 ? 'Updated just now' : 'Updated ' + ago + ' min ago \u00b7 ' + timeStr;
+      } else if (tsEl) {
+        tsEl.textContent = 'No data available';
+      }
+    }
+  }
+
+  // Initial fetch
+  fetchTsaData().then(updateUI);
+
+  // Auto-refresh
+  setInterval(function() { fetchTsaData().then(updateUI); }, REFRESH_INTERVAL);
+})();
+</script>
+</body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -18,11 +18,14 @@
         "api/cron/sync-starlink.ts": { "maxDuration": 30 },
         "api/starlink-data.ts": { "maxDuration": 20 },
         "api/predict-flight.ts": { "maxDuration": 15 },
-        "api/news-notify.ts": { "maxDuration": 15 }
+        "api/news-notify.ts": { "maxDuration": 15 },
+        "api/tsa.ts": { "maxDuration": 30 },
+        "api/cron/refresh-tsa.ts": { "maxDuration": 30 }
     },
     "crons": [
         { "path": "/api/cron/warm-schedules", "schedule": "*/15 * * * *" },
-        { "path": "/api/cron/sync-starlink", "schedule": "0 */4 * * *" }
+        { "path": "/api/cron/sync-starlink", "schedule": "0 */4 * * *" },
+        { "path": "/api/cron/refresh-tsa", "schedule": "*/5 * * * *" }
     ],
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
@@ -67,6 +70,12 @@
       "source": "/hubs/(.*)",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=3600, s-maxage=86400, stale-while-revalidate=600" }
+      ]
+    },
+    {
+      "source": "/tsa",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=300, s-maxage=3600, stale-while-revalidate=600" }
       ]
     },
     {


### PR DESCRIPTION
## Summary
- New `/tsa` page with live TSA checkpoint wait times at United terminals across all 7 domestic hubs
- Per-checkpoint lane breakdown: Standard, Pre✓, CLEAR, Priority with availability badges
- Serverless API proxy (`/api/tsa`) fetching MyTSA gov API with 5-minute in-memory cache
- Cron job (`/api/cron/refresh-tsa`) warming cache every 5 minutes
- Email gate modal for lead capture (dismissible, persisted via localStorage)
- 35 FAQ entries with FAQPage structured data for SEO
- Jump nav pills, mobile responsive layout, hub cross-links
- TSA cross-link banner on all 7 domestic hub pages (correctly excludes NRT/GUM)

## Test Coverage
- All 288 existing tests pass
- Build compiles successfully (36 pages)
- Browser QA verified: desktop, tablet (768px), mobile (375px)
- Zero console errors, zero failed network requests

## Pre-Landing Review
- Input validation on MyTSA `Wait_Time` buckets (reject negative/non-integer values)
- Dismiss gate properly unblurs wait time values
- `__HOME_LASTMOD__` placeholder preserved for build stamp
- TSA cross-link gated to domestic hubs only (Codex finding)
- Unused `TsaWaitTime` interface removed

## Codex Review
- GATE: PASS (0 P1, 1 P2 — fixed)
- P2: TSA deep links on NRT/GUM hub pages pointed to non-existent anchors — fixed

## Test plan
- [x] Build compiles (36 pages)
- [x] All 288 tests pass
- [x] Browser QA: email gate, jump nav, lane badges, responsive layout
- [x] Codex code review: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)