### PR TITLE
Pre-launch QA fixes: popup timing, sitemap, TSA noindex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-03-25
+
+### Added
+- **TSA Checkpoint Guide** (`/tsa`) — static terminal-by-terminal checkpoint reference for all 7 United hubs (Pre✓, CLEAR, Priority, standard lane availability, hours, and tips)
+- **Supporter Wall** — dashboard section recognizing project supporters
+- **Smart email signup triggers** — new visitors see the signup prompt after 90 seconds or 8 clicks; returning visitors keep the original 5-minute / 30-click thresholds
+- **News articles** — "United's First Polaris Studio 787-9 Enters Fleet" and "Kirby's Playbook for $175 Oil"
+- **News banner crossfade** — rotating animation on the dashboard news banner
+
+### Changed
+- **Typography and color redesign** — Satoshi + DM Sans typefaces, amber accent palette, updated design tokens across the entire app
+- **Fleet tab redesigned** — 3-zone layout with family grouping for easier navigation
+- **Fleet pages redesigned** — improved information hierarchy for SEO and user experience
+- **Mobile UX polish** — weather map zoom controls, popup overlap fixes, SVG icons replacing emoji
+- **Email signup UX** — popup dismissal now persists for 7 days, prevents stacking on the onboarding overlay
+- Fleet Site links updated to new domain (unitedfleetsite.com)
+- Updated README screenshot and OG image
+
+### Fixed
+- 9 critical findings from Codex code review across APIs, dashboard, and CI
+- Weather delay context not propagating to delay explanation engine
+- Fleet page schema type (Product → SoftwareApplication)
+- Waitlist popup could fire on top of the onboarding overlay for new visitors
+- Homepage page speed bottlenecks (deferred non-critical scripts)
+
+### Removed
+- TSA link from homepage navigation (MyTSA live API was shut down; page kept as static reference)
+- `/tsa` removed from sitemap, page set to `noindex`
+
 ## [1.4.0] - 2026-03-19
 
 ### Added
@@ -298,6 +327,7 @@ Initial public launch.
 - JSON-LD structured data, Open Graph metadata
 - Vercel hosting with edge caching
 
+[1.5.0]: https://github.com/notjbg/the-blue-board/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/notjbg/the-blue-board/compare/v1.3.8...v1.4.0
 [1.3.8]: https://github.com/notjbg/the-blue-board/compare/v1.3.7...v1.3.8
 [1.3.7]: https://github.com/notjbg/the-blue-board/compare/v1.3.6...v1.3.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,32 +6,71 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versio
 
 ## [1.5.0] - 2026-03-25
 
-### Added
-- **TSA Checkpoint Guide** (`/tsa`) — static terminal-by-terminal checkpoint reference for all 7 United hubs (Pre✓, CLEAR, Priority, standard lane availability, hours, and tips)
+**6 weeks, 300+ commits, and 70 merged PRs since launch day.** This is everything that shipped between v1.0 (Feb 12) and v1.5.
+
+### Network & Coverage
+- **9 hubs** (was 7) — added Tokyo Narita (NRT) and Guam (GUM) with full schedule, weather, and fleet support
+- **Pacific view toggle** — transpacific route visualization with antimeridian-crossing fix
+- **SEO-optimized hub pages** for all 9 hubs (`/hubs/ord`, `/hubs/den`, etc.) with structured data and canonical URLs
+- **TSA Checkpoint Guide** (`/tsa`) — terminal-by-terminal Pre✓, CLEAR, Priority, and standard lane reference for all 7 domestic hubs
+
+### Intelligence
+- **AI-Powered Delay Explanations** — Claude Haiku explains why a flight is delayed in plain language, with inbound aircraft context and weather correlation
+- **Delay Risk Engine v3** — 8-signal scoring: phenomena-aware weather, IROPS stress, ETA-based turnaround, historical OTP, hub congestion, equipment age, route complexity, and time-of-day patterns
+- **Aircraft Journey Chain Tracking** — see where an aircraft has been and predict downstream delay propagation
+- **Ops Impact Assessment** — flags snow, gusts ≥30kt, freezing precip, and thunderstorms even when VFR
+
+### Fleet
+- **Fleet Health Dashboard** — live fleet status with health categories, pie chart, and aircraft count by type
+- **Fleet tab redesigned** — 3-zone layout with family grouping, fleet stats chips, and Starlink WiFi status
+- **19 SEO-optimized fleet type pages** (`/fleet/737-max-9`, `/fleet/a321neo`, etc.) with structured data, full aircraft registry tables, and inter-type navigation
+- **Special Aircraft Tracker** — named and special-livery aircraft panel
+- **Aircraft Detail Modal** — click any tail number for registration, type, engine, status, live flight, and history
+- **Equipment Swap Impact Analysis** — schedule tab highlights equipment changes with seat and amenity impact
+- **Live Starlink Data** — replaced static database with live API feed and flight connectivity predictions
+
+### Schedule & Data
+- **Schedule Filters** — filter by route type (domestic/international), Starlink-equipped, time range, and delay risk level
+- **Scrape-first FR24 routing** with circuit breaker — projected ~96-99% API credit savings vs. official-first
+- **Background cache warming** — Vercel cron pre-warms schedule data for faster tab loads
+- **Schedule resilience** — partial data instead of 502s, stale-complete fallback, retry with backoff
+
+### News & Content
+- **News Hub** (`/news`) — curated United Airlines articles with SEO-optimized pages, NewsArticle structured data, and OG/Twitter previews
+- **Google News sitemap** (`/news-sitemap.xml`) and **dynamic RSS feed** (`/feed.xml`)
+- **Email news digest** — waitlist subscribers receive a Resend-powered email when new articles are published
+- **Rotating news banner** with crossfade animation on the dashboard
+
+### Design & UX
+- **Typography and color redesign** — Satoshi + DM Sans typefaces, amber accent palette, self-hosted fonts (zero FOUT)
+- **Mobile-first redesign** — map-maximized layout, bottom tab bar, collapsible filters, touch-optimized controls
+- **Weather tab** — 60/40 desktop split layout with compact IROPS stats bar
+- **SVG plane icons** replace emoji for cross-platform accuracy
+- **Onboarding overlay** — first-time welcome with home hub selection
 - **Supporter Wall** — dashboard section recognizing project supporters
-- **Smart email signup triggers** — new visitors see the signup prompt after 90 seconds or 8 clicks; returning visitors keep the original 5-minute / 30-click thresholds
-- **News articles** — "United's First Polaris Studio 787-9 Enters Fleet" and "Kirby's Playbook for $175 Oil"
-- **News banner crossfade** — rotating animation on the dashboard news banner
 
-### Changed
-- **Typography and color redesign** — Satoshi + DM Sans typefaces, amber accent palette, updated design tokens across the entire app
-- **Fleet tab redesigned** — 3-zone layout with family grouping for easier navigation
-- **Fleet pages redesigned** — improved information hierarchy for SEO and user experience
-- **Mobile UX polish** — weather map zoom controls, popup overlap fixes, SVG icons replacing emoji
-- **Email signup UX** — popup dismissal now persists for 7 days, prevents stacking on the onboarding overlay
-- Fleet Site links updated to new domain (unitedfleetsite.com)
-- Updated README screenshot and OG image
+### Email & Engagement
+- **Email signup with smart triggers** — new visitors: 90s / 8 clicks; returning visitors: 5min / 30 clicks; 7-day dismiss persistence
+- **Welcome email** via Resend on first waitlist signup with de-duplication
+- **Shareable flight links** (`?flight=UA1234`) with push notification watch alerts
+- **PWA support** — installable home screen app with service worker
 
-### Fixed
-- 9 critical findings from Codex code review across APIs, dashboard, and CI
-- Weather delay context not propagating to delay explanation engine
-- Fleet page schema type (Product → SoftwareApplication)
-- Waitlist popup could fire on top of the onboarding overlay for new visitors
-- Homepage page speed bottlenecks (deferred non-critical scripts)
+### Infrastructure
+- **Astro migration** — hub pages built from shared templates (3,001 lines of duplicated HTML → 1,555 lines of templates)
+- **TypeScript migration** — core API modules migrated for type safety
+- **CSS extraction** — styles extracted from inline to dedicated stylesheets
+- **JS modularization** — monolithic scripts split into focused modules
+- **Automated sitemap** with build-time lastmod stamps
+- **CI/CD** — `npm test` on all pushes and PRs
+- **100+ unit tests** across schedule, fleet, weather, news, popup, and API endpoints
 
-### Removed
-- TSA link from homepage navigation (MyTSA live API was shut down; page kept as static reference)
-- `/tsa` removed from sitemap, page set to `noindex`
+### Security & Performance
+- **API rate limiting** — all endpoints protected with per-IP limits
+- **XSS hardening** — innerHTML replaced with DOM node construction, all interpolations escaped
+- **Supabase RLS** on waitlist table, prompt injection sanitization on AI endpoint
+- **CORS hardening**, handler-level API timeouts, Anthropic SDK key isolation
+- **Homepage speed** — deferred non-critical scripts, preloaded LCP tile, fixed Core Web Vitals
+- **9 critical Codex code review findings** resolved across APIs, dashboard, and CI
 
 ## [1.4.0] - 2026-03-19
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "scripts": {
     "dev": "node scripts/run-astro-dev.mjs",
     "build": "vite build --config vite.dashboard.config.js && astro build && node scripts/stamp-seo-build-date.mjs",

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -5920,6 +5920,8 @@ function hideDisclaimer() {
     if (waitlistSubmitted) return;
     if (!force && waitlistShownThisSession) return;
     if (!force && isDismissedRecently('bb_waitlist_dismissed')) return;
+    // Don't stack on top of onboarding overlay (Codex P2 finding)
+    if (!force && overlay && overlay.style.display !== 'none' && !overlay.classList.contains('ob-hidden')) return;
     if (document.getElementById('waitlist-modal')) {
       document.getElementById('waitlist-modal').style.display = 'flex';
       waitlistShownThisSession = true;

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -6101,17 +6101,22 @@ function hideDisclaimer() {
     setTimeout(function() { emailInput.focus(); }, 100);
   }
 
-  // Trigger 1: After 5 minutes of active use
+  // Trigger thresholds: aggressive for new visitors, gentle for returning
+  var isNewVisitor = !localStorage.getItem('bb-visited');
+  var TRIGGER_TIME_MS = isNewVisitor ? 90 * 1000 : 5 * 60 * 1000;    // 90s new, 5min returning
+  var TRIGGER_CLICKS  = isNewVisitor ? 8 : 30;                         // 8 new, 30 returning
+
+  // Trigger 1: After time threshold of active use
   setTimeout(function() {
     if (!waitlistShownThisSession && !waitlistSubmitted) {
       showWaitlistModal();
     }
-  }, 5 * 60 * 1000);
+  }, TRIGGER_TIME_MS);
 
-  // Trigger 2: After 30+ interactions (tab switches, searches, flight clicks)
+  // Trigger 2: After click threshold interactions (tab switches, searches, flight clicks)
   document.addEventListener('click', function() {
     engagementInteractions++;
-    if (engagementInteractions === 30 && !waitlistShownThisSession && !waitlistSubmitted) {
+    if (engagementInteractions === TRIGGER_CLICKS && !waitlistShownThisSession && !waitlistSubmitted) {
       showWaitlistModal();
     }
   });

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -30,7 +30,6 @@ export function GET() {
   const fleetKeys = fleetOrder as Array<keyof typeof fleetTypes>;
   const urls = [
     renderUrl('/', getLastModified(homeLastmodPaths), 'daily', '1.0'),
-    renderUrl('/tsa', new Date().toISOString().split('T')[0], 'hourly', '0.9'),
     renderUrl('/fleet', getLastModified(fleetIndexLastmodPaths), 'daily', '0.9'),
     ...fleetKeys.map((key) =>
       renderUrl(

--- a/src/pages/tsa.astro
+++ b/src/pages/tsa.astro
@@ -14,7 +14,7 @@ const faqEntries = getAllFaqEntries();
 <title>United Airlines TSA Checkpoints — Pre✓, CLEAR & Lane Guide at All 7 Hubs | The Blue Board</title>
 <meta name="description" content="Complete TSA checkpoint guide for United Airlines terminals. Pre✓, CLEAR, Priority, and standard lane availability at ORD, DEN, IAH, EWR, SFO, IAD, and LAX. Checkpoint hours, tips, and which security line to use.">
 <meta name="author" content="The Blue Board">
-<meta name="robots" content="index, follow">
+<meta name="robots" content="noindex, follow">
 <link rel="canonical" href="https://theblueboard.co/tsa">
 <meta property="og:type" content="website">
 <meta property="og:locale" content="en_US">


### PR DESCRIPTION
## Summary
- Lower email popup thresholds for new visitors (90s / 8 clicks) while keeping existing thresholds for returning users (5min / 30 clicks) — maximizes launch-day email conversion without annoying power users
- Prevent waitlist popup from stacking on top of onboarding overlay for first-time visitors (Codex P2 finding)
- Remove /tsa from sitemap (nav link was already removed)
- Add noindex to TSA page since live wait times are no longer available (Codex P3 finding)

## Test plan
- [ ] Visit theblueboard.co as new visitor — popup should appear within ~90s or 8 clicks
- [ ] Visit as returning visitor — popup timing unchanged (5min / 30 clicks)
- [ ] Verify onboarding overlay dismisses before waitlist popup can appear
- [ ] Check sitemap.xml no longer contains /tsa
- [ ] Verify /tsa page still loads but has noindex meta tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)