### PR TITLE
chore: integrate vercel speed insights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versio
 - Dev script uses `bunx` instead of `npx` for Astro dev server
 - Converted `prewarm-cache.sh` bash script to TypeScript with native `fetch`
 - Converted `fix-fleet.cjs` and `rebuild-fleet.cjs` from CommonJS to ESM
+- Added `@vercel/speed-insights` v2.0.0 and moved Speed Insights loading to shared Astro wrappers plus the dashboard bundle, replacing the hardcoded homepage script
 
 ### Added
 - `@types/bun` for TypeScript support of Bun-specific APIs
 - `scripts/prewarm-cache.ts` (TypeScript replacement for bash script)
+- Regression coverage for the Speed Insights integration points across the dashboard entrypoint and static Astro documents
 
 ### Removed
 - `scripts/prewarm-cache.sh` (replaced by TypeScript version)

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@anthropic-ai/sdk": "^0.78.0",
         "@supabase/supabase-js": "^2.49.1",
         "@vercel/functions": "^3.4.3",
+        "@vercel/speed-insights": "^2.0.0",
         "astro": "^5.0.0",
         "fast-xml-parser": "^5.5.9",
         "resend": "^6.9.4",
@@ -312,6 +313,8 @@
     "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
 
     "@vercel/python-analysis": ["@vercel/python-analysis@0.9.0", "", { "dependencies": { "@bytecodealliance/preview2-shim": "0.17.6", "@renovatebot/pep440": "4.2.1", "fs-extra": "11.1.1", "js-yaml": "4.1.1", "minimatch": "10.1.1", "pip-requirements-js": "1.0.2", "smol-toml": "1.5.2", "zod": "3.22.4" } }, "sha512-F69vtvfPKR+N+g1B4zeKTiVztuSTbUopk6zypwO/nvPmz5rZmpqK/aCvTi+uEVKMvq7UGlOXS8RYdnVMxpzXSw=="],
+
+    "@vercel/speed-insights": ["@vercel/speed-insights@2.0.0", "", { "peerDependencies": { "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "nuxt": ">= 3", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@sveltejs/kit", "next", "nuxt", "react", "svelte", "vue", "vue-router"] }, "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w=="],
 
     "@vercel/static-config": ["@vercel/static-config@3.1.2", "", { "dependencies": { "ajv": "8.6.3", "json-schema-to-ts": "1.6.4", "ts-morph": "12.0.0" } }, "sha512-2d+TXr6K30w86a+WbMbGm2W91O0UzO5VeemZYBBUJbCjk/5FLLGIi8aV6RS2+WmaRvtcqNTn2pUA7nCOK3bGcQ=="],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@anthropic-ai/sdk": "^0.78.0",
     "@supabase/supabase-js": "^2.49.1",
     "@vercel/functions": "^3.4.3",
+    "@vercel/speed-insights": "^2.0.0",
     "astro": "^5.0.0",
     "fast-xml-parser": "^5.5.9",
     "resend": "^6.9.4"

--- a/public/index.html
+++ b/public/index.html
@@ -794,7 +794,6 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
 </footer>
 
 <script defer src="/_vercel/insights/script.js"></script>
-<script defer src="/_vercel/speed-insights/script.js"></script>
 <script>
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker.register('/sw.js').catch(() => {});

--- a/src/components/VercelSpeedInsights.astro
+++ b/src/components/VercelSpeedInsights.astro
@@ -1,0 +1,5 @@
+---
+import SpeedInsights from '@vercel/speed-insights/astro';
+---
+
+<SpeedInsights />

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -1,3 +1,4 @@
+import { injectSpeedInsights } from '@vercel/speed-insights';
 import { computeDelayRiskModel, HUB_COORDINATES, HUB_RISK_PROFILES } from '../lib/delay-risk.js';
 import { formatDelayExplainFAAStatus, getScheduleRiskContext } from '../lib/delay-explain-context.js';
 import { getMetarStationForIata, INTL_AIRPORTS } from '../lib/airport-metadata.js';
@@ -5,6 +6,8 @@ import { chunkMetarStationIds, normalizeMetarPayload } from '../lib/metar.js';
 import { categorizeFleetStatus, FLEET_HEALTH_CATEGORIES, FLEET_FAMILIES, normalizeWifi, WIFI_DISPLAY, sortFleetData, filterFleetData, parseFleetDeepLink, TAB_MAP, VALID_FLEET_VIEWS } from '../lib/fleet-utils.js';
 import { getFlightPopupMetrics } from '../lib/flight-popup.js';
 import { getScheduleFleetFamily } from '../lib/schedule-filters.js';
+
+injectSpeedInsights();
 
 // ═══════════════════════════════════════════════
 // SVG ICON CONSTANTS — clean icons for buttons

--- a/src/layouts/FleetTypeLayout.astro
+++ b/src/layouts/FleetTypeLayout.astro
@@ -1,6 +1,7 @@
 ---
 import { fleetOrder, fleetNavLabels } from '../data/fleet/index.js';
 import Footer from '../components/Footer.astro';
+import VercelSpeedInsights from '../components/VercelSpeedInsights.astro';
 import fleetDb from '../../public/data/fleet.json';
 
 const { data } = Astro.props;
@@ -286,6 +287,8 @@ a:hover{text-decoration:underline}
 </main>
 
 <Footer />
+
+<VercelSpeedInsights />
 
 <!-- Scroll Hint Script -->
 <script is:inline>

--- a/src/layouts/HubLayout.astro
+++ b/src/layouts/HubLayout.astro
@@ -1,6 +1,7 @@
 ---
 import { hubOrder, hubNavLabels } from '../data/hubs/index.js';
 import Footer from '../components/Footer.astro';
+import VercelSpeedInsights from '../components/VercelSpeedInsights.astro';
 
 const { data } = Astro.props;
 const iata = data.iata;
@@ -287,6 +288,8 @@ nav.jump-nav a:hover{border-color:var(--ua-accent);color:var(--ua-accent);text-d
 </main>
 
 <Footer />
+
+<VercelSpeedInsights />
 
 <!-- Live Data Script -->
 <script is:inline define:vars={{ iata }}>

--- a/src/layouts/NewsLayout.astro
+++ b/src/layouts/NewsLayout.astro
@@ -1,5 +1,6 @@
 ---
 import Footer from '../components/Footer.astro';
+import VercelSpeedInsights from '../components/VercelSpeedInsights.astro';
 import { resolveTag } from '../data/news/index.js';
 
 const { article } = Astro.props;
@@ -195,6 +196,8 @@ a:hover{text-decoration:underline}
 </main>
 
 <Footer />
+
+<VercelSpeedInsights />
 
 </body>
 </html>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,5 +1,6 @@
 ---
 import { hubOrder, hubNavLabels } from '../data/hubs/index.js';
+import VercelSpeedInsights from '../components/VercelSpeedInsights.astro';
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -43,5 +44,6 @@ a:hover{text-decoration:underline}
   </div>
 </main>
   <div class="footer">The Blue Board · Independent · Not affiliated with United Airlines, Inc.</div>
+<VercelSpeedInsights />
 </body>
 </html>

--- a/src/pages/fleet/index.astro
+++ b/src/pages/fleet/index.astro
@@ -1,5 +1,6 @@
 ---
 import { fleetOrder, fleetNavLabels, fleetTypes } from '../../data/fleet/index.js';
+import VercelSpeedInsights from '../../components/VercelSpeedInsights.astro';
 
 // Build type summaries for the grid
 const typeSummaries: Record<string, { displayName: string; count: number; role: string; bodyType: string; seatTotal: string; slug: string }> = {};
@@ -454,6 +455,8 @@ p{margin-bottom:12px}
     <span style="white-space:nowrap">Built by <a href="https://github.com/notjbg" target="_blank" rel="noopener noreferrer" style="color:var(--ua-accent);text-decoration:none">Jonah Berg</a> · <a href="https://x.com/theblueboard" target="_blank" rel="noopener noreferrer" style="color:var(--ua-accent);text-decoration:none">Follow @theblueboard</a></span>
   </div>
 </div>
+
+<VercelSpeedInsights />
 
 </body>
 </html>

--- a/src/pages/hubs/index.astro
+++ b/src/pages/hubs/index.astro
@@ -1,5 +1,6 @@
 ---
 import { hubOrder, hubNavLabels, hubs } from '../../data/hubs/index.js';
+import VercelSpeedInsights from '../../components/VercelSpeedInsights.astro';
 
 const hubSummaries: Record<string, { name: string; city: string; subtitle: string; iata: string }> = {};
 for (const key of hubOrder) {
@@ -244,6 +245,8 @@ p{margin-bottom:12px}
     <span style="white-space:nowrap">Built by <a href="https://github.com/notjbg" target="_blank" rel="noopener noreferrer" style="color:var(--ua-accent);text-decoration:none">Jonah Berg</a> · <a href="https://x.com/theblueboard" target="_blank" rel="noopener noreferrer" style="color:var(--ua-accent);text-decoration:none">Follow @theblueboard</a></span>
   </div>
 </div>
+
+<VercelSpeedInsights />
 
 </body>
 </html>

--- a/src/pages/news/index.astro
+++ b/src/pages/news/index.astro
@@ -1,5 +1,6 @@
 ---
 import Footer from '../../components/Footer.astro';
+import VercelSpeedInsights from '../../components/VercelSpeedInsights.astro';
 import { articles } from '../../data/news/index.js';
 
 const featured = articles[0]; // newest
@@ -159,6 +160,8 @@ a:hover{text-decoration:underline}
 </main>
 
 <Footer />
+
+<VercelSpeedInsights />
 
 </body>
 </html>

--- a/src/pages/tsa.astro
+++ b/src/pages/tsa.astro
@@ -1,6 +1,7 @@
 ---
 import { unitedTerminals, tsaHubOrder, getAllFaqEntries } from '../data/tsa/united-terminals.js';
 import Footer from '../components/Footer.astro';
+import VercelSpeedInsights from '../components/VercelSpeedInsights.astro';
 
 const faqEntries = getAllFaqEntries();
 ---
@@ -364,5 +365,6 @@ const faqEntries = getAllFaqEntries();
   // The API proxy and cron remain in place for when the data source returns.
 })();
 </script>
+<VercelSpeedInsights />
 </body>
 </html>

--- a/tests/speed-insights-integration.test.js
+++ b/tests/speed-insights-integration.test.js
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function readProjectFile(path) {
+  return readFileSync(resolve(process.cwd(), path), 'utf8');
+}
+
+describe('Speed Insights integration', () => {
+  it('uses a shared Astro wrapper component', () => {
+    const component = readProjectFile('src/components/VercelSpeedInsights.astro');
+
+    expect(component).toContain("import SpeedInsights from '@vercel/speed-insights/astro';");
+    expect(component).toContain('<SpeedInsights />');
+  });
+
+  it('injects Speed Insights from the dashboard bundle and avoids a duplicate static script', () => {
+    const dashboardEntry = readProjectFile('src/dashboard/main.js');
+    const dashboardHtml = readProjectFile('public/index.html');
+
+    expect(dashboardEntry).toContain("import { injectSpeedInsights } from '@vercel/speed-insights';");
+    expect(dashboardEntry).toContain('injectSpeedInsights();');
+    expect(dashboardHtml).toContain('<script defer src="/_vercel/insights/script.js"></script>');
+    expect(dashboardHtml).not.toContain('/_vercel/speed-insights/script.js');
+  });
+
+  it('mounts the shared wrapper from every static Astro document entrypoint', () => {
+    const entrypoints = [
+      'src/layouts/FleetTypeLayout.astro',
+      'src/layouts/HubLayout.astro',
+      'src/layouts/NewsLayout.astro',
+      'src/pages/404.astro',
+      'src/pages/fleet/index.astro',
+      'src/pages/hubs/index.astro',
+      'src/pages/news/index.astro',
+      'src/pages/tsa.astro',
+    ];
+
+    for (const file of entrypoints) {
+      const source = readProjectFile(file);
+
+      expect(source, file).toContain('VercelSpeedInsights');
+      expect(source, file).toContain('<VercelSpeedInsights />');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add `@vercel/speed-insights` v2.0.0 to the project and wire it into the dashboard bundle plus shared Astro document wrappers
- remove the old hardcoded homepage Speed Insights script so the site reports through the maintained package integration instead of a duplicate static tag
- add a focused Vitest regression file that locks the dashboard, wrapper, and static entrypoint integration points

## Test Coverage
```text
CODE PATH COVERAGE
==================
[+] src/dashboard/main.js
    └── [★★★ TESTED] Boot-time Speed Insights injection is present and package-backed — tests/speed-insights-integration.test.js:16

[+] src/components/VercelSpeedInsights.astro
    └── [★★★ TESTED] Shared Astro wrapper imports the official Vercel component — tests/speed-insights-integration.test.js:9

[+] Static Astro document entrypoints
    └── [★★★ TESTED] Shared wrapper is mounted from every static page/layout touched by this PR — tests/speed-insights-integration.test.js:26

[+] public/index.html
    └── [★★★ TESTED] Duplicate hardcoded Speed Insights script is removed while Vercel Analytics remains — tests/speed-insights-integration.test.js:16

─────────────────────────────────
COVERAGE: 4/4 paths tested (100%)
QUALITY:  ★★★: 4  ★★: 0  ★: 0
Tests: 22 → 23 (+1 new)
─────────────────────────────────
```

## Pre-Landing Review
No issues found.

## Design Review
Design Review (lite): No issues found.

## Eval Results
No prompt-related files changed — evals skipped.

## Test plan
- [x] `bun run test` (23 files, 307 tests)
- [x] `bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)