### PR TITLE
fix: prevent empty news sitemap XML error

### DIFF
--- a/src/pages/news-sitemap.xml.ts
+++ b/src/pages/news-sitemap.xml.ts
@@ -18,7 +18,13 @@ export function GET() {
   twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
   const cutoff = twoDaysAgo.toISOString().slice(0, 10);
 
-  const recent = articles.filter((a) => a.date >= cutoff);
+  let recent = articles.filter((a) => a.date >= cutoff);
+
+  // Google requires at least one <url> in a sitemap — fall back to the
+  // most recent article so the XML is always valid.
+  if (recent.length === 0 && articles.length > 0) {
+    recent = [articles[0]];
+  }
 
   const entries = recent.map(
     (a) => `  <url>


### PR DESCRIPTION
## Summary
- The news sitemap filters articles to the last 2 days. When no articles fall within that window, it produced an empty `<urlset>` with zero `<url>` entries, which Google Search Console flagged as "Missing XML tag" (line 5).
- Added a fallback: when the 2-day filter yields no results, include the most recent article. Google silently ignores stale entries but errors on empty sitemaps.

## Test plan
- [x] All 11 news data tests pass
- [ ] Verify on Google Search Console after deploy — resubmit sitemap, confirm error resolves