### PR TITLE
Fix delay weather context for inbound flights

### DIFF
--- a/api/delay-explain.ts
+++ b/api/delay-explain.ts
@@ -25,6 +25,7 @@ interface DelayContext {
   otp?: string;
   weather?: string;
   destWeather?: string;
+  faaStatus?: string;
   inbound?: string;
   hub?: string;
   irops?: string;
@@ -41,7 +42,8 @@ function sanitize(val: string | undefined, maxLen: number): string {
 function getCacheKey(ctx: DelayContext): string {
   const inboundKey = ctx.inbound ? ctx.inbound.slice(0, 100) : '';
   const weatherKey = (ctx.weather || '').slice(0, 40) + '|' + (ctx.destWeather || '').slice(0, 40);
-  return `${ctx.flight}:${ctx.route || ''}:${ctx.status || ''}:${ctx.riskScore}:${(ctx.factors || []).join(',')}:${ctx.otp || ''}:${ctx.hub || ''}:${ctx.irops || ''}:${inboundKey}:${weatherKey}`;
+  const faaKey = (ctx.faaStatus || '').slice(0, 120);
+  return `${ctx.flight}:${ctx.route || ''}:${ctx.status || ''}:${ctx.riskScore}:${(ctx.factors || []).join(',')}:${ctx.otp || ''}:${ctx.hub || ''}:${ctx.irops || ''}:${inboundKey}:${weatherKey}:${faaKey}`;
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -96,6 +98,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       lines.push(`Contributing factors: ${ctx.factors.map(f => sanitize(f, 80)).join('; ')}`);
     }
     if (ctx.otp) lines.push(`Hub on-time performance: ${sanitize(ctx.otp, 10)}%`);
+    if (ctx.faaStatus) lines.push(`FAA status: ${sanitize(ctx.faaStatus, 300)}`);
     if (ctx.weather) lines.push(`Origin weather: ${sanitize(ctx.weather, 200)}`);
     if (ctx.destWeather) lines.push(`Destination weather: ${sanitize(ctx.destWeather, 200)}`);
     if (ctx.irops) lines.push(`Hub disruption status: ${sanitize(ctx.irops, 200)}`);
@@ -110,6 +113,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
 CRITICAL RULE: You may ONLY discuss data that is explicitly provided in the user message below. Do NOT invent, assume, or speculate about information that is not present. Specifically:
 - If no "Aircraft journey" line is provided, do NOT discuss inbound aircraft, turnaround times, rotations, or crew legality.
+- If no "FAA status" line is provided, do NOT discuss FAA programs, ATC flow restrictions, or stated causes like weather/thunderstorms.
 - If no "Origin weather" or "Destination weather" line is provided, do NOT discuss weather conditions, de-icing, thunderstorms, or visibility.
 - If no "Hub disruption status" line is provided, do NOT discuss cancellation rates or IROPS.
 - If no "Hub on-time performance" line is provided, do NOT cite OTP percentages.
@@ -118,8 +122,8 @@ Never fabricate operational details. If the data is sparse, give a shorter analy
 
 Analysis framework — discuss ONLY topics where data is provided:
 1. AIRCRAFT ROUTING (only if "Aircraft journey" data is present): Explain delay propagation across segments. If turnaround time is tight, state the specific math. Note de-icing impact if freezing conditions are mentioned.
-2. FAA PROGRAMS (only if contributing factors mention GDP, ground stop, or closure): Explain what the program means for this flight's departure window.
-3. WEATHER (only if weather data is present): Distinguish between departure weather (taxi, de-icing, takeoff) and arrival weather (holds, diversions). SFO LIFR = single-stream runway ops (~50% capacity). EWR LIFR = crossing runway restrictions.
+2. FAA STATUS (only if "FAA status" data is present): Explain the airport program or delay status and its stated cause. If the FAA status says delays are due to weather or thunderstorms, treat that as authoritative network-level weather constraint.
+3. WEATHER (only if weather data is present): Distinguish between departure weather (taxi, de-icing, takeoff) and arrival weather (holds, diversions). If FAA status cites weather but the METAR looks normal, say the operational impact is likely broader airspace/weather flow control rather than field conditions alone. SFO LIFR = single-stream runway ops (~50% capacity). EWR LIFR = crossing runway restrictions.
 4. NETWORK HEALTH (only if OTP or disruption data is present): Explain what low OTP or high cancellation rates mean for this flight.
 5. TIME-OF-DAY: You may always comment on time-of-day cascade effects if the hub time is provided, since this is general knowledge.
 6. DELAY MAGNITUDE: If a large delay is already reported, explain what a delay of that size typically means operationally — but stick to general implications, not invented specifics about this aircraft's history.

--- a/api/flight-times.ts
+++ b/api/flight-times.ts
@@ -3,6 +3,7 @@
 // Returns scheduled, estimated, and actual gate/takeoff/landing times
 
 import type { VercelRequest, VercelResponse } from './types.js';
+import { icaoToIata } from '../src/lib/airport-metadata.js';
 
 const CACHE_TTL_MS = 60_000; // 1 minute
 const cache = new Map<string, { data: any; ts: number }>();
@@ -134,14 +135,6 @@ async function tryFR24Summary(req: VercelRequest, res: VercelResponse, flight: s
       source: 'fr24-summary',
       cached: false,
     };
-    // Map ICAO to IATA for origin/dest (strip leading K for US airports, else use ICAO as-is)
-    function icaoToIata(icao: string): string {
-      if (!icao) return '';
-      if (icao.length === 4 && icao.startsWith('K')) return icao.slice(1);
-      // Common international mappings
-      const map: Record<string, string> = { RJAA: 'NRT', RJTT: 'HND', PGUM: 'GUM', EGLL: 'LHR', LFPG: 'CDG', EDDF: 'FRA', RCKH: 'KHH', VHHH: 'HKG', WSSS: 'SIN', NZAA: 'AKL', YSSY: 'SYD', LEMD: 'MAD', EHAM: 'AMS', OMDB: 'DXB', ZBAA: 'PEK' };
-      return map[icao] || icao;
-    }
     if (f.orig_icao) result.origin.iata = icaoToIata(f.orig_icao);
     if (f.dest_icao_actual || f.dest_icao) result.destination.iata = icaoToIata(f.dest_icao_actual || f.dest_icao);
     setCache(cacheKey, result);

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -3,6 +3,7 @@ import { createRateLimiter } from './_rate-limit.js';
 import { loadScheduleSnapshot, saveScheduleSnapshot } from './_schedule-snapshots.js';
 import { getStartOfDayForHub } from './irops.js';
 import { waitUntil } from '@vercel/functions';
+import { icaoToIata, isInternationalRoute } from '../src/lib/airport-metadata.js';
 
 const isRateLimited = createRateLimiter('schedule', 30);
 
@@ -44,26 +45,6 @@ const UNITED_HUB_TERMINALS: Record<string, { domestic: string; international: st
   NRT: { domestic: '1', international: '1' },       // Terminal 1
   GUM: { domestic: '1', international: '1' },       // Single terminal
 };
-
-// US airport IATA codes (3-letter codes starting from common US airports)
-// Used to determine if a route is domestic or international for terminal assignment
-const US_AIRPORTS = new Set([
-  // United hubs
-  'ORD','DEN','EWR','IAH','SFO','LAX','IAD','GUM',
-  // Major US airports
-  'ATL','JFK','LGA','DFW','CLT','MIA','FLL','TPA','MCO','SEA','MSP','DTW','PHL','BOS',
-  'DCA','BWI','SAN','PHX','SLC','AUS','SAT','HOU','DAL','MDW','OAK','SJC','SMF','PDX',
-  'MCI','MSY','STL','IND','CLE','CVG','CMH','PIT','RDU','BNA','MKE','OMA','RSW',
-  // Hawaii (treated as domestic for terminal purposes)
-  'HNL','OGG','LIH','KOA',
-]);
-
-function isInternationalRoute(origIata: string, destIata: string): boolean {
-  if (!origIata || !destIata) return false;
-  const origUS = US_AIRPORTS.has(origIata.toUpperCase());
-  const destUS = US_AIRPORTS.has(destIata.toUpperCase());
-  return !(origUS && destUS);
-}
 
 function getHubTerminal(iata: string, isIntl: boolean): string {
   const hub = UNITED_HUB_TERMINALS[iata.toUpperCase()];
@@ -289,22 +270,6 @@ const FR24_API_BASE = 'https://fr24api.flightradar24.com';
 function formatForFR24(date: Date): string {
   // FR24 API expects YYYY-MM-DDTHH:MM:SSZ format (with trailing Z, no milliseconds)
   return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
-}
-
-function icaoToIata(icao: string): string {
-  if (!icao) return '';
-  if (icao.length === 4 && icao.startsWith('K')) return icao.slice(1);
-  const map: Record<string, string> = { RJAA:'NRT', RJTT:'HND', PGUM:'GUM', EGLL:'LHR', LFPG:'CDG',
-                EDDF:'FRA', VHHH:'HKG', WSSS:'SIN', NZAA:'AKL', YSSY:'SYD',
-                LEMD:'MAD', EHAM:'AMS', OMDB:'DXB', ZBAA:'PEK', RCTP:'TPE',
-                RJBB:'KIX', RKSI:'ICN', VTBS:'BKK', WMKK:'KUL', CYYZ:'YYZ',
-                CYUL:'YUL', CYVR:'YVR', MMMX:'MEX', MMUN:'CUN', TNCM:'SXM',
-                TXKF:'BDA', MUHA:'HAV', LIRF:'FCO', EGKK:'LGW', EIDW:'DUB',
-                LSZH:'ZRH', LOWW:'VIE', EKCH:'CPH', ENGM:'OSL', ESSA:'ARN',
-                EFHK:'HEL', LPPT:'LIS', LEBL:'BCN', LGAV:'ATH', LTFM:'IST',
-                VIDP:'DEL', VABB:'BOM', RPLL:'MNL', ZUUU:'CTU', ZSPD:'PVG',
-                ZSSS:'SHA', VVNB:'HAN', VVTS:'SGN' };
-  return map[icao] || icao;
 }
 
 const ICAO_TO_IATA_AIRLINE: Record<string, string> = { UAL:'UA', AAL:'AA', DAL:'DL', SWA:'WN', JBU:'B6', ASA:'AS', SKW:'OO', RPA:'YX', ENY:'MQ', GJS:'G7', ACA:'AC', BAW:'BA', DLH:'LH', AFR:'AF', KLM:'KL' };

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -1,5 +1,7 @@
 import { computeDelayRiskModel, HUB_COORDINATES, HUB_RISK_PROFILES } from '../lib/delay-risk.js';
-import { normalizeMetarPayload } from '../lib/metar.js';
+import { formatDelayExplainFAAStatus, getScheduleRiskContext } from '../lib/delay-explain-context.js';
+import { getMetarStationForIata, INTL_AIRPORTS } from '../lib/airport-metadata.js';
+import { chunkMetarStationIds, normalizeMetarPayload } from '../lib/metar.js';
 import { categorizeFleetStatus, FLEET_HEALTH_CATEGORIES, FLEET_FAMILIES, normalizeWifi, WIFI_DISPLAY, sortFleetData, filterFleetData, parseFleetDeepLink, TAB_MAP, VALID_FLEET_VIEWS } from '../lib/fleet-utils.js';
 
 // ═══════════════════════════════════════════════
@@ -233,7 +235,6 @@ const TERMINAL_WALK_TIMES = {
   IAH:{'A-B':8,'A-C':12,'A-D':15,'A-E':20,'B-C':8,'B-D':12,'B-E':15,'C-D':8,'C-E':12,'D-E':8,default:12},
   SFO:{default:12},IAD:{default:10},LAX:{'7-8':5,'7-B':15,'8-B':12,default:10},NRT:{default:15},GUM:{default:5}
 };
-const INTL_AIRPORTS = new Set(['NRT','GUM','HND','LHR','FRA','CDG','AMS','ZRH','FCO','MAD','BCN','DUB','IST','TLV','MUC','EDI','BRU','LIS','CPH','ARN','HEL','OSL','SIN','HKG','SYD','PEK','ICN','TPE','BKK','DEL','MEL','AKL','PVG','CAN','BOM','NAN','PPT','KIX','CTU','XIY','CKG','SNN','MAN','GLA']);
 // Known United Airlines terminals at each hub (fallback when API doesn't provide terminal data)
 const UNITED_HUB_TERMINALS = {
   ORD:{domestic:'1',international:'1'},       // Terminal 1 (B & C); Express uses T2
@@ -2595,9 +2596,16 @@ function hasRenderableMetarData(metar) {
 }
 
 async function fetchMetarBatch(allStations) {
-  const response = await fetch(`/api/metar?ids=${allStations}`);
-  if (!response.ok) throw new Error(`metar-${response.status}`);
-  return normalizeMetarPayload(await response.json());
+  const stationChunks = chunkMetarStationIds(allStations);
+  if (!stationChunks.length) return [];
+
+  const payloads = await Promise.all(stationChunks.map(async (stationIds) => {
+    const response = await fetch(`/api/metar?ids=${stationIds}`);
+    if (!response.ok) throw new Error(`metar-${response.status}`);
+    return normalizeMetarPayload(await response.json());
+  }));
+
+  return payloads.flat();
 }
 
 async function initWeatherTab() {
@@ -3444,6 +3452,7 @@ async function loadScheduleData() {
 
     schedAllFlights = allUAFlights;
     schedRawByHub[hubKey] = allUAFlights;
+    preloadWeatherAndFAA();
     detectEquipmentSwaps(allUAFlights, schedCurrentHub, schedCurrentDir, schedCurrentDay);
     populateAircraftFilter();
     // Reset advanced filters on hub/direction/day change
@@ -3769,18 +3778,18 @@ function renderScheduleTable() {
 
     // Watch button
     const isWatched = isFlightWatched(ident);
-    const origCode = fl.airport?.origin?.code?.iata || '?';
-    const destCode = fl.airport?.destination?.code?.iata || '?';
+    const { origCode, destCode, depHub, arrHub } = getScheduleRiskContext(fl, hub, schedCurrentDir);
     const watchRoute = `${origCode}→${destCode}`;
     const watchBtn = ident !== '—' ? `<button class="watch-btn${isWatched ? ' watching' : ''}" data-action="toggle-watch-flight" data-flight="${escapeHtml(ident)}" data-route="${escapeHtml(watchRoute)}" data-status="${escapeHtml(status.text)}" data-stop-prop="1" aria-label="${isWatched ? 'Unwatch flight' : 'Watch flight'}" title="${isWatched ? 'Unwatch' : 'Watch'} this flight">${isWatched ? ICO_WATCHING : ICO_WATCH}</button>` : '';
 
     // Delay risk scoring
     const dRisk = computeDelayRiskForScheduleFlight(fl, hub);
-    const schedRiskOtp = hubHealthData[hub];
-    const schedRiskWxOrig = weatherOpsByHub[hub];
-    const schedRiskWxDest = weatherOpsByHub[destCode];
-    const schedRiskIrops = iropsHubData[hub];
-    const riskCell = dRisk ? `<span class="delay-risk-badge" data-action="explain-delay" data-flight="${escapeHtml(ident)}" data-route="${escapeHtml(origCode + '\u2192' + destCode)}" data-status="${escapeHtml(status.text)}" data-risk-label="${dRisk.label}" data-risk-score="${dRisk.score}" data-risk-factors="${escapeHtml(dRisk.factors.join('|'))}" data-hub="${escapeHtml(hub)}"${schedRiskOtp !== undefined ? ' data-otp="' + schedRiskOtp + '"' : ''}${schedRiskWxOrig ? ' data-weather="' + escapeHtml(schedRiskWxOrig.level + (schedRiskWxOrig.reasons.length ? ': ' + schedRiskWxOrig.reasons.join(', ') : '')) + '"' : ''}${schedRiskWxDest ? ' data-dest-weather="' + escapeHtml(schedRiskWxDest.level + (schedRiskWxDest.reasons.length ? ': ' + schedRiskWxDest.reasons.join(', ') : '')) + '"' : ''}${schedRiskIrops ? ' data-irops="' + escapeHtml(schedRiskIrops.cancellationRate + '% cancelled, ' + (schedRiskIrops.delayed60Rate || 0) + '% delayed 60min+') + '"' : ''} style="background:${dRisk.color}20;color:${dRisk.color};cursor:pointer" title="Click for AI analysis">${dRisk.label}</span>` : '';
+    const schedRiskOtp = hubHealthData[depHub];
+    const schedRiskWxOrig = weatherOpsByHub[depHub];
+    const schedRiskWxDest = weatherOpsByHub[arrHub];
+    const schedRiskIrops = iropsHubData[depHub];
+    const schedRiskFaa = formatDelayExplainFAAStatus(depHub, arrHub, faaDelayIndex);
+    const riskCell = dRisk ? `<span class="delay-risk-badge" data-action="explain-delay" data-flight="${escapeHtml(ident)}" data-route="${escapeHtml(origCode + '\u2192' + destCode)}" data-status="${escapeHtml(status.text)}" data-risk-label="${dRisk.label}" data-risk-score="${dRisk.score}" data-risk-factors="${escapeHtml(dRisk.factors.join('|'))}" data-hub="${escapeHtml(depHub)}"${schedRiskOtp !== undefined ? ' data-otp="' + schedRiskOtp + '"' : ''}${schedRiskWxOrig ? ' data-weather="' + escapeHtml(schedRiskWxOrig.level + (schedRiskWxOrig.reasons.length ? ': ' + schedRiskWxOrig.reasons.join(', ') : '')) + '"' : ''}${schedRiskWxDest ? ' data-dest-weather="' + escapeHtml(schedRiskWxDest.level + (schedRiskWxDest.reasons.length ? ': ' + schedRiskWxDest.reasons.join(', ') : '')) + '"' : ''}${schedRiskIrops ? ' data-irops="' + escapeHtml(schedRiskIrops.cancellationRate + '% cancelled, ' + (schedRiskIrops.delayed60Rate || 0) + '% delayed 60min+') + '"' : ''}${schedRiskFaa ? ' data-faa-status="' + escapeHtml(schedRiskFaa) + '"' : ''} style="background:${dRisk.color}20;color:${dRisk.color};cursor:pointer" title="Click for AI analysis">${dRisk.label}</span>` : '';
 
     return `<tr>
       <td>${escapeHtml(timeStr)}${timeExtra}</td>
@@ -4231,27 +4240,42 @@ async function _doPreloadWeatherAndFAA() {
     const stationToHub = {};
     for (const [hub, station] of Object.entries(hubStations)) stationToHub[station] = hub;
 
-    // Collect non-hub destinations from watched flights for destination weather
-    const watchedDests = new Set();
+    const extraAirports = new Map();
+    const addExtraAirport = (iata) => {
+      const code = (iata || '').trim().toUpperCase();
+      if (!code || code.length !== 3 || hubStations[code]) return;
+      const station = getMetarStationForIata(code);
+      if (!station) return;
+      extraAirports.set(code, station);
+    };
+
+    // Collect non-hub airports from watched flights for origin/destination weather
     try {
       const watchedRaw = localStorage.getItem('bb_watched_flights') || localStorage.getItem('watchedFlights');
       if (watchedRaw) {
         const wf = JSON.parse(watchedRaw);
         wf.forEach(w => {
-          const dest = (w.route || '').split('\u2192')[1]?.trim() || (w.route || '').split('→')[1]?.trim();
-          if (dest && dest.length === 3 && !hubStations[dest]) watchedDests.add(dest);
+          const route = w.route || '';
+          const parts = route.split('\u2192').length > 1 ? route.split('\u2192') : route.split('→');
+          addExtraAirport(parts[0]);
+          addExtraAirport(parts[1]);
         });
       }
     } catch(e) {}
 
+    Object.values(schedRawByHub).forEach(flights => {
+      if (!Array.isArray(flights)) return;
+      flights.forEach(fl => {
+        addExtraAirport(fl.airport?.origin?.code?.iata);
+        addExtraAirport(fl.airport?.destination?.code?.iata);
+      });
+    });
+
     // Map non-hub IATA to ICAO for METAR API (US airports = K + IATA)
     const extraStations = {};
-    watchedDests.forEach(iata => {
-      // US domestic: prepend K. International would need a lookup table,
-      // but most United destinations are US domestic
-      const icao = iata.length === 3 ? 'K' + iata : iata;
-      extraStations[iata] = icao;
-      stationToHub[icao] = iata;
+    extraAirports.forEach((station, iata) => {
+      extraStations[iata] = station;
+      stationToHub[station] = iata;
     });
 
     const allStations = [...Object.values(hubStations), ...Object.values(extraStations)].join(',');
@@ -4267,7 +4291,7 @@ async function _doPreloadWeatherAndFAA() {
         const key = stationToHub[m.icaoId || m.stationId] || stationToHub[m.id];
         if (key) metarByHub[key] = m;
       });
-      [...hubs, ...watchedDests].forEach(apt => {
+      [...hubs, ...extraAirports.keys()].forEach(apt => {
         const data = metarByHub[apt];
         if (!data) return;
         const raw = data.rawOb || '';
@@ -4297,6 +4321,11 @@ async function _doPreloadWeatherAndFAA() {
         else if (d.type === 'closure') faaIndex[code].closure = true;
       });
       faaDelayIndex = faaIndex;
+    }
+
+    if (document.getElementById('tab-schedule')?.classList.contains('active') && schedAllFlights.length) {
+      renderScheduleTable();
+      renderScheduleStats();
     }
   } catch(e) {
     console.error('Weather/FAA preload error:', e);
@@ -4459,6 +4488,11 @@ function renderIropsFromAPI(data) {
   html += '</div>';
 
   content.innerHTML = html;
+
+  if (document.getElementById('tab-schedule')?.classList.contains('active') && schedAllFlights.length) {
+    renderScheduleTable();
+    renderScheduleStats();
+  }
 }
 
 // ═══ FAA DELAY CONTEXT ═══
@@ -4945,12 +4979,13 @@ function buildMyFlightCard(watched, td) {
   const riskWx = weatherOpsByHub[origCode];
   const riskWxDest = weatherOpsByHub[destCode];
   const riskIrops = iropsHubData[origCode];
+  const riskFaaStatus = formatDelayExplainFAAStatus(origCode, destCode, faaDelayIndex);
   const riskConn = connectionIndex[flightNum];
   const riskConnStr = riskConn ? (riskConn.isOutbound
     ? 'Connecting from ' + riskConn.connFlight + ' via ' + riskConn.hub + ', ' + riskConn.minutes + 'min layover (' + riskConn.risk + ')'
     : 'Connects to ' + riskConn.connFlight + ' ' + riskConn.hub + '\u2192' + (riskConn.dest || '?') + ', ' + riskConn.minutes + 'min layover (' + riskConn.risk + ')') : '';
   if (risk && (resolvedStatus === 'scheduled' || resolvedStatus === 'delayed' || resolvedStatus === '' || !resolvedStatus)) {
-    riskHtml = `<span class="delay-risk-badge" data-action="explain-delay" data-flight="${flightNum}" data-route="${escapeHtml(origCode + '\u2192' + destCode)}" data-status="${escapeHtml(resolvedStatus || 'scheduled')}" data-risk-label="${risk.label}" data-risk-score="${risk.score}" data-risk-factors="${escapeHtml(risk.factors.join('|'))}" data-hub="${escapeHtml(origCode)}"${riskOtp !== undefined ? ' data-otp="' + riskOtp + '"' : ''}${riskWx ? ' data-weather="' + escapeHtml(riskWx.level + (riskWx.reasons.length ? ': ' + riskWx.reasons.join(', ') : '')) + '"' : ''}${riskWxDest ? ' data-dest-weather="' + escapeHtml(riskWxDest.level + (riskWxDest.reasons.length ? ': ' + riskWxDest.reasons.join(', ') : '')) + '"' : ''}${riskIrops ? ' data-irops="' + escapeHtml(riskIrops.cancellationRate + '% cancelled, ' + (riskIrops.delayed60Rate || 0) + '% delayed 60min+') + '"' : ''}${riskConnStr ? ' data-connection="' + escapeHtml(riskConnStr) + '"' : ''}${inboundStr ? ' data-inbound="' + escapeHtml(inboundStr) + '"' : ''} style="background:${risk.color}20;color:${risk.color};cursor:pointer" title="Click for AI analysis">${risk.label} RISK</span>`;
+    riskHtml = `<span class="delay-risk-badge" data-action="explain-delay" data-flight="${flightNum}" data-route="${escapeHtml(origCode + '\u2192' + destCode)}" data-status="${escapeHtml(resolvedStatus || 'scheduled')}" data-risk-label="${risk.label}" data-risk-score="${risk.score}" data-risk-factors="${escapeHtml(risk.factors.join('|'))}" data-hub="${escapeHtml(origCode)}"${riskOtp !== undefined ? ' data-otp="' + riskOtp + '"' : ''}${riskWx ? ' data-weather="' + escapeHtml(riskWx.level + (riskWx.reasons.length ? ': ' + riskWx.reasons.join(', ') : '')) + '"' : ''}${riskWxDest ? ' data-dest-weather="' + escapeHtml(riskWxDest.level + (riskWxDest.reasons.length ? ': ' + riskWxDest.reasons.join(', ') : '')) + '"' : ''}${riskIrops ? ' data-irops="' + escapeHtml(riskIrops.cancellationRate + '% cancelled, ' + (riskIrops.delayed60Rate || 0) + '% delayed 60min+') + '"' : ''}${riskFaaStatus ? ' data-faa-status="' + escapeHtml(riskFaaStatus) + '"' : ''}${riskConnStr ? ' data-connection="' + escapeHtml(riskConnStr) + '"' : ''}${inboundStr ? ' data-inbound="' + escapeHtml(inboundStr) + '"' : ''} style="background:${risk.color}20;color:${risk.color};cursor:pointer" title="Click for AI analysis">${risk.label} RISK</span>`;
   }
 
   // Departure/arrival time data attributes for countdown timer
@@ -4978,7 +5013,7 @@ function buildMyFlightCard(watched, td) {
     <div class="mf-actions">
       ${liveFlight ? `<button data-action="focus-flight" data-icao24="${escapeHtml(liveFlight.icao24)}">View on Map</button>` : ''}
       ${reg ? `<button data-action="aircraft-detail" data-reg="${escapeHtml(reg)}">Aircraft Details</button>` : ''}
-      ${risk ? `<button class="delay-explain-btn" data-action="explain-delay" data-flight="${flightNum}" data-route="${escapeHtml(origCode + '\u2192' + destCode)}" data-status="${escapeHtml(resolvedStatus || 'scheduled')}" data-risk-label="${risk.label}" data-risk-score="${risk.score}" data-risk-factors="${escapeHtml(risk.factors.join('|'))}" data-hub="${escapeHtml(origCode)}"${riskOtp !== undefined ? ' data-otp="' + riskOtp + '"' : ''}${riskWx ? ' data-weather="' + escapeHtml(riskWx.level + (riskWx.reasons.length ? ': ' + riskWx.reasons.join(', ') : '')) + '"' : ''}${riskWxDest ? ' data-dest-weather="' + escapeHtml(riskWxDest.level + (riskWxDest.reasons.length ? ': ' + riskWxDest.reasons.join(', ') : '')) + '"' : ''}${riskIrops ? ' data-irops="' + escapeHtml(riskIrops.cancellationRate + '% cancelled, ' + (riskIrops.delayed60Rate || 0) + '% delayed 60min+') + '"' : ''}${riskConnStr ? ' data-connection="' + escapeHtml(riskConnStr) + '"' : ''}${inboundStr ? ' data-inbound="' + escapeHtml(inboundStr) + '"' : ''}>Explain Delay Risk</button>` : ''}
+      ${risk ? `<button class="delay-explain-btn" data-action="explain-delay" data-flight="${flightNum}" data-route="${escapeHtml(origCode + '\u2192' + destCode)}" data-status="${escapeHtml(resolvedStatus || 'scheduled')}" data-risk-label="${risk.label}" data-risk-score="${risk.score}" data-risk-factors="${escapeHtml(risk.factors.join('|'))}" data-hub="${escapeHtml(origCode)}"${riskOtp !== undefined ? ' data-otp="' + riskOtp + '"' : ''}${riskWx ? ' data-weather="' + escapeHtml(riskWx.level + (riskWx.reasons.length ? ': ' + riskWx.reasons.join(', ') : '')) + '"' : ''}${riskWxDest ? ' data-dest-weather="' + escapeHtml(riskWxDest.level + (riskWxDest.reasons.length ? ': ' + riskWxDest.reasons.join(', ') : '')) + '"' : ''}${riskIrops ? ' data-irops="' + escapeHtml(riskIrops.cancellationRate + '% cancelled, ' + (riskIrops.delayed60Rate || 0) + '% delayed 60min+') + '"' : ''}${riskFaaStatus ? ' data-faa-status="' + escapeHtml(riskFaaStatus) + '"' : ''}${riskConnStr ? ' data-connection="' + escapeHtml(riskConnStr) + '"' : ''}${inboundStr ? ' data-inbound="' + escapeHtml(inboundStr) + '"' : ''}>Explain Delay Risk</button>` : ''}
       <button data-action="toggle-watch-flight" data-flight="${flightNum}" data-route="${escapeHtml(watched.route)}" data-status="${escapeHtml(watched.status)}" data-stop-prop="1">Unwatch</button>
     </div>
   </div>`;
@@ -5098,15 +5133,10 @@ function computeDelayRisk(watched, origHub, destHub, timeData, liveFlight) {
 }
 
 function computeDelayRiskForScheduleFlight(fl, hub) {
-  const orig = fl.airport?.origin?.code?.iata || hub;
-  const dest = fl.airport?.destination?.code?.iata || '';
+  const { depHub, arrHub } = getScheduleRiskContext(fl, hub, schedCurrentDir);
   const status = classifySchedStatus(fl);
   // Only score not-yet-departed flights
   if (status.key !== 'scheduled' && status.key !== 'estimated' && status.key !== 'delayed') return null;
-
-  const dir = schedCurrentDir;
-  const depHub = dir === 'departures' ? hub : orig;
-  const arrHub = dir === 'departures' ? dest : hub;
 
   const schedTime = fl.time?.scheduled?.departure || fl.time?.scheduled?.arrival;
   const estTime = fl.time?.estimated?.departure || fl.time?.estimated?.arrival;
@@ -5575,6 +5605,7 @@ document.addEventListener('click', function(e) {
         otp: el.dataset.otp,
         weather: el.dataset.weather,
         destWeather: el.dataset.destWeather,
+        faaStatus: el.dataset.faaStatus,
         inbound: el.dataset.inbound,
         irops: el.dataset.irops,
         hubTime: el.dataset.hubTime,
@@ -6185,6 +6216,7 @@ async function fetchDelayExplanation(ctx) {
         otp: ctx.otp,
         weather: ctx.weather,
         destWeather: ctx.destWeather,
+        faaStatus: ctx.faaStatus,
         inbound: ctx.inbound,
         irops: ctx.irops,
         hubTime: ctx.hubTime,

--- a/src/lib/airport-metadata.js
+++ b/src/lib/airport-metadata.js
@@ -1,0 +1,95 @@
+export const INTL_AIRPORTS = new Set([
+  'NRT','GUM','HND','LHR','FRA','CDG','AMS','ZRH','FCO','MAD','BCN','DUB','IST','TLV','MUC','EDI','BRU','LIS','CPH',
+  'ARN','HEL','OSL','SIN','HKG','SYD','PEK','ICN','TPE','BKK','DEL','MEL','AKL','PVG','CAN','BOM','NAN','PPT',
+  'KIX','CTU','XIY','CKG','SNN','MAN','GLA'
+]);
+
+export const US_AIRPORTS = new Set([
+  'ORD','DEN','EWR','IAH','SFO','LAX','IAD','GUM',
+  'ATL','JFK','LGA','DFW','CLT','MIA','FLL','TPA','MCO','SEA','MSP','DTW','PHL','BOS',
+  'DCA','BWI','SAN','PHX','SLC','AUS','SAT','HOU','DAL','MDW','OAK','SJC','SMF','PDX',
+  'MCI','MSY','STL','IND','CLE','CVG','CMH','PIT','RDU','BNA','MKE','OMA','RSW',
+  'HNL','OGG','LIH','KOA'
+]);
+
+export const ICAO_TO_IATA_OVERRIDES = Object.freeze({
+  RJAA: 'NRT',
+  RJTT: 'HND',
+  PGUM: 'GUM',
+  EGLL: 'LHR',
+  LFPG: 'CDG',
+  EDDF: 'FRA',
+  RCKH: 'KHH',
+  VHHH: 'HKG',
+  WSSS: 'SIN',
+  NZAA: 'AKL',
+  YSSY: 'SYD',
+  LEMD: 'MAD',
+  EHAM: 'AMS',
+  OMDB: 'DXB',
+  ZBAA: 'PEK',
+  RCTP: 'TPE',
+  RJBB: 'KIX',
+  RKSI: 'ICN',
+  VTBS: 'BKK',
+  WMKK: 'KUL',
+  CYYZ: 'YYZ',
+  CYUL: 'YUL',
+  CYVR: 'YVR',
+  MMMX: 'MEX',
+  MMUN: 'CUN',
+  TNCM: 'SXM',
+  TXKF: 'BDA',
+  MUHA: 'HAV',
+  LIRF: 'FCO',
+  EGKK: 'LGW',
+  EIDW: 'DUB',
+  LSZH: 'ZRH',
+  LOWW: 'VIE',
+  EKCH: 'CPH',
+  ENGM: 'OSL',
+  ESSA: 'ARN',
+  EFHK: 'HEL',
+  LPPT: 'LIS',
+  LEBL: 'BCN',
+  LGAV: 'ATH',
+  LTFM: 'IST',
+  VIDP: 'DEL',
+  VABB: 'BOM',
+  RPLL: 'MNL',
+  ZUUU: 'CTU',
+  ZSPD: 'PVG',
+  ZSSS: 'SHA',
+  VVNB: 'HAN',
+  VVTS: 'SGN',
+});
+
+export const IATA_TO_ICAO_OVERRIDES = Object.freeze(
+  Object.fromEntries(Object.entries(ICAO_TO_IATA_OVERRIDES).map(([icao, iata]) => [iata, icao]))
+);
+
+function normalizeCode(code) {
+  return String(code || '').trim().toUpperCase();
+}
+
+export function icaoToIata(icao) {
+  const code = normalizeCode(icao);
+  if (!code) return '';
+  if (code.length === 4 && code.startsWith('K')) return code.slice(1);
+  return ICAO_TO_IATA_OVERRIDES[code] || code;
+}
+
+export function isInternationalRoute(origIata, destIata) {
+  const orig = normalizeCode(origIata);
+  const dest = normalizeCode(destIata);
+  if (!orig || !dest) return false;
+  return !(US_AIRPORTS.has(orig) && US_AIRPORTS.has(dest));
+}
+
+export function getMetarStationForIata(iata) {
+  const code = normalizeCode(iata);
+  if (!code || code.length !== 3) return '';
+  if (IATA_TO_ICAO_OVERRIDES[code]) return IATA_TO_ICAO_OVERRIDES[code];
+  if (US_AIRPORTS.has(code)) return `K${code}`;
+  return '';
+}

--- a/src/lib/delay-explain-context.js
+++ b/src/lib/delay-explain-context.js
@@ -1,0 +1,62 @@
+function normalizeAirportCode(iata) {
+  return String(iata || '').trim().toUpperCase();
+}
+
+export function getScheduleRiskContext(flight, hub, direction) {
+  const pageHub = normalizeAirportCode(hub);
+  const flightDirection = direction === 'arrivals' ? 'arrivals' : 'departures';
+  const origCode = normalizeAirportCode(flight?.airport?.origin?.code?.iata) || pageHub;
+  const destCode = normalizeAirportCode(flight?.airport?.destination?.code?.iata);
+  const depHub = flightDirection === 'departures' ? pageHub : origCode;
+  const arrHub = flightDirection === 'departures' ? destCode : pageHub;
+  return { origCode, destCode, depHub, arrHub };
+}
+
+export function formatDelayExplainFAAStatus(originIata, destIata, faaDelayIndex) {
+  const seen = new Set();
+  const contexts = [];
+  const airports = [normalizeAirportCode(originIata), normalizeAirportCode(destIata)].filter(Boolean);
+
+  airports.forEach((airport) => {
+    const faa = faaDelayIndex?.[airport];
+    if (!faa || !faa.delays || !faa.delays.length) return;
+
+    faa.delays.forEach((delay) => {
+      const dtype = String(delay.type || '').toLowerCase();
+      let label = 'Delay';
+      let window = '';
+
+      if (dtype.includes('ground stop')) {
+        label = 'Ground stop';
+      } else if (dtype.includes('ground delay') || dtype.includes('gdp')) {
+        label = 'Ground delay program';
+        if (faa.avgDelay) window = ` (avg ${faa.avgDelay}m)`;
+      } else if (dtype.includes('departure')) {
+        label = 'Departure delays';
+        if (faa.minDelay || faa.maxDelay) {
+          const low = faa.minDelay || '?';
+          const high = faa.maxDelay || faa.minDelay || '?';
+          window = ` (${low}-${high}m)`;
+        }
+      } else if (dtype.includes('arrival')) {
+        label = 'Arrival delays';
+        if (faa.minDelay || faa.maxDelay) {
+          const low = faa.minDelay || '?';
+          const high = faa.maxDelay || faa.minDelay || '?';
+          window = ` (${low}-${high}m)`;
+        }
+      } else if (dtype.includes('closure')) {
+        label = 'Airport closure';
+      }
+
+      const reason = String(delay.reason || '').trim();
+      const context = reason ? `${airport} ${label}${window}: ${reason}` : `${airport} ${label}${window}`;
+      if (!seen.has(context)) {
+        seen.add(context);
+        contexts.push(context);
+      }
+    });
+  });
+
+  return contexts.join(' · ');
+}

--- a/src/lib/metar.js
+++ b/src/lib/metar.js
@@ -14,6 +14,10 @@ function firstFiniteNumber(...values) {
   return null;
 }
 
+function normalizeStationId(station) {
+  return firstNonEmptyString(station).toUpperCase();
+}
+
 function normalizeCloudLayer(layer) {
   if (!layer || typeof layer !== 'object') return null;
   const cover = firstNonEmptyString(layer.cover, layer.skyCover, layer.sky_cover).toUpperCase();
@@ -123,4 +127,33 @@ export function normalizeMetarPayload(payload) {
   return rows
     .map(normalizeMetarRecord)
     .filter(Boolean);
+}
+
+export function chunkMetarStationIds(stations, maxQueryLength = 180) {
+  const stationList = Array.isArray(stations)
+    ? stations
+    : String(stations || '').split(',');
+
+  const chunks = [];
+  let current = [];
+  let currentLength = 0;
+
+  stationList.forEach((station) => {
+    const id = normalizeStationId(station);
+    if (!id) return;
+
+    const nextLength = currentLength ? currentLength + 1 + id.length : id.length;
+    if (nextLength > maxQueryLength && current.length) {
+      chunks.push(current.join(','));
+      current = [id];
+      currentLength = id.length;
+      return;
+    }
+
+    current.push(id);
+    currentLength = nextLength;
+  });
+
+  if (current.length) chunks.push(current.join(','));
+  return chunks;
 }

--- a/tests/airport-metadata.test.js
+++ b/tests/airport-metadata.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { getMetarStationForIata, icaoToIata, isInternationalRoute } from '../src/lib/airport-metadata.js';
+
+describe('airport metadata', () => {
+  it('maps domestic airports to K-prefixed METAR stations', () => {
+    expect(getMetarStationForIata('LGA')).toBe('KLGA');
+    expect(getMetarStationForIata('ord')).toBe('KORD');
+  });
+
+  it('maps international airports through shared ICAO overrides', () => {
+    expect(getMetarStationForIata('NRT')).toBe('RJAA');
+    expect(getMetarStationForIata('GUM')).toBe('PGUM');
+    expect(getMetarStationForIata('MNL')).toBe('RPLL');
+  });
+
+  it('returns empty station for unsupported airports', () => {
+    expect(getMetarStationForIata('ZZZ')).toBe('');
+    expect(getMetarStationForIata('')).toBe('');
+  });
+
+  it('shares ICAO to IATA normalization across APIs', () => {
+    expect(icaoToIata('KLGA')).toBe('LGA');
+    expect(icaoToIata('RJAA')).toBe('NRT');
+    expect(icaoToIata('RCKH')).toBe('KHH');
+  });
+
+  it('classifies domestic and international routes consistently', () => {
+    expect(isInternationalRoute('ORD', 'LGA')).toBe(false);
+    expect(isInternationalRoute('ORD', 'NRT')).toBe(true);
+    expect(isInternationalRoute('GUM', 'HNL')).toBe(false);
+  });
+});

--- a/tests/delay-explain-context.test.js
+++ b/tests/delay-explain-context.test.js
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { formatDelayExplainFAAStatus, getScheduleRiskContext } from '../src/lib/delay-explain-context.js';
+
+function makeFlight(origin, destination) {
+  return {
+    airport: {
+      origin: { code: { iata: origin } },
+      destination: { code: { iata: destination } },
+    },
+  };
+}
+
+describe('getScheduleRiskContext', () => {
+  it('keeps arrivals aligned to the true departure airport', () => {
+    expect(getScheduleRiskContext(makeFlight('LGA', 'ORD'), 'ORD', 'arrivals')).toEqual({
+      origCode: 'LGA',
+      destCode: 'ORD',
+      depHub: 'LGA',
+      arrHub: 'ORD',
+    });
+  });
+
+  it('keeps departures aligned to the page hub as origin', () => {
+    expect(getScheduleRiskContext(makeFlight('ORD', 'LGA'), 'ORD', 'departures')).toEqual({
+      origCode: 'ORD',
+      destCode: 'LGA',
+      depHub: 'ORD',
+      arrHub: 'LGA',
+    });
+  });
+});
+
+describe('formatDelayExplainFAAStatus', () => {
+  it('preserves weather causes and delay windows for the explainer', () => {
+    const faaDelayIndex = {
+      LGA: {
+        minDelay: '31',
+        maxDelay: '45',
+        delays: [{ type: 'departure_delay', reason: 'due to weather' }],
+      },
+      ORD: {
+        minDelay: '31',
+        maxDelay: '45',
+        delays: [{ type: 'departure_delay', reason: 'due to thunderstorms' }],
+      },
+    };
+
+    expect(formatDelayExplainFAAStatus('LGA', 'ORD', faaDelayIndex)).toBe(
+      'LGA Departure delays (31-45m): due to weather · ORD Departure delays (31-45m): due to thunderstorms'
+    );
+  });
+
+  it('dedupes repeated FAA rows', () => {
+    const faaDelayIndex = {
+      LGA: {
+        minDelay: '31',
+        maxDelay: '45',
+        delays: [
+          { type: 'departure_delay', reason: 'due to weather' },
+          { type: 'departure_delay', reason: 'due to weather' },
+        ],
+      },
+    };
+
+    expect(formatDelayExplainFAAStatus('LGA', '', faaDelayIndex)).toBe('LGA Departure delays (31-45m): due to weather');
+  });
+});

--- a/tests/metar-normalize.test.js
+++ b/tests/metar-normalize.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeMetarPayload } from '../src/lib/metar.js';
+import { chunkMetarStationIds, normalizeMetarPayload } from '../src/lib/metar.js';
 
 describe('normalizeMetarPayload', () => {
   it('accepts wrapped payloads and alternate field names', () => {
@@ -32,5 +32,21 @@ describe('normalizeMetarPayload', () => {
 
   it('returns an empty list for non-array error payloads', () => {
     expect(normalizeMetarPayload({ error: 'rate limited' })).toEqual([]);
+  });
+});
+
+describe('chunkMetarStationIds', () => {
+  it('splits large station lists into API-safe chunks', () => {
+    const chunks = chunkMetarStationIds([
+      'KORD','KEWR','KIAH','KDEN','KSFO','KLAX','KIAD','RJAA','PGUM',
+      'KLGA','KDCA','KRSW','KMCO','KBNA','KFLL','KSAN','KMSY','KCMH',
+      'KPIT','KCLT','CYYZ','KPHL','KATL','KTPA','KPHX',
+    ], 40);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.length <= 40)).toBe(true);
+    expect(chunks.join(',')).toBe(
+      'KORD,KEWR,KIAH,KDEN,KSFO,KLAX,KIAD,RJAA,PGUM,KLGA,KDCA,KRSW,KMCO,KBNA,KFLL,KSAN,KMSY,KCMH,KPIT,KCLT,CYYZ,KPHL,KATL,KTPA,KPHX'
+    );
   });
 });


### PR DESCRIPTION
This updates the delay-risk pipeline so schedule and My Flights explanations use the true departure and arrival airports, and it passes FAA status into the explainer for weather-driven NAS constraints. It replaces duplicated airport mappings with shared airport metadata, expands non-hub weather preload coverage, and chunks METAR batch requests so the wider airport set stays within the API query limit. It also adds regression tests for airport metadata, arrival/departure risk context, FAA explanation formatting, and METAR chunking. Verified with `npx vitest run tests/delay-risk.test.js tests/airport-metadata.test.js tests/delay-explain-context.test.js tests/metar-normalize.test.js` and `npm run build:dashboard`.