### PR TITLE
Fix flight popup metrics and improve tracking UX

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -540,6 +540,11 @@ tbody td{padding:5px 8px;white-space:nowrap}
   .hub-row{padding:10px 12px}
   .phase-row{padding:8px 6px}
   .search-result{padding:10px 12px}
+  .watch-btn,.share-btn,#watch-header-btn,.watch-remove,.mf-actions button{min-height:40px}
+  .watch-btn,.share-btn,.mf-actions button{padding:8px 12px;font-size:12px}
+  .watch-remove{min-width:40px;display:inline-flex;align-items:center;justify-content:center}
+  .popup-links .watch-btn,.popup-links .share-btn,.popup-links a{flex:1 1 calc(50% - 6px);justify-content:center}
+  .mf-actions{flex-wrap:wrap}
   /* Footer mobile */
   #disclaimer-modal > div{margin:10px;padding:16px}
   /* ── Ticker: static single-line with fade rotation (Change 3) ── */
@@ -680,10 +685,10 @@ tbody td{padding:5px 8px;white-space:nowrap}
 .faa-delay-context{font-size:9px;color:#f59e0b;font-style:italic;margin-top:2px;opacity:.85}
 
 /* Flight Watch */
-.watch-btn{background:none;border:1px solid var(--ua-border);color:var(--ua-muted);padding:3px 8px;border-radius:3px;cursor:pointer;font-size:10px;font-family:var(--font-mono);transition:border-color .15s cubic-bezier(.4,0,.2,1),color .15s cubic-bezier(.4,0,.2,1),background-color .15s cubic-bezier(.4,0,.2,1);display:inline-flex;align-items:center;gap:4px}
+.watch-btn{background:none;border:1px solid var(--ua-border);color:var(--ua-muted);padding:3px 8px;border-radius:3px;cursor:pointer;font-size:10px;font-family:var(--font-mono);transition:border-color .15s cubic-bezier(.4,0,.2,1),color .15s cubic-bezier(.4,0,.2,1),background-color .15s cubic-bezier(.4,0,.2,1);display:inline-flex;align-items:center;gap:4px;touch-action:manipulation;-webkit-tap-highlight-color:transparent}
 .watch-btn:hover{border-color:var(--ua-accent);color:var(--ua-accent);background:rgba(0,93,170,.06)}
 .watch-btn.watching{border-color:var(--ua-blue);color:var(--ua-accent);background:var(--ua-blue-soft)}
-.share-btn{background:none;border:1px solid var(--ua-border);color:var(--ua-muted);padding:3px 8px;border-radius:3px;cursor:pointer;font-size:10px;font-family:var(--font-mono);transition:border-color .15s cubic-bezier(.4,0,.2,1),color .15s cubic-bezier(.4,0,.2,1),background-color .15s cubic-bezier(.4,0,.2,1);display:inline-flex;align-items:center;gap:4px}
+.share-btn{background:none;border:1px solid var(--ua-border);color:var(--ua-muted);padding:3px 8px;border-radius:3px;cursor:pointer;font-size:10px;font-family:var(--font-mono);transition:border-color .15s cubic-bezier(.4,0,.2,1),color .15s cubic-bezier(.4,0,.2,1),background-color .15s cubic-bezier(.4,0,.2,1);display:inline-flex;align-items:center;gap:4px;touch-action:manipulation;-webkit-tap-highlight-color:transparent}
 .share-btn:hover{border-color:var(--ua-accent);color:var(--ua-accent);background:rgba(0,93,170,.06)}
 .share-btn.copied{border-color:#22c55e;color:#22c55e;background:rgba(34,197,94,.06)}
 #push-prompt{position:fixed;bottom:20px;left:50%;transform:translateX(-50%);background:rgba(17,24,39,.97);border:1px solid var(--ua-border);border-radius:8px;padding:12px 16px;font-size:11px;color:var(--ua-text);z-index:10001;display:none;align-items:center;gap:10px;backdrop-filter:blur(12px);box-shadow:0 8px 32px rgba(0,0,0,.5);max-width:400px;font-family:var(--font-ui)}
@@ -702,7 +707,7 @@ tbody td{padding:5px 8px;white-space:nowrap}
 .watch-flight-info .wf-num{font-weight:700;color:var(--ua-accent);font-size:11px}
 .watch-flight-info .wf-route{color:var(--ua-muted)}
 .watch-flight-status{text-align:right}
-.watch-remove{background:none;border:none;color:var(--ua-muted);cursor:pointer;font-size:12px;margin-left:6px;padding:2px}
+.watch-remove{background:none;border:none;color:var(--ua-muted);cursor:pointer;font-size:12px;margin-left:6px;padding:2px;touch-action:manipulation;-webkit-tap-highlight-color:transparent}
 .watch-remove:hover{color:var(--ua-red)}
 #watch-notification{position:fixed;top:0;left:0;right:0;background:rgba(0,93,170,.95);color:#fff;padding:10px 16px;font-size:12px;font-weight:600;z-index:10000;display:none;align-items:center;justify-content:space-between;backdrop-filter:blur(8px)}
 #watch-notification.show{display:flex}

--- a/public/index.html
+++ b/public/index.html
@@ -348,6 +348,15 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
         <select id="sched-aircraft" aria-label="Schedule aircraft filter" style="background:var(--bg-card);color:var(--ua-text);border:1px solid var(--ua-border);padding:4px 8px;font-family:var(--mono);font-size:10px;border-radius:3px">
           <option value="">All Aircraft</option>
         </select>
+        <select id="sched-fleet-family" aria-label="Schedule fleet family filter" style="background:var(--bg-card);color:var(--ua-text);border:1px solid var(--ua-border);padding:4px 8px;font-family:var(--mono);font-size:10px;border-radius:3px">
+          <option value="">All Fleet Families</option>
+          <option value="737">737 Family</option>
+          <option value="A320">A320 Family</option>
+          <option value="757">757 Family</option>
+          <option value="767">767 Family</option>
+          <option value="777">777 Family</option>
+          <option value="787">787 Family</option>
+        </select>
         <select id="sched-route-type" aria-label="Schedule route type filter" style="background:var(--bg-card);color:var(--ua-text);border:1px solid var(--ua-border);padding:4px 8px;font-family:var(--mono);font-size:10px;border-radius:3px">
           <option value="">All Routes</option>
           <option value="domestic">Domestic Only</option>

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -3,6 +3,8 @@ import { formatDelayExplainFAAStatus, getScheduleRiskContext } from '../lib/dela
 import { getMetarStationForIata, INTL_AIRPORTS } from '../lib/airport-metadata.js';
 import { chunkMetarStationIds, normalizeMetarPayload } from '../lib/metar.js';
 import { categorizeFleetStatus, FLEET_HEALTH_CATEGORIES, FLEET_FAMILIES, normalizeWifi, WIFI_DISPLAY, sortFleetData, filterFleetData, parseFleetDeepLink, TAB_MAP, VALID_FLEET_VIEWS } from '../lib/fleet-utils.js';
+import { getFlightPopupMetrics } from '../lib/flight-popup.js';
+import { getScheduleFleetFamily } from '../lib/schedule-filters.js';
 
 // ═══════════════════════════════════════════════
 // SVG ICON CONSTANTS — clean icons for buttons
@@ -1185,10 +1187,7 @@ function showFlightPopup(f, marker) {
   const flightNum = f.flightIATA || f.callsign.replace(/^UAL/, '');
   const displayFlight = f.flightIATA || f.callsign || 'N/A';
 
-  const altFt = f.alt ? Math.round(f.alt * 3.28084) : null;
-  const spdKts = f.spd ? Math.round(f.spd * 1.944) : null;
-  const altPct = altFt ? Math.min(100, (altFt / 41000) * 100) : 0;
-  const mach = altFt && altFt > 28000 && spdKts ? (spdKts / 661).toFixed(2) : null;
+  const { altFt, altPct, speedText } = getFlightPopupMetrics(f);
 
   const origCode = f.origin || originObj?.iata || '???';
   const destCode = f.dest || destObj?.iata || '???';
@@ -1211,7 +1210,7 @@ function showFlightPopup(f, marker) {
   html += `<div class="popup-grid">`;
   html += `<div class="popup-field"><span class="popup-field-label">Altitude</span><span class="popup-field-value">${altFt ? altFt.toLocaleString() + ' ft' : 'N/A'}</span>`;
   html += `<div class="alt-bar"><div class="alt-bar-fill" style="width:${altPct}%"></div></div></div>`;
-  html += `<div class="popup-field"><span class="popup-field-label">Speed</span><span class="popup-field-value">${spdKts ? spdKts + ' kts' : 'N/A'}${mach ? ' / M' + mach : ''}</span></div>`;
+  html += `<div class="popup-field"><span class="popup-field-label">Speed</span><span class="popup-field-value">${speedText}</span></div>`;
   html += `<div class="popup-field"><span class="popup-field-label">Heading</span><span class="popup-field-value">${f.hdg ? Math.round(f.hdg) + '°' : 'N/A'}</span></div>`;
   html += `<div class="popup-field"><span class="popup-field-label">V/S</span><span class="popup-field-value">${f.vr ? Math.round(f.vr * 196.85) + ' fpm' : 'N/A'}</span></div>`;
   html += `</div>`;
@@ -1257,8 +1256,8 @@ function showFlightPopup(f, marker) {
   const popupFlt = displayFlight;
   const popupRoute = (f.origin||'?') + '→' + (f.dest||'?');
   const popupWatched = isFlightWatched(popupFlt);
-  html += `<button class="watch-btn${popupWatched ? ' watching' : ''}" data-action="toggle-watch-flight" data-flight="${escapeHtml(popupFlt)}" data-route="${escapeHtml(popupRoute)}" data-status="airborne" aria-label="${popupWatched ? 'Unwatch flight' : 'Watch flight'}" style="margin-left:auto">${popupWatched ? ICO_WATCHING + ' Watching' : ICO_WATCH + ' Watch'}</button>`;
-  html += `<button class="share-btn" data-action="share-flight" data-flight="${escapeHtml(popupFlt)}" aria-label="Share flight link" title="Copy shareable link">${ICO_SHARE} Share</button>`;
+  html += `<button class="watch-btn${popupWatched ? ' watching' : ''}" data-action="toggle-watch-flight" data-flight="${escapeHtml(popupFlt)}" data-route="${escapeHtml(popupRoute)}" data-status="airborne" data-stop-prop="1" aria-label="${popupWatched ? 'Unwatch flight' : 'Watch flight'}" style="margin-left:auto">${popupWatched ? ICO_WATCHING + ' Watching' : ICO_WATCH + ' Watch'}</button>`;
+  html += `<button class="share-btn" data-action="share-flight" data-flight="${escapeHtml(popupFlt)}" data-stop-prop="1" aria-label="Share flight link" title="Copy shareable link">${ICO_SHARE} Share</button>`;
   html += `</div></div>`;
 
   if (marker.getPopup()) marker.unbindPopup();
@@ -3256,6 +3255,7 @@ function initScheduleTab() {
     const schedFilterChanged = () => { debouncedSchedRender(); updateAdvFilterBtnText(); };
     document.getElementById('sched-status').addEventListener('change', schedFilterChanged);
     document.getElementById('sched-aircraft').addEventListener('change', schedFilterChanged);
+    document.getElementById('sched-fleet-family').addEventListener('change', schedFilterChanged);
     document.getElementById('sched-route-type').addEventListener('change', schedFilterChanged);
     document.getElementById('sched-starlink').addEventListener('change', schedFilterChanged);
     document.getElementById('sched-timerange').addEventListener('change', schedFilterChanged);
@@ -3535,6 +3535,7 @@ function formatSchedTime(utcTimestamp, hub) {
 function getFilteredScheduleFlights() {
   const statusFilter = document.getElementById('sched-status').value;
   const aircraftFilter = document.getElementById('sched-aircraft').value;
+  const fleetFamilyFilter = document.getElementById('sched-fleet-family').value;
   const routeTypeFilter = document.getElementById('sched-route-type').value;
   const starlinkFilter = document.getElementById('sched-starlink').value;
   const timeRangeFilter = document.getElementById('sched-timerange').value;
@@ -3549,6 +3550,11 @@ function getFilteredScheduleFlights() {
     }
     // Aircraft filter
     if (aircraftFilter && fl.aircraft?.model?.code !== aircraftFilter) return false;
+    // Fleet family filter
+    if (fleetFamilyFilter) {
+      const family = getScheduleFleetFamily(fl.aircraft?.model?.code, fl.aircraft?.model?.text);
+      if (family !== fleetFamilyFilter) return false;
+    }
     // Route type filter (domestic / international)
     if (routeTypeFilter) {
       const endpoint = schedCurrentDir === 'departures'
@@ -4535,10 +4541,13 @@ function isFlightWatched(flightNum) {
 function toggleWatchFlight(flightNum, route, currentStatus) {
   let watched = getWatchedFlights();
   const idx = watched.findIndex(w => w.flight === flightNum);
+  let isWatched;
   if (idx >= 0) {
     watched.splice(idx, 1);
+    isWatched = false;
   } else {
     watched.push({ flight: flightNum, route: route || '', status: currentStatus || '', ts: Date.now() });
+    isWatched = true;
     // Show push notification prompt if not yet asked
     const prompted = localStorage.getItem('bb_push_prompted');
     if (!prompted && 'Notification' in window && Notification.permission === 'default') {
@@ -4554,6 +4563,25 @@ function toggleWatchFlight(flightNum, route, currentStatus) {
   updateMarkers();
   // Re-render MY FLIGHTS if that tab is active
   if (document.getElementById('tab-myflight')?.classList.contains('active')) renderMyFlights();
+  syncWatchButtons(flightNum, isWatched);
+  showWatchNotification(isWatched ? `👁️ Watching ${flightNum}` : `✕ Removed ${flightNum} from watched flights`);
+  return isWatched;
+}
+
+function syncWatchButtons(flightNum, isWatched) {
+  document.querySelectorAll('[data-action="toggle-watch-flight"]').forEach(el => {
+    if (el.dataset.flight !== flightNum || el.classList.contains('watch-remove')) return;
+    if (!el.classList.contains('watch-btn')) return;
+
+    el.classList.toggle('watching', isWatched);
+    el.setAttribute('aria-label', isWatched ? 'Unwatch flight' : 'Watch flight');
+    if (el.title) el.title = isWatched ? 'Unwatch this flight' : 'Watch this flight';
+
+    const showLabel = el.closest('.popup-links') || el.closest('.ac-modal-footer');
+    el.innerHTML = showLabel
+      ? (isWatched ? ICO_WATCHING + ' Watching' : ICO_WATCH + ' Watch')
+      : (isWatched ? ICO_WATCHING : ICO_WATCH);
+  });
 }
 
 function updateWatchBadge() {
@@ -5385,6 +5413,7 @@ function getActiveAdvFilterCount() {
   let count = 0;
   if (document.getElementById('sched-status')?.value) count++;
   if (document.getElementById('sched-aircraft')?.value) count++;
+  if (document.getElementById('sched-fleet-family')?.value) count++;
   if (document.getElementById('sched-route-type')?.value) count++;
   if (document.getElementById('sched-starlink')?.value) count++;
   if (document.getElementById('sched-timerange')?.value) count++;
@@ -5402,7 +5431,7 @@ function updateAdvFilterBtnText() {
     btn.textContent = `Filters (${count} active) ${isOpen ? '▴' : '▾'}`;
     btn.style.color = 'var(--ua-accent)';
   } else {
-    btn.textContent = isOpen ? 'Less Filters ▴' : 'Filter: Aircraft, Starlink, Delay… ▾';
+    btn.textContent = isOpen ? 'Less Filters ▴' : 'Filter: Fleet, Aircraft, Starlink… ▾';
     btn.style.color = 'var(--ua-muted)';
   }
 }
@@ -5687,7 +5716,7 @@ document.addEventListener('click', function(e) {
       'Toggle the weather radar overlay with the rain cloud button on the map'
     ],
     'tab-schedule': [
-      'Use "Filter: Aircraft, Starlink, Delay…" to find Starlink-equipped flights on your route',
+      'Use "Filter: Fleet, Aircraft, Starlink…" to narrow by family, equipment, or WiFi',
       'Click any registration in the schedule table to see full aircraft details'
     ],
     'tab-myflight': [
@@ -6392,7 +6421,7 @@ function buildAircraftDetailHTML(ac, reg) {
     var watchFlt = liveFlight.flightIATA || liveFlight.callsign || '';
     var watchRoute = (liveFlight.origin || '?') + '→' + (liveFlight.dest || '?');
     var watched = watchFlt ? isFlightWatched(watchFlt) : false;
-    html += '<button class="ac-action-btn watch-btn' + (watched ? ' watching' : '') + '" data-action="toggle-watch-flight" data-flight="' + escapeHtml(watchFlt) + '" data-route="' + escapeHtml(watchRoute) + '" data-status="airborne">' + (watched ? ICO_WATCHING + ' Watching' : ICO_WATCH + ' Watch') + '</button>';
+    html += '<button class="ac-action-btn watch-btn' + (watched ? ' watching' : '') + '" data-action="toggle-watch-flight" data-flight="' + escapeHtml(watchFlt) + '" data-route="' + escapeHtml(watchRoute) + '" data-status="airborne" data-stop-prop="1">' + (watched ? ICO_WATCHING + ' Watching' : ICO_WATCH + ' Watch') + '</button>';
   }
   html += '<a class="ac-action-btn" href="https://www.planespotters.net/search?q=' + encodeURIComponent(reg) + '" target="_blank" rel="noopener noreferrer">Planespotters ' + ICO_EXTLINK + '</a>';
   html += '<a class="ac-action-btn" href="https://flightaware.com/resources/registration/' + encodeURIComponent(reg) + '" target="_blank" rel="noopener noreferrer">FlightAware ' + ICO_EXTLINK + '</a>';

--- a/src/lib/flight-popup.js
+++ b/src/lib/flight-popup.js
@@ -1,0 +1,12 @@
+export function getFlightPopupMetrics(flight) {
+  const altFt = flight.alt ? Math.round(flight.alt * 3.28084) : null;
+  const spdKts = flight.spd ? Math.round(flight.spd * 1.944) : null;
+  const altPct = altFt ? Math.min(100, (altFt / 41000) * 100) : 0;
+
+  return {
+    altFt,
+    altPct,
+    // FR24 feed speed is groundspeed; do not infer Mach from it.
+    speedText: spdKts ? `${spdKts} kts` : 'N/A',
+  };
+}

--- a/src/lib/schedule-filters.js
+++ b/src/lib/schedule-filters.js
@@ -1,0 +1,13 @@
+export function getScheduleFleetFamily(modelCode, modelText = '') {
+  const code = String(modelCode || '').toUpperCase().replace(/[^A-Z0-9]/g, '');
+  const text = String(modelText || '').toUpperCase();
+
+  if (/^(B?73|73|7M)/.test(code) || text.includes('737')) return '737';
+  if (/^(A?31|31|A?32|32)/.test(code) || /(A319|A320|A321)/.test(text)) return 'A320';
+  if (/^(B?75|75)/.test(code) || text.includes('757')) return '757';
+  if (/^(B?76|76)/.test(code) || text.includes('767')) return '767';
+  if (/^(B?77|77)/.test(code) || text.includes('777')) return '777';
+  if (/^(B?78|78)/.test(code) || text.includes('787') || text.includes('DREAMLINER')) return '787';
+
+  return '';
+}

--- a/tests/flight-popup.test.js
+++ b/tests/flight-popup.test.js
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { getFlightPopupMetrics } from '../src/lib/flight-popup.js';
+
+describe('getFlightPopupMetrics', () => {
+  it('shows cruise speed in knots without inventing a Mach number', () => {
+    const metrics = getFlightPopupMetrics({
+      alt: 35000 / 3.28084,
+      spd: 450 / 1.944,
+    });
+
+    expect(metrics.altFt).toBe(35000);
+    expect(metrics.speedText).toBe('450 kts');
+    expect(metrics.speedText).not.toContain('M');
+  });
+
+  it('falls back to N/A when speed is missing', () => {
+    expect(getFlightPopupMetrics({ alt: 12000 / 3.28084, spd: 0 }).speedText).toBe('N/A');
+  });
+});

--- a/tests/schedule-filters.test.js
+++ b/tests/schedule-filters.test.js
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { getScheduleFleetFamily } from '../src/lib/schedule-filters.js';
+
+describe('getScheduleFleetFamily', () => {
+  it('maps 777 variants to the 777 family', () => {
+    expect(getScheduleFleetFamily('B772', 'Boeing 777-200')).toBe('777');
+    expect(getScheduleFleetFamily('77W', 'Boeing 777-300ER')).toBe('777');
+  });
+
+  it('maps Airbus narrowbody variants to the A320 family', () => {
+    expect(getScheduleFleetFamily('A319', 'Airbus A319')).toBe('A320');
+    expect(getScheduleFleetFamily('32N', 'Airbus A321neo')).toBe('A320');
+  });
+
+  it('maps Dreamliner variants to the 787 family', () => {
+    expect(getScheduleFleetFamily('B78X', 'Boeing 787-10 Dreamliner')).toBe('787');
+  });
+
+  it('returns empty string for unknown equipment', () => {
+    expect(getScheduleFleetFamily('CRJ7', 'Canadair Regional Jet')).toBe('');
+  });
+});


### PR DESCRIPTION
This stops deriving Mach from FR24 groundspeed in the live aircraft popup and shows speed in knots only. It also improves mobile flight tracking UX by preventing popup/modal watch taps from bubbling, syncing visible watch buttons immediately, enlarging watch/share touch targets, and showing a confirmation banner after save/remove. The Schedule tab now has a fleet-family filter for 737, A320, 757, 767, 777, and 787, including the missing HTML control and mapping tests. Verification: npm test and npm run build:dashboard both passed.