### PR TITLE
fix: upgrade fast-xml-parser and rate-limit unprotected endpoints

### DIFF
--- a/api/predict-flight.ts
+++ b/api/predict-flight.ts
@@ -2,8 +2,10 @@
 // Calls upstream unitedstarlinktracker.com/api/predict-flight
 
 import type { VercelRequest, VercelResponse } from './types.js';
+import { createRateLimiter } from './_rate-limit.js';
 
 const UPSTREAM_URL = 'https://unitedstarlinktracker.com/api/predict-flight';
+const isRateLimited = createRateLimiter('predict-flight', 20);
 
 // Simple in-memory cache: predictions don't change frequently
 const cache = new Map<string, { data: any; ts: number }>();
@@ -25,11 +27,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     : 'UA' + flightNumber.replace(/^UAL/i, '');
 
   try {
-    // Check cache
+    // Check cache — serve cached responses without rate limiting
     const cached = cache.get(normalized);
     if (cached && Date.now() - cached.ts < CACHE_TTL) {
       res.setHeader('Cache-Control', 'public, s-maxage=1800, stale-while-revalidate=300');
       return res.status(200).json(cached.data);
+    }
+
+    // Rate limit only upstream fetches, not cache hits
+    if (isRateLimited(req)) {
+      return res.status(429).json({ error: 'Too many requests' });
     }
 
     const controller = new AbortController();

--- a/api/starlink-data.ts
+++ b/api/starlink-data.ts
@@ -3,6 +3,7 @@
 // Fallback: fetches directly from upstream if cache is empty
 
 import type { VercelRequest, VercelResponse } from './types.js';
+import { createRateLimiter } from './_rate-limit.js';
 
 const UPSTREAM_URL = 'https://unitedstarlinktracker.com/api/data';
 const CACHE_TTL = 4 * 60 * 60 * 1000; // 4 hours
@@ -15,6 +16,8 @@ interface StarlinkCache {
   lastUpdated: string;
   syncedAt: string;
 }
+
+const isRateLimited = createRateLimiter('starlink-data', 30);
 
 let inMemoryCache: StarlinkCache | null = null;
 let lastFetch = 0;
@@ -77,17 +80,21 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   try {
-    // Check cron-populated global cache first
+    // Serve cached responses without rate limiting
     const cronCache = (globalThis as any).__starlinkCache as StarlinkCache | undefined;
     if (cronCache) {
       res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=600');
       return res.status(200).json(cronCache);
     }
 
-    // Fall back to in-memory cache with TTL
     if (inMemoryCache && Date.now() - lastFetch < CACHE_TTL) {
       res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=600');
       return res.status(200).json(inMemoryCache);
+    }
+
+    // Rate limit only upstream fetches, not cache hits
+    if (isRateLimited(req)) {
+      return res.status(429).json({ error: 'Too many requests' });
     }
 
     // Fetch fresh

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@supabase/supabase-js": "^2.49.1",
         "@vercel/functions": "^3.4.3",
         "astro": "^5.0.0",
-        "fast-xml-parser": "^5.4.2",
+        "fast-xml-parser": "^5.5.9",
         "resend": "^6.9.4",
       },
       "devDependencies": {
@@ -505,9 +505,9 @@
 
     "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
 
-    "fast-xml-builder": ["fast-xml-builder@1.0.0", "", {}, "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ=="],
+    "fast-xml-builder": ["fast-xml-builder@1.1.4", "", { "dependencies": { "path-expression-matcher": "^1.1.3" } }, "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg=="],
 
-    "fast-xml-parser": ["fast-xml-parser@5.4.2", "", { "dependencies": { "fast-xml-builder": "^1.0.0", "strnum": "^2.1.2" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-pw/6pIl4k0CSpElPEJhDppLzaixDEuWui2CUQQBH/ECDf7+y6YwA4Gf7Tyb0Rfe4DIMuZipYj4AEL0nACKglvQ=="],
+    "fast-xml-parser": ["fast-xml-parser@5.5.9", "", { "dependencies": { "fast-xml-builder": "^1.1.4", "path-expression-matcher": "^1.2.0", "strnum": "^2.2.2" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
@@ -767,6 +767,8 @@
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
+    "path-expression-matcher": ["path-expression-matcher@1.2.0", "", {}, "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ=="],
+
     "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
     "path-to-regexp": ["path-to-regexp@6.1.0", "", {}, "sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw=="],
@@ -889,7 +891,7 @@
 
     "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
 
-    "strnum": ["strnum@2.1.2", "", {}, "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ=="],
+    "strnum": ["strnum@2.2.2", "", {}, "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA=="],
 
     "svgo": ["svgo@4.0.0", "", { "dependencies": { "commander": "^11.1.0", "css-select": "^5.1.0", "css-tree": "^3.0.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.1.1", "sax": "^1.4.1" }, "bin": "bin/svgo.js" }, "sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@supabase/supabase-js": "^2.49.1",
     "@vercel/functions": "^3.4.3",
     "astro": "^5.0.0",
-    "fast-xml-parser": "^5.4.2",
+    "fast-xml-parser": "^5.5.9",
     "resend": "^6.9.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Upgrades `fast-xml-parser` from 5.4.2 to 5.5.9, fixing 3 CVEs (CVE-2026-26278, CVE-2026-25896, CVE-2026-33036) for entity expansion bypass in XML parsing used on FAA data
- Adds rate limiting to `/api/predict-flight` (20/min) and `/api/starlink-data` (30/min), the only two public endpoints that were missing it
- Rate limits gate upstream fetches only — cache hits are served freely so users behind shared NATs don't get false 429s

## Test plan
- [x] All 304 existing tests pass
- [x] Codex independent review: PASS (caught and fixed rate-limit placement before cache check)