### PR TITLE
feat: integrate FAA NAS rich JSON API with en-route programs and operations plan

### DIFF
--- a/api/faa.ts
+++ b/api/faa.ts
@@ -4,23 +4,348 @@ import { createRateLimiter } from './_rate-limit.js';
 
 const isRateLimited = createRateLimiter('faa', 60);
 
-const parser = new XMLParser({
+// --- Types ---
+
+interface FAAProgram {
+  type: 'ground_stop' | 'ground_delay' | 'departure_delay' | 'arrival_delay' | 'closure';
+  reason: string;
+  avgDelay?: number | null;
+  minDelay?: number | null;
+  maxDelay?: number | null;
+  endTime?: string | null;
+  trend?: string | null;
+  probabilityOfExtension?: string | null;
+  advisoryUrl?: string | null;
+  center?: string | null;
+}
+
+interface FAARunwayConfig {
+  arrivalRunways: string;
+  departureRunways: string;
+  arrivalRate: number;
+}
+
+interface FAAAirport {
+  airportCode: string;
+  programs: FAAProgram[];
+  runwayConfig?: FAARunwayConfig | null;
+  deicing: boolean;
+  notam?: string | null;
+  groundStop: boolean;
+  groundDelay: boolean;
+  departureDelay: boolean;
+  arrivalDelay: boolean;
+  closure: boolean;
+  avgDelay: number | null;
+  minDelay: number | null;
+  maxDelay: number | null;
+  // Legacy compat: flat delays array for existing client code
+  delays: { reason: string; type: string; avgDelay?: number | null; minDelay?: number | null; maxDelay?: number | null; trend?: string | null; endTime?: string | null }[];
+}
+
+// --- Helpers ---
+
+/** Parse numeric minutes from strings like "31 minutes", "5 hours and 45 minutes", or plain numbers */
+export function parseDelayMinutes(val: unknown): number | null {
+  if (val === null || val === undefined) return null;
+  if (typeof val === 'number') return Number.isFinite(val) ? Math.round(val) : null;
+  const s = String(val).trim();
+  if (!s) return null;
+  // Try plain number first
+  const plain = Number(s);
+  if (Number.isFinite(plain)) return Math.round(plain);
+  // Parse "X hours and Y minutes" or "X minutes"
+  let total = 0;
+  const hours = s.match(/(\d+)\s*hour/i);
+  const mins = s.match(/(\d+)\s*min/i);
+  if (hours) total += parseInt(hours[1], 10) * 60;
+  if (mins) total += parseInt(mins[1], 10);
+  return total > 0 ? total : null;
+}
+
+function safeUrl(url: unknown): string | null {
+  if (!url || typeof url !== 'string') return null;
+  const trimmed = url.trim();
+  return trimmed.startsWith('https://') ? trimmed : null;
+}
+
+function str(val: unknown): string {
+  return val != null ? String(val).trim() : '';
+}
+
+// --- JSON path: /api/airport-events ---
+
+function parseJsonResponse(data: any[]): FAAAirport[] {
+  const results: FAAAirport[] = [];
+
+  for (const airport of data) {
+    const code = str(airport.airportId);
+    if (!code) continue;
+
+    const programs: FAAProgram[] = [];
+    let worstAvg: number | null = null;
+    let worstMin: number | null = null;
+    let worstMax: number | null = null;
+
+    // Ground Stop
+    if (airport.groundStop) {
+      const gs = airport.groundStop;
+      programs.push({
+        type: 'ground_stop',
+        reason: str(gs.impactingCondition),
+        endTime: str(gs.endTime) || null,
+        probabilityOfExtension: str(gs.probabilityOfExtension) || null,
+        advisoryUrl: safeUrl(gs.advisoryUrl),
+        center: str(gs.center) || null,
+      });
+    }
+
+    // Ground Delay
+    if (airport.groundDelay) {
+      const gd = airport.groundDelay;
+      const avg = parseDelayMinutes(gd.avgDelay);
+      const max = parseDelayMinutes(gd.maxDelay);
+      if (avg !== null) worstAvg = Math.max(worstAvg ?? 0, avg);
+      if (max !== null) worstMax = Math.max(worstMax ?? 0, max);
+      programs.push({
+        type: 'ground_delay',
+        reason: str(gd.impactingCondition),
+        avgDelay: avg,
+        maxDelay: max,
+        endTime: str(gd.endTime) || null,
+        advisoryUrl: safeUrl(gd.advisoryUrl),
+        center: str(gd.center) || null,
+      });
+    }
+
+    // Arrival Delay
+    if (airport.arrivalDelay) {
+      const ad = airport.arrivalDelay;
+      const min = parseDelayMinutes(ad.arrivalDeparture?.min);
+      const max = parseDelayMinutes(ad.arrivalDeparture?.max);
+      if (min !== null) worstMin = Math.max(worstMin ?? 0, min);
+      if (max !== null) worstMax = Math.max(worstMax ?? 0, max);
+      programs.push({
+        type: 'arrival_delay',
+        reason: str(ad.reason),
+        minDelay: min,
+        maxDelay: max,
+        trend: str(ad.arrivalDeparture?.trend) || str(ad.trend) || null,
+      });
+    }
+
+    // Departure Delay
+    if (airport.departureDelay) {
+      const dd = airport.departureDelay;
+      const min = parseDelayMinutes(dd.arrivalDeparture?.min);
+      const max = parseDelayMinutes(dd.arrivalDeparture?.max);
+      const avg = parseDelayMinutes(dd.averageDelay);
+      if (avg !== null) worstAvg = Math.max(worstAvg ?? 0, avg);
+      if (min !== null) worstMin = Math.max(worstMin ?? 0, min);
+      if (max !== null) worstMax = Math.max(worstMax ?? 0, max);
+      programs.push({
+        type: 'departure_delay',
+        reason: str(dd.reason),
+        avgDelay: avg,
+        minDelay: min,
+        maxDelay: max,
+        trend: str(dd.arrivalDeparture?.trend) || str(dd.trend) || null,
+      });
+    }
+
+    // Airport Closure
+    if (airport.airportClosure) {
+      const ac = airport.airportClosure;
+      programs.push({
+        type: 'closure',
+        reason: str(ac.reason || ac.simpleText),
+      });
+    }
+
+    // Runway Config
+    let runwayConfig: FAARunwayConfig | null = null;
+    if (airport.airportConfig && airport.airportConfig.arrivalRate > 0) {
+      runwayConfig = {
+        arrivalRunways: str(airport.airportConfig.arrivalRunwayConfig),
+        departureRunways: str(airport.airportConfig.departureRunwayConfig),
+        arrivalRate: Number(airport.airportConfig.arrivalRate) || 0,
+      };
+    }
+
+    // De-icing
+    const deicing = airport.deicing != null && airport.deicing !== false;
+
+    // NOTAM (freeForm)
+    const notam = airport.freeForm ? str(airport.freeForm.text || airport.freeForm.simpleText) || null : null;
+
+    // Build legacy flat delays array for backward compat
+    // Include per-program timing fields that existing UI code reads
+    const delays = programs.map(p => ({
+      reason: p.reason || p.type,
+      type: p.type,
+      avgDelay: p.avgDelay ?? null,
+      minDelay: p.minDelay ?? null,
+      maxDelay: p.maxDelay ?? null,
+      trend: p.trend ?? null,
+      endTime: p.endTime ?? null,
+    }));
+
+    results.push({
+      airportCode: code,
+      programs,
+      runwayConfig,
+      deicing,
+      notam,
+      groundStop: programs.some(p => p.type === 'ground_stop'),
+      groundDelay: programs.some(p => p.type === 'ground_delay'),
+      departureDelay: programs.some(p => p.type === 'departure_delay'),
+      arrivalDelay: programs.some(p => p.type === 'arrival_delay'),
+      closure: programs.some(p => p.type === 'closure'),
+      avgDelay: worstAvg,
+      minDelay: worstMin,
+      maxDelay: worstMax,
+      delays,
+    });
+  }
+
+  return results;
+}
+
+function validateJsonResponse(data: unknown): data is any[] {
+  if (!Array.isArray(data)) return false;
+  if (data.length === 0) return true; // Empty is valid (no active events)
+  // Spot-check first element has expected shape
+  const first = data[0];
+  return typeof first === 'object' && first !== null && 'airportId' in first;
+}
+
+// --- XML fallback path: /api/airport-status-information ---
+
+const xmlParser = new XMLParser({
   ignoreAttributes: false,
   allowBooleanAttributes: true,
   parseTagValue: true,
   trimValues: true,
 });
 
-interface FAADelay {
-  airportCode: string;
-  type: string;
-  reason: string;
-  avgDelay?: string | null;
-  endTime?: string | null;
-  minDelay?: string | null;
-  maxDelay?: string | null;
-  delays: { reason: string; type: string }[];
+function parseXmlFallback(xml: string): FAAAirport[] {
+  let parsed: any;
+  try {
+    parsed = xmlParser.parse(xml);
+  } catch (parseErr: any) {
+    console.error('FAA XML parse error:', parseErr.message);
+    return [];
+  }
+
+  // Collect all delays by airport, then group into FAAAirport objects
+  const byAirport = new Map<string, FAAProgram[]>();
+
+  function ensure(code: string): FAAProgram[] {
+    if (!byAirport.has(code)) byAirport.set(code, []);
+    return byAirport.get(code)!;
+  }
+
+  // Ground Delays
+  for (const entry of toArray(
+    parsed?.AIRPORT_STATUS_INFORMATION?.Delay_type?.Ground_Delay?.Delay ??
+    parsed?.Delay_type?.Ground_Delay?.Delay
+  )) {
+    const arpt = str(entry?.ARPT);
+    if (!arpt) continue;
+    ensure(arpt).push({
+      type: 'ground_delay',
+      reason: str(entry?.Reason),
+      avgDelay: parseDelayMinutes(entry?.Avg),
+      maxDelay: parseDelayMinutes(entry?.Max),
+    });
+  }
+
+  // Ground Stops
+  for (const entry of toArray(
+    parsed?.AIRPORT_STATUS_INFORMATION?.Delay_type?.Ground_Stop?.Delay ??
+    parsed?.Delay_type?.Ground_Stop?.Delay
+  )) {
+    const arpt = str(entry?.ARPT);
+    if (!arpt) continue;
+    ensure(arpt).push({
+      type: 'ground_stop',
+      reason: str(entry?.Reason),
+      endTime: str(entry?.End_Time || entry?.EndTime) || null,
+    });
+  }
+
+  // Arrival/Departure Delays
+  for (const entry of toArray(
+    parsed?.AIRPORT_STATUS_INFORMATION?.Delay_type?.Arrival_Departure_Delay?.Delay ??
+    parsed?.Delay_type?.Arrival_Departure_Delay?.Delay
+  )) {
+    const arpt = str(entry?.ARPT);
+    const reason = str(entry?.Reason);
+    if (!arpt) continue;
+    const isDep = reason.toLowerCase().includes('depart');
+    ensure(arpt).push({
+      type: isDep ? 'departure_delay' : 'arrival_delay',
+      reason,
+      minDelay: parseDelayMinutes(entry?.Min),
+      maxDelay: parseDelayMinutes(entry?.Max),
+    });
+  }
+
+  // Airport Closures
+  for (const entry of toArray(
+    parsed?.AIRPORT_STATUS_INFORMATION?.Delay_type?.Airport_Closure?.Airport ??
+    parsed?.Delay_type?.Airport_Closure?.Airport
+  )) {
+    const arpt = str(entry?.ARPT);
+    if (!arpt) continue;
+    ensure(arpt).push({
+      type: 'closure',
+      reason: str(entry?.Reason).split(' ').slice(0, 8).join(' '),
+    });
+  }
+
+  // Build FAAAirport objects from grouped programs
+  const results: FAAAirport[] = [];
+  for (const [code, programs] of byAirport) {
+    let worstAvg: number | null = null;
+    let worstMin: number | null = null;
+    let worstMax: number | null = null;
+    for (const p of programs) {
+      if (p.avgDelay != null) worstAvg = Math.max(worstAvg ?? 0, p.avgDelay);
+      if (p.minDelay != null) worstMin = Math.max(worstMin ?? 0, p.minDelay);
+      if (p.maxDelay != null) worstMax = Math.max(worstMax ?? 0, p.maxDelay);
+    }
+
+    results.push({
+      airportCode: code,
+      programs,
+      runwayConfig: null, // Not available in XML
+      deicing: false,     // Not available in XML
+      notam: null,        // Not available in XML
+      groundStop: programs.some(p => p.type === 'ground_stop'),
+      groundDelay: programs.some(p => p.type === 'ground_delay'),
+      departureDelay: programs.some(p => p.type === 'departure_delay'),
+      arrivalDelay: programs.some(p => p.type === 'arrival_delay'),
+      closure: programs.some(p => p.type === 'closure'),
+      avgDelay: worstAvg,
+      minDelay: worstMin,
+      maxDelay: worstMax,
+      delays: programs.map(p => ({
+        reason: p.reason || p.type, type: p.type,
+        avgDelay: p.avgDelay ?? null, minDelay: p.minDelay ?? null,
+        maxDelay: p.maxDelay ?? null, endTime: p.endTime ?? null,
+      })),
+    });
+  }
+
+  return results;
 }
+
+// --- Handler ---
+
+// Track consecutive JSON failures for exponential backoff
+let jsonFailCount = 0;
+let lastJsonFailTime = 0;
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'GET') {
@@ -37,106 +362,68 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 8000);
-    const upstream = await fetch('https://nasstatus.faa.gov/api/airport-status-information', {
-      signal: controller.signal
-    });
-    clearTimeout(timeout);
-    if (!upstream.ok) return res.status(502).json({ error: 'Upstream service unavailable' });
-    const xml = await upstream.text();
+    // Try JSON primary with exponential backoff
+    const now = Date.now();
+    const backoffMs = jsonFailCount > 0
+      ? Math.min(1000 * Math.pow(2, jsonFailCount - 1), 8000)
+      : 0;
+    const skipJson = jsonFailCount > 0 && (now - lastJsonFailTime) < backoffMs;
 
-    if (!xml || !xml.trim()) {
-      res.setHeader('Cache-Control', 's-maxage=60');
-      return res.status(200).json([]);
+    let airports: FAAAirport[] | null = null;
+
+    if (!skipJson) {
+      try {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 8000);
+        const upstream = await fetch('https://nasstatus.faa.gov/api/airport-events', {
+          signal: controller.signal,
+        });
+        clearTimeout(timeout);
+
+        if (upstream.ok) {
+          const json = await upstream.json();
+          if (validateJsonResponse(json)) {
+            airports = parseJsonResponse(json);
+            jsonFailCount = 0; // Reset on success
+          } else {
+            console.warn('FAA JSON schema validation failed, falling back to XML');
+            jsonFailCount++;
+            lastJsonFailTime = now;
+          }
+        } else {
+          console.warn(`FAA JSON primary returned ${upstream.status}, falling back to XML`);
+          jsonFailCount++;
+          lastJsonFailTime = now;
+        }
+      } catch (jsonErr: any) {
+        console.warn('FAA JSON primary failed:', jsonErr.message || jsonErr);
+        jsonFailCount++;
+        lastJsonFailTime = now;
+      }
     }
 
-    let parsed: any;
-    try {
-      parsed = parser.parse(xml);
-    } catch (parseErr: any) {
-      console.error('FAA XML parse error:', parseErr.message);
-      return res.status(200).json([]);
-    }
-
-    const delays: FAADelay[] = [];
-
-    // Ground Delays — preserve type so client can set groundDelay boolean
-    const groundDelays = toArray(
-      parsed?.AIRPORT_STATUS_INFORMATION?.Delay_type?.Ground_Delay?.Delay ||
-      parsed?.Delay_type?.Ground_Delay?.Delay
-    );
-    for (const entry of groundDelays) {
-      const arpt = String(entry?.ARPT || '').trim();
-      const reason = String(entry?.Reason || '').trim();
-      if (!arpt) continue;
-      delays.push({
-        airportCode: arpt,
-        type: 'ground_delay',
-        reason,
-        avgDelay: String(entry?.Avg || '').trim() || null,
-        delays: [{ reason, type: 'ground_delay' }],
+    // XML fallback
+    if (!airports) {
+      console.warn(`FAA using XML fallback (JSON fail count: ${jsonFailCount})`);
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 8000);
+      const upstream = await fetch('https://nasstatus.faa.gov/api/airport-status-information', {
+        signal: controller.signal,
       });
-    }
+      clearTimeout(timeout);
 
-    // Ground Stops — preserve type so client can set groundStop boolean
-    const groundStops = toArray(
-      parsed?.AIRPORT_STATUS_INFORMATION?.Delay_type?.Ground_Stop?.Delay ||
-      parsed?.Delay_type?.Ground_Stop?.Delay
-    );
-    for (const entry of groundStops) {
-      const arpt = String(entry?.ARPT || '').trim();
-      const reason = String(entry?.Reason || '').trim();
-      if (!arpt) continue;
-      delays.push({
-        airportCode: arpt,
-        type: 'ground_stop',
-        reason,
-        endTime: String(entry?.End_Time || entry?.EndTime || '').trim() || null,
-        delays: [{ reason, type: 'ground_stop' }],
-      });
-    }
-
-    // Arrival/Departure Delays — distinguish by reason text
-    const arrDepDelays = toArray(
-      parsed?.AIRPORT_STATUS_INFORMATION?.Delay_type?.Arrival_Departure_Delay?.Delay ||
-      parsed?.Delay_type?.Arrival_Departure_Delay?.Delay
-    );
-    for (const entry of arrDepDelays) {
-      const arpt = String(entry?.ARPT || '').trim();
-      const reason = String(entry?.Reason || '').trim();
-      if (!arpt) continue;
-      const isDep = reason.toLowerCase().includes('depart');
-      delays.push({
-        airportCode: arpt,
-        type: isDep ? 'departure_delay' : 'arrival_delay',
-        reason,
-        minDelay: String(entry?.Min || '').trim() || null,
-        maxDelay: String(entry?.Max || '').trim() || null,
-        delays: [{ reason, type: isDep ? 'departure_delay' : 'arrival_delay' }],
-      });
-    }
-
-    // Airport Closures
-    const closureEntries = toArray(
-      parsed?.AIRPORT_STATUS_INFORMATION?.Delay_type?.Airport_Closure?.Airport ||
-      parsed?.Delay_type?.Airport_Closure?.Airport
-    );
-    for (const entry of closureEntries) {
-      const arpt = String(entry?.ARPT || '').trim();
-      const reason = String(entry?.Reason || '').trim();
-      if (!arpt) continue;
-      delays.push({
-        airportCode: arpt,
-        type: 'closure',
-        reason,
-        delays: [{ reason: 'CLOSED: ' + reason.split(' ').slice(0, 8).join(' '), type: 'closure' }],
-      });
+      if (!upstream.ok) return res.status(502).json({ error: 'Upstream service unavailable' });
+      const xml = await upstream.text();
+      if (!xml || !xml.trim()) {
+        res.setHeader('Cache-Control', 's-maxage=60');
+        return res.status(200).json([]);
+      }
+      airports = parseXmlFallback(xml);
     }
 
     res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate=600');
     res.setHeader('Content-Type', 'application/json');
-    return res.status(200).json(delays);
+    return res.status(200).json(airports);
   } catch (e: any) {
     console.error('FAA API error:', e);
     if (e.name === 'AbortError') return res.status(504).json({ error: 'Upstream timeout' });
@@ -144,7 +431,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 }
 
-// Normalize a value to an array (handles undefined, single object, or array)
+/** Normalize a value to an array (handles undefined, single object, or array) */
 export function toArray<T>(val: T | T[] | undefined | null): T[] {
   if (!val) return [];
   return Array.isArray(val) ? val : [val];

--- a/api/nas.ts
+++ b/api/nas.ts
@@ -1,0 +1,208 @@
+import type { VercelRequest, VercelResponse } from './types.js';
+import { createRateLimiter } from './_rate-limit.js';
+
+const isRateLimited = createRateLimiter('nas', 60);
+
+// --- ARTCC code → plain-English name ---
+
+const ARTCC_NAMES: Record<string, string> = {
+  ZNY: 'New York Center', ZBW: 'Boston Center', ZDC: 'Washington Center',
+  ZTL: 'Atlanta Center', ZJX: 'Jacksonville Center', ZMA: 'Miami Center',
+  ZAU: 'Chicago Center', ZMP: 'Minneapolis Center', ZKC: 'Kansas City Center',
+  ZFW: 'Fort Worth Center', ZHU: 'Houston Center', ZDV: 'Denver Center',
+  ZLC: 'Salt Lake Center', ZLA: 'Los Angeles Center', ZOA: 'Oakland Center',
+  ZSE: 'Seattle Center', ZME: 'Memphis Center', ZID: 'Indianapolis Center',
+  ZOB: 'Cleveland Center', ZAB: 'Albuquerque Center',
+};
+
+// --- FAA shorthand decoder ---
+
+const FAA_SHORTHAND: Record<string, string> = {
+  GDP: 'Ground Delay Program',
+  GS: 'Ground Stop',
+  GDS: 'Ground Stop',
+  MIT: 'Miles-in-Trail',
+  MINIT: 'Minutes-in-Trail',
+  CDRS: 'Coded Departure Routes',
+  SWAP: 'Severe Weather Avoidance',
+  AFP: 'Airspace Flow Program',
+  EDCT: 'Expect Departure Clearance Time',
+  APREQ: 'Approval Request',
+  DSP: 'Departure Spacing Program',
+  FCA: 'Flow Constrained Area',
+  FEA: 'Flow Evaluation Area',
+};
+
+function decodeFaaShorthand(event: string): string {
+  let decoded = event.replace(/^-/, '').trim();
+  // Replace known abbreviations
+  for (const [abbr, full] of Object.entries(FAA_SHORTHAND)) {
+    decoded = decoded.replace(new RegExp(`\\b${abbr}\\b`, 'g'), full);
+  }
+  return decoded;
+}
+
+/** Extract 3-letter IATA airport codes from event text */
+function extractAirportCodes(text: string): string[] {
+  const matches = text.match(/\b([A-Z]{3})\b/g) || [];
+  // Filter to known airports (simple heuristic: exclude common abbreviations)
+  const exclude = new Set(['AND', 'THE', 'FOR', 'NOT', 'ALL', 'CDR', 'MIT', 'AFP', 'FCA', 'LOW', 'MED', 'EST', 'UTC']);
+  return matches.filter(m => !exclude.has(m));
+}
+
+function artccName(code: string): string {
+  return ARTCC_NAMES[code] || code;
+}
+
+// --- Types ---
+
+interface EnrouteProgram {
+  name: string;
+  reason: string;
+  avgDelay: number | null;
+  startTime: string;
+  endTime: string;
+  affectedFacilities: string[];
+}
+
+interface PlannedTMI {
+  time: string;
+  event: string;
+  decoded: string;
+  affectedAirports: string[];
+  type: 'terminal' | 'enroute';
+}
+
+interface NASResponse {
+  active: EnrouteProgram[];
+  planned: PlannedTMI[];
+  advisoryUrl: string | null;
+}
+
+// --- Parsers ---
+
+function parseEnrouteEvents(data: unknown): EnrouteProgram[] {
+  if (!Array.isArray(data)) return [];
+  const programs: EnrouteProgram[] = [];
+
+  for (const item of data) {
+    const afp = item?.airspaceFlowProgram;
+    if (!afp) continue;
+
+    const name = String(afp.afpName || '').trim();
+    if (!name) continue;
+
+    programs.push({
+      name,
+      reason: String(afp.impactingCondition || '').trim(),
+      avgDelay: typeof afp.avgDelay === 'number' && Number.isFinite(afp.avgDelay)
+        ? Math.round(afp.avgDelay) : null,
+      startTime: String(afp.startTime || ''),
+      endTime: String(afp.endTime || ''),
+      affectedFacilities: [
+        ...(Array.isArray(item.departsAny) ? item.departsAny : String(item.departsAny || '').split(',').filter(Boolean)),
+        ...(Array.isArray(item.arrivesAny) ? item.arrivesAny : String(item.arrivesAny || '').split(',').filter(Boolean)),
+      ].map(s => s.trim()).filter(Boolean),
+    });
+  }
+
+  return programs;
+}
+
+function parseOperationsPlan(data: unknown): { planned: PlannedTMI[]; advisoryUrl: string | null } {
+  if (!data || typeof data !== 'object') return { planned: [], advisoryUrl: null };
+  const obj = data as any;
+
+  const advisoryUrl = typeof obj.link === 'string' && obj.link.startsWith('https://')
+    ? obj.link : null;
+
+  const planned: PlannedTMI[] = [];
+
+  for (const entry of Array.isArray(obj.terminalPlanned) ? obj.terminalPlanned : []) {
+    const time = String(entry?.time || '').trim();
+    const event = String(entry?.event || '').replace(/^-/, '').trim();
+    if (!event) continue;
+    planned.push({
+      time,
+      event,
+      decoded: decodeFaaShorthand(event),
+      affectedAirports: extractAirportCodes(event),
+      type: 'terminal',
+    });
+  }
+
+  for (const entry of Array.isArray(obj.enRoutePlanned) ? obj.enRoutePlanned : []) {
+    const time = String(entry?.time || '').trim();
+    const event = String(entry?.event || '').replace(/^-/, '').trim();
+    if (!event) continue;
+    planned.push({
+      time,
+      event,
+      decoded: decodeFaaShorthand(event),
+      affectedAirports: extractAirportCodes(event),
+      type: 'enroute',
+    });
+  }
+
+  return { planned, advisoryUrl };
+}
+
+// --- Handler ---
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const origin = req.headers?.origin || '';
+  if (origin && origin !== 'https://theblueboard.co' && !/^http:\/\/localhost(:\d+)?$/.test(origin)) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  if (isRateLimited(req)) {
+    return res.status(429).json({ error: 'Rate limited — try again shortly' });
+  }
+
+  try {
+    const [enrouteResult, planResult] = await Promise.allSettled([
+      fetchWithTimeout('https://nasstatus.faa.gov/api/enroute-events', 8000),
+      fetchWithTimeout('https://nasstatus.faa.gov/api/operations-plan', 8000),
+    ]);
+
+    const active = enrouteResult.status === 'fulfilled'
+      ? parseEnrouteEvents(enrouteResult.value)
+      : [];
+
+    const { planned, advisoryUrl } = planResult.status === 'fulfilled'
+      ? parseOperationsPlan(planResult.value)
+      : { planned: [], advisoryUrl: null };
+
+    if (enrouteResult.status === 'rejected') {
+      console.warn('NAS enroute-events fetch failed:', enrouteResult.reason?.message || enrouteResult.reason);
+    }
+    if (planResult.status === 'rejected') {
+      console.warn('NAS operations-plan fetch failed:', planResult.reason?.message || planResult.reason);
+    }
+
+    const response: NASResponse = { active, planned, advisoryUrl };
+
+    res.setHeader('Cache-Control', 's-maxage=300, stale-while-revalidate=600');
+    res.setHeader('Content-Type', 'application/json');
+    return res.status(200).json(response);
+  } catch (e: any) {
+    console.error('NAS API error:', e);
+    return res.status(502).json({ error: 'Upstream service unavailable' });
+  }
+}
+
+async function fetchWithTimeout(url: string, ms: number): Promise<any> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), ms);
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    return await response.json();
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -2610,6 +2610,66 @@ async function fetchMetarBatch(allStations) {
   return payloads.flat();
 }
 
+const UA_HUBS = new Set(['ORD','DEN','IAH','EWR','SFO','IAD','LAX','NRT','GUM']);
+
+function renderNasPanel() {
+  let panelEl = document.getElementById('nas-status-panel');
+  if (!nasData || ((!nasData.active || !nasData.active.length) && (!nasData.planned || !nasData.planned.length))) {
+    if (panelEl) panelEl.style.display = 'none';
+    return;
+  }
+
+  // Create panel if it doesn't exist — insert after radar map
+  if (!panelEl) {
+    panelEl = document.createElement('div');
+    panelEl.id = 'nas-status-panel';
+    panelEl.style.cssText = 'background:var(--ua-panel);border-left:3px solid var(--ua-amber);border-radius:0 6px 6px 0;padding:10px 14px;margin-top:12px';
+    const radarMap = document.getElementById('radar-map');
+    if (radarMap && radarMap.parentNode) {
+      radarMap.parentNode.insertBefore(panelEl, radarMap.nextSibling);
+    } else {
+      const hubCards = document.getElementById('hub-cards');
+      if (hubCards) hubCards.parentNode.insertBefore(panelEl, hubCards);
+    }
+  }
+
+  panelEl.style.display = 'block';
+  let html = `<div style="font-family:'JetBrains Mono',monospace;font-size:10px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;color:var(--ua-amber);margin-bottom:8px">NAS STATUS</div>`;
+
+  // Active en-route programs
+  if (nasData.active && nasData.active.length) {
+    html += `<div style="font-family:Satoshi,sans-serif;font-size:11px;font-weight:600;color:var(--ua-text);margin-bottom:4px">Active</div>`;
+    for (const prog of nasData.active) {
+      html += `<div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ua-muted);margin-bottom:3px">${escapeHtml(prog.name)} — ${escapeHtml(prog.reason)}${prog.avgDelay ? ` (avg ${prog.avgDelay}m)` : ''}</div>`;
+    }
+  }
+
+  // Planned TMIs
+  if (nasData.planned && nasData.planned.length) {
+    html += `<div style="font-family:Satoshi,sans-serif;font-size:11px;font-weight:600;color:var(--ua-text);margin-top:8px;margin-bottom:4px">Planned</div>`;
+    for (const tmi of nasData.planned) {
+      const isHub = tmi.affectedAirports && tmi.affectedAirports.some(a => UA_HUBS.has(a));
+      const highlight = isHub ? 'color:var(--ua-text);font-weight:500' : 'color:var(--ua-muted)';
+      html += `<div style="font-family:'JetBrains Mono',monospace;font-size:10px;${highlight};margin-bottom:3px">${escapeHtml(tmi.time || '')} — ${escapeHtml(tmi.decoded || tmi.event)}</div>`;
+    }
+  }
+
+  // Advisory link
+  if (nasData.advisoryUrl) {
+    html += `<div style="margin-top:6px"><a href="${escapeHtml(nasData.advisoryUrl)}" target="_blank" rel="noopener noreferrer" style="font-size:9px;color:var(--ua-amber);text-decoration:underline">View full ATCSCC advisory →</a></div>`;
+  }
+
+  panelEl.innerHTML = html;
+}
+
+function trendIndicator(trend) {
+  if (!trend) return '';
+  const t = String(trend).toLowerCase();
+  if (t === 'increasing') return '<span style="color:var(--ua-red)">↑ Increasing</span>';
+  if (t === 'decreasing') return '<span style="color:var(--ua-green)">↓ Decreasing</span>';
+  return '<span style="color:var(--ua-muted)">→ Stable</span>';
+}
+
 async function initWeatherTab() {
   if (weatherInitialized) return;
   weatherInitialized = true;
@@ -2651,14 +2711,16 @@ async function initWeatherTab() {
     }
   });
 
-  // Fetch ALL METARs in a single request + FAA in parallel (2 requests instead of 8)
+  // Fetch ALL METARs + FAA + NAS in parallel (3 requests)
   const allStations = Object.values(hubStations).join(',');
-  const [metarResult, faaResult] = await Promise.allSettled([
+  const [metarResult, faaResult, nasResult] = await Promise.allSettled([
     fetchMetarBatch(allStations),
-    fetch('/api/faa').then(r => r.ok ? r.json() : Promise.reject(new Error(`faa-${r.status}`)))
+    fetch('/api/faa').then(r => r.ok ? r.json() : Promise.reject(new Error(`faa-${r.status}`))),
+    fetch('/api/nas').then(r => r.ok ? r.json() : Promise.reject(new Error(`nas-${r.status}`)))
   ]);
   const metarData = metarResult.status === 'fulfilled' ? metarResult.value : [];
   const faaData = faaResult.status === 'fulfilled' ? faaResult.value : [];
+  nasData = nasResult.status === 'fulfilled' ? nasResult.value : null;
 
   // Index METAR results by station ID → hub
   const stationToHub = {};
@@ -2671,21 +2733,8 @@ async function initWeatherTab() {
   const metarResults = hubs.map(hub => ({hub, data: metarByHub[hub] || null}));
   const loadedMetars = metarResults.filter(({ data }) => hasRenderableMetarData(data)).length;
 
-  // Index FAA delays by airport code — merge multiple entries per airport
-  const faaIndex = {};
-  if (Array.isArray(faaData)) faaData.forEach(d => {
-    const code = d.airportCode || d.airport;
-    if (!code) return;
-    if (!faaIndex[code]) faaIndex[code] = { delays: [] };
-    faaIndex[code].delays.push(...(d.delays || []));
-    // Set typed boolean flags the delay engine expects
-    if (d.type === 'ground_stop') faaIndex[code].groundStop = true;
-    else if (d.type === 'ground_delay') { faaIndex[code].groundDelay = true; faaIndex[code].avgDelay = d.avgDelay; }
-    else if (d.type === 'departure_delay') { faaIndex[code].departureDelay = true; faaIndex[code].minDelay = d.minDelay; faaIndex[code].maxDelay = d.maxDelay; }
-    else if (d.type === 'arrival_delay') { faaIndex[code].arrivalDelay = true; }
-    else if (d.type === 'closure') faaIndex[code].closure = true;
-  });
-  // Store globally for IROPS & schedule cross-reference
+  // Index FAA data by airport code
+  const faaIndex = buildFaaIndex(faaData);
   faaDelayIndex = faaIndex;
 
   // Build cards + map markers
@@ -2714,7 +2763,25 @@ async function initWeatherTab() {
     // Status line: FAA delays take priority, then ops impact, then normal
     let faaLine;
     if (hasDelay) {
-      faaLine = `<div class="hub-faa delay">⚠ ${faa.delays.map(d=>d.reason||d.type||'Delay').join(', ')}</div>`;
+      // Build enhanced FAA status with programs data
+      const statusParts = [];
+      if (faa.programs && faa.programs.length) {
+        for (const prog of faa.programs) {
+          let text = prog.reason || prog.type || 'Delay';
+          if (prog.type === 'ground_stop') {
+            text = 'Ground Stop';
+            if (prog.endTime) text += ` until ${prog.endTime}`;
+            if (prog.probabilityOfExtension) text += ` · ext: ${prog.probabilityOfExtension}`;
+          } else if (prog.type === 'ground_delay' && prog.avgDelay) {
+            text = `GDP (avg ${prog.avgDelay}m)`;
+          }
+          if (prog.trend) text += ` ${trendIndicator(prog.trend)}`;
+          statusParts.push(text);
+        }
+      } else {
+        statusParts.push(...faa.delays.map(d => d.reason || d.type || 'Delay'));
+      }
+      faaLine = `<div class="hub-faa delay">⚠ ${statusParts.join(', ')}</div>`;
     } else if (ops.level === 'severe') {
       faaLine = `<div class="hub-faa delay">⚠ Severe Weather Impact — ${ops.reasons.join(', ')}</div>`;
     } else if (ops.level === 'warning') {
@@ -2725,6 +2792,19 @@ async function initWeatherTab() {
       faaLine = `<div class="hub-faa normal">✓ Normal Operations</div>`;
     }
 
+    // Runway config summary line (scan tier)
+    let rwyLine = '';
+    if (faa && faa.runwayConfig && faa.runwayConfig.arrivalRate > 0) {
+      const rc = faa.runwayConfig;
+      rwyLine = `<div class="hub-rwy" style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ua-muted);margin-top:4px">RWY: ${escapeHtml(rc.arrivalRunways)}/${escapeHtml(rc.departureRunways)} · ${rc.arrivalRate}/hr</div>`;
+    }
+
+    // De-icing badge (scan tier, next to flight category)
+    const deiceBadge = faa && faa.deicing
+      ? `<span style="background:var(--ua-amber-soft);color:var(--ua-amber);font-family:'JetBrains Mono',monospace;font-size:9px;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;padding:2px 6px;border-radius:3px;margin-left:4px">DE-ICE</span>`
+      : '';
+
+    // Detail tier content (expandable)
     const explainer = raw ? explainMETAR(raw, hub, cat) : '';
     const faaExplainer = faa ? explainFAAStatus(hub, faa.delays||[], faa) : '';
     const unavailable = !hasRenderableMetarData(data);
@@ -2732,8 +2812,25 @@ async function initWeatherTab() {
       ? '<div class="hub-explainer">Current METAR observation unavailable. Retry in a moment.</div>'
       : '';
 
+    // Advisory links from programs
+    let advisoryLinks = '';
+    if (faa && faa.programs) {
+      const urls = faa.programs.filter(p => p.advisoryUrl).map(p =>
+        `<a href="${escapeHtml(p.advisoryUrl)}" target="_blank" rel="noopener noreferrer" style="font-size:9px;color:var(--ua-amber);text-decoration:underline">Advisory</a>`
+      );
+      if (urls.length) advisoryLinks = `<div style="margin-top:4px">${urls.join(' · ')}</div>`;
+    }
+
+    // NOTAM text
+    let notamHtml = '';
+    if (faa && faa.notam) {
+      notamHtml = `<div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ua-muted);margin-top:6px;padding-top:6px;border-top:1px solid var(--ua-border-subtle)">${escapeHtml(faa.notam)}</div>`;
+    }
+
+    const hasDetailContent = explainer || faaExplainer || raw || advisoryLinks || notamHtml;
+
     cardsHtml += `<div class="hub-card" data-hub="${hub}" style="border-top:3px solid ${borderColor}">
-      <div class="hub-card-top"><span class="hub-card-code">${hub}</span><span class="cat-badge" style="background:${catColor};color:#000">${cat}</span></div>
+      <div class="hub-card-top"><span class="hub-card-code">${hub}</span>${deiceBadge}<span class="cat-badge" style="background:${catColor};color:#000">${cat}</span></div>
       <div class="hub-card-name">${HUB_NAMES[hub]||hub}</div>
       <div class="hub-metrics">
         <div class="hub-metric"><div class="hub-metric-label">Temperature</div><div class="hub-metric-val">${m.temp}</div></div>
@@ -2741,11 +2838,17 @@ async function initWeatherTab() {
         <div class="hub-metric"><div class="hub-metric-label">Visibility</div><div class="hub-metric-val">${m.vis}</div></div>
         <div class="hub-metric"><div class="hub-metric-label">Ceiling</div><div class="hub-metric-val">${m.clouds}</div></div>
       </div>
+      ${rwyLine}
       ${faaLine}
       ${availabilityLine}
-      ${explainer?`<div class="hub-explainer">${explainer}</div>`:''}
-      ${faaExplainer?`<div class="hub-explainer">${faaExplainer}</div>`:''}
-      ${raw?`<div class="hub-raw">${escapeHtml(raw)}</div>`:''}
+      ${hasDetailContent ? `<div class="hub-card-expand" tabindex="0" role="button" aria-expanded="false" style="text-align:center;padding:4px 0;cursor:pointer;color:var(--ua-dim);font-size:10px;font-family:'JetBrains Mono',monospace;transition:color 150ms ease;outline:none" onfocus="this.style.outline='2px solid var(--ua-accent)';this.style.outlineOffset='2px'" onblur="this.style.outline='none'" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();this.click()}" onclick="const d=this.nextElementSibling;const open=d.style.display!=='none';d.style.display=open?'none':'block';this.textContent=open?'▾ Details':'▴ Details';this.setAttribute('aria-expanded',!open)">▾ Details</div>
+      <div class="hub-card-detail" style="display:none">
+        ${explainer?`<div class="hub-explainer">${explainer}</div>`:''}
+        ${faaExplainer?`<div class="hub-explainer">${faaExplainer}</div>`:''}
+        ${advisoryLinks}
+        ${notamHtml}
+        ${raw?`<div class="hub-raw">${escapeHtml(raw)}</div>`:''}
+      </div>` : ''}
     </div>`;
 
     // Update radar map marker — use ops impact color for operational awareness
@@ -2762,6 +2865,9 @@ async function initWeatherTab() {
   }
   document.getElementById('hub-cards').innerHTML = cardsHtml;
 
+  // Render NAS STATUS panel below radar map
+  renderNasPanel();
+
   // Auto-hide scroll hint once hub cards are visible
   const wxHint = document.getElementById('wx-scroll-hint');
   if (wxHint) {
@@ -2771,15 +2877,17 @@ async function initWeatherTab() {
     observer.observe(document.getElementById('hub-cards'));
   }
 
-  // Refresh weather + FAA data every 5 minutes so the tab stays current
+  // Refresh weather + FAA + NAS data every 5 minutes so the tab stays current
   setInterval(async () => {
     try {
-      const [newMetar, newFaa] = await Promise.allSettled([
+      const [newMetar, newFaa, newNas] = await Promise.allSettled([
         fetchMetarBatch(allStations),
-        fetch('/api/faa').then(r => r.ok ? r.json() : Promise.reject(new Error(`faa-${r.status}`)))
+        fetch('/api/faa').then(r => r.ok ? r.json() : Promise.reject(new Error(`faa-${r.status}`))),
+        fetch('/api/nas').then(r => r.ok ? r.json() : Promise.reject(new Error(`nas-${r.status}`)))
       ]);
       const freshMetar = newMetar.status === 'fulfilled' ? newMetar.value : [];
       const freshFaa = newFaa.status === 'fulfilled' ? newFaa.value : [];
+      if (newNas.status === 'fulfilled') { nasData = newNas.value; renderNasPanel(); }
       if (!Array.isArray(freshMetar) || freshMetar.length === 0) return;
 
       // Rebuild METAR index
@@ -2790,19 +2898,7 @@ async function initWeatherTab() {
       });
 
       // Rebuild FAA index
-      const freshFaaIndex = {};
-      if (Array.isArray(freshFaa)) freshFaa.forEach(d => {
-        const code = d.airportCode || d.airport;
-        if (!code) return;
-        if (!freshFaaIndex[code]) freshFaaIndex[code] = { delays: [] };
-        freshFaaIndex[code].delays.push(...(d.delays || []));
-        if (d.type === 'ground_stop') freshFaaIndex[code].groundStop = true;
-        else if (d.type === 'ground_delay') { freshFaaIndex[code].groundDelay = true; freshFaaIndex[code].avgDelay = d.avgDelay; }
-        else if (d.type === 'departure_delay') { freshFaaIndex[code].departureDelay = true; freshFaaIndex[code].minDelay = d.minDelay; freshFaaIndex[code].maxDelay = d.maxDelay; }
-        else if (d.type === 'arrival_delay') { freshFaaIndex[code].arrivalDelay = true; }
-        else if (d.type === 'closure') freshFaaIndex[code].closure = true;
-      });
-      faaDelayIndex = freshFaaIndex;
+      faaDelayIndex = buildFaaIndex(freshFaa);
 
       // Update weatherOpsByHub + hub card colors/statuses
       hubs.forEach(hub => {
@@ -4226,7 +4322,22 @@ function updateHubHealth() {
 
 // ═══ IROPS DASHBOARD ═══
 let faaDelayIndex = {};
+let nasData = null;       // Global NAS status (en-route programs + planned TMIs) — populated by initWeatherTab
 let weatherOpsByHub = {};  // Global METAR-derived ops impact per hub — populated by preloadWeatherAndFAA or initWeatherTab
+
+/** Build faaDelayIndex from the /api/faa response (new per-airport shape with programs[]) */
+function buildFaaIndex(faaResponse) {
+  const index = {};
+  if (!Array.isArray(faaResponse)) return index;
+  for (const airport of faaResponse) {
+    const code = airport.airportCode;
+    if (!code) continue;
+    // The new API returns per-airport objects directly — store them as-is
+    // with backward-compat fields already populated by the server
+    index[code] = airport;
+  }
+  return index;
+}
 let iropsHubData = {};    // Global IROPS cancellation/delay rates per hub — for delay risk engine
 let aircraftJourneyCache = {};  // { reg: { segments, ts } } — aircraft history cache (5min TTL)
 let connectionIndex = {};  // { flightNum: { connFlight, hub, minutes, risk } } — connection context for AI
@@ -4317,19 +4428,7 @@ async function _doPreloadWeatherAndFAA() {
 
     // Parse FAA data (covers ALL airports with active delays, not just hubs)
     if (faaResult.status === 'fulfilled' && Array.isArray(faaResult.value)) {
-      const faaIndex = {};
-      faaResult.value.forEach(d => {
-        const code = d.airportCode || d.airport;
-        if (!code) return;
-        if (!faaIndex[code]) faaIndex[code] = { delays: [] };
-        faaIndex[code].delays.push(...(d.delays || []));
-        if (d.type === 'ground_stop') faaIndex[code].groundStop = true;
-        else if (d.type === 'ground_delay') { faaIndex[code].groundDelay = true; faaIndex[code].avgDelay = d.avgDelay; }
-        else if (d.type === 'departure_delay') { faaIndex[code].departureDelay = true; faaIndex[code].minDelay = d.minDelay; faaIndex[code].maxDelay = d.maxDelay; }
-        else if (d.type === 'arrival_delay') { faaIndex[code].arrivalDelay = true; }
-        else if (d.type === 'closure') faaIndex[code].closure = true;
-      });
-      faaDelayIndex = faaIndex;
+      faaDelayIndex = buildFaaIndex(faaResult.value);
     }
 
     if (document.getElementById('tab-schedule')?.classList.contains('active') && schedAllFlights.length) {
@@ -5160,6 +5259,7 @@ function computeDelayRisk(watched, origHub, destHub, timeData, liveFlight) {
     hubProfile: HUB_RISK_PROFILES[origHub],
     originIrops: iropsHubData[origHub],
     destinationIrops: iropsHubData[destHub],
+    plannedTmis: nasData?.planned || null,
   });
 }
 
@@ -5190,6 +5290,7 @@ function computeDelayRiskForScheduleFlight(fl, hub) {
     hubProfile: HUB_RISK_PROFILES[depHub],
     originIrops: iropsHubData[depHub],
     destinationIrops: iropsHubData[arrHub],
+    plannedTmis: nasData?.planned || null,
   });
 
   return result.score === 0 ? null : result;

--- a/src/lib/delay-explain-context.js
+++ b/src/lib/delay-explain-context.js
@@ -19,44 +19,108 @@ export function formatDelayExplainFAAStatus(originIata, destIata, faaDelayIndex)
 
   airports.forEach((airport) => {
     const faa = faaDelayIndex?.[airport];
-    if (!faa || !faa.delays || !faa.delays.length) return;
+    if (!faa) return;
 
-    faa.delays.forEach((delay) => {
-      const dtype = String(delay.type || '').toLowerCase();
-      let label = 'Delay';
-      let window = '';
+    // Use programs array if available (new JSON path), fall back to legacy delays array
+    const programs = faa.programs || [];
+    const delays = faa.delays || [];
 
-      if (dtype.includes('ground stop')) {
-        label = 'Ground stop';
-      } else if (dtype.includes('ground delay') || dtype.includes('gdp')) {
-        label = 'Ground delay program';
-        if (faa.avgDelay) window = ` (avg ${faa.avgDelay}m)`;
-      } else if (dtype.includes('departure')) {
-        label = 'Departure delays';
-        if (faa.minDelay || faa.maxDelay) {
-          const low = faa.minDelay || '?';
-          const high = faa.maxDelay || faa.minDelay || '?';
-          window = ` (${low}-${high}m)`;
+    if (programs.length) {
+      // Rich path: iterate programs for detailed context
+      for (const prog of programs) {
+        const dtype = prog.type || '';
+        let label = 'Delay';
+        let window = '';
+        let extras = [];
+
+        if (dtype === 'ground_stop') {
+          label = 'Ground stop';
+          if (prog.endTime) extras.push(`until ${prog.endTime}`);
+          if (prog.probabilityOfExtension) extras.push(`ext: ${prog.probabilityOfExtension}`);
+        } else if (dtype === 'ground_delay') {
+          label = 'Ground delay program';
+          if (prog.avgDelay) window = ` (avg ${prog.avgDelay}m)`;
+          if (prog.trend) extras.push(`${trendArrow(prog.trend)} ${prog.trend.toLowerCase()}`);
+        } else if (dtype === 'departure_delay') {
+          label = 'Departure delays';
+          if (prog.minDelay || prog.maxDelay) {
+            window = ` (${prog.minDelay || '?'}-${prog.maxDelay || '?'}m)`;
+          }
+          if (prog.trend) extras.push(`${trendArrow(prog.trend)} ${prog.trend.toLowerCase()}`);
+        } else if (dtype === 'arrival_delay') {
+          label = 'Arrival delays';
+          if (prog.minDelay || prog.maxDelay) {
+            window = ` (${prog.minDelay || '?'}-${prog.maxDelay || '?'}m)`;
+          }
+          if (prog.trend) extras.push(`${trendArrow(prog.trend)} ${prog.trend.toLowerCase()}`);
+        } else if (dtype === 'closure') {
+          label = 'Airport closure';
         }
-      } else if (dtype.includes('arrival')) {
-        label = 'Arrival delays';
-        if (faa.minDelay || faa.maxDelay) {
-          const low = faa.minDelay || '?';
-          const high = faa.maxDelay || faa.minDelay || '?';
-          window = ` (${low}-${high}m)`;
-        }
-      } else if (dtype.includes('closure')) {
-        label = 'Airport closure';
-      }
 
-      const reason = String(delay.reason || '').trim();
-      const context = reason ? `${airport} ${label}${window}: ${reason}` : `${airport} ${label}${window}`;
-      if (!seen.has(context)) {
-        seen.add(context);
-        contexts.push(context);
+        const reason = String(prog.reason || '').trim();
+        let context = reason ? `${airport} ${label}${window}: ${reason}` : `${airport} ${label}${window}`;
+        if (extras.length) context += ` (${extras.join(', ')})`;
+        if (!seen.has(context)) {
+          seen.add(context);
+          contexts.push(context);
+        }
       }
-    });
+    } else if (delays.length) {
+      // Legacy path: use flat delays array (XML fallback)
+      for (const delay of delays) {
+        const dtype = String(delay.type || '').toLowerCase();
+        let label = 'Delay';
+        let window = '';
+
+        if (dtype.includes('ground stop') || dtype === 'ground_stop') {
+          label = 'Ground stop';
+        } else if (dtype.includes('ground delay') || dtype === 'ground_delay') {
+          label = 'Ground delay program';
+          if (faa.avgDelay) window = ` (avg ${faa.avgDelay}m)`;
+        } else if (dtype.includes('departure') || dtype === 'departure_delay') {
+          label = 'Departure delays';
+          if (faa.minDelay || faa.maxDelay) {
+            window = ` (${faa.minDelay || '?'}-${faa.maxDelay || '?'}m)`;
+          }
+        } else if (dtype.includes('arrival') || dtype === 'arrival_delay') {
+          label = 'Arrival delays';
+          if (faa.minDelay || faa.maxDelay) {
+            window = ` (${faa.minDelay || '?'}-${faa.maxDelay || '?'}m)`;
+          }
+        } else if (dtype.includes('closure') || dtype === 'closure') {
+          label = 'Airport closure';
+        }
+
+        const reason = String(delay.reason || '').trim();
+        const context = reason ? `${airport} ${label}${window}: ${reason}` : `${airport} ${label}${window}`;
+        if (!seen.has(context)) {
+          seen.add(context);
+          contexts.push(context);
+        }
+      }
+    }
+
+    // Runway config context (new)
+    if (faa.runwayConfig && faa.runwayConfig.arrivalRate > 0) {
+      const rc = faa.runwayConfig;
+      const ctx = `${airport} config: ${rc.arrivalRunways}/${rc.departureRunways}, rate ${rc.arrivalRate}/hr`;
+      if (!seen.has(ctx)) { seen.add(ctx); contexts.push(ctx); }
+    }
+
+    // De-icing context (new)
+    if (faa.deicing) {
+      const ctx = `De-icing active at ${airport}`;
+      if (!seen.has(ctx)) { seen.add(ctx); contexts.push(ctx); }
+    }
   });
 
   return contexts.join(' · ');
+}
+
+function trendArrow(trend) {
+  if (!trend) return '';
+  const t = String(trend).toLowerCase();
+  if (t === 'increasing') return '↑';
+  if (t === 'decreasing') return '↓';
+  return '→';
 }

--- a/src/lib/delay-risk.js
+++ b/src/lib/delay-risk.js
@@ -170,6 +170,7 @@ function collectFaaSignals(state, airportCode, faa, role) {
   if (!airportCode || !faa) return;
 
   const roleLabel = role === 'origin' ? 'at' : 'at';
+  // parseDelayNumber handles both numeric (from JSON) and string (from XML fallback) inputs
   const severityWindow = Math.max(
     parseDelayNumber(faa.avgDelay),
     parseDelayNumber(faa.minDelay),
@@ -182,6 +183,10 @@ function collectFaaSignals(state, airportCode, faa, role) {
   }
   if (faa.groundStop) {
     addPoints(state, `${role}-faa-gs`, role === 'origin' ? 30 : 20, `Ground stop ${roleLabel} ${airportCode}`);
+    // Probability of extension signal (ground stops only)
+    const ext = faa.probabilityOfExtension || (faa.programs && faa.programs.find(p => p.type === 'ground_stop')?.probabilityOfExtension);
+    if (ext === 'HIGH') addPoints(state, `${role}-faa-gs-ext`, 5, `GS extension likely at ${airportCode}`);
+    else if (ext === 'MEDIUM') addPoints(state, `${role}-faa-gs-ext`, 3, `GS extension possible at ${airportCode}`);
     return;
   }
   if (faa.groundDelay) {
@@ -205,6 +210,26 @@ function collectFaaSignals(state, airportCode, faa, role) {
     if (severityWindow >= 90) points += 3;
     const detail = severityWindow ? ` (up to ${severityWindow}m)` : '';
     addPoints(state, `${role}-faa-arr`, points, `Arrival delays ${roleLabel} ${airportCode}${detail}`);
+  }
+
+  // Arrival rate signal — reduced capacity means higher delay risk
+  const arrivalRate = faa.runwayConfig?.arrivalRate;
+  if (typeof arrivalRate === 'number' && arrivalRate > 0 && arrivalRate < 25) {
+    addPoints(state, `${role}-faa-rate`, role === 'origin' ? 4 : 2, `Reduced arrival rate at ${airportCode} (${arrivalRate}/hr)`);
+  }
+}
+
+function collectPlannedTmiSignals(state, airportCode, plannedTmis, role) {
+  if (!airportCode || !Array.isArray(plannedTmis) || !plannedTmis.length) return;
+  for (const tmi of plannedTmis) {
+    if (tmi.type !== 'terminal') continue;
+    if (!tmi.affectedAirports || !tmi.affectedAirports.includes(airportCode)) continue;
+    const event = (tmi.event || '').toUpperCase();
+    if (event.includes('GS') || event.includes('GROUND STOP')) {
+      addPoints(state, `${role}-planned-gs`, 3, `Planned ground stop at ${airportCode} (${tmi.time || 'later'})`);
+    } else if (event.includes('GDP') || event.includes('GROUND DELAY')) {
+      addPoints(state, `${role}-planned-gdp`, 2, `Planned ground delay at ${airportCode} (${tmi.time || 'later'})`);
+    }
   }
 }
 
@@ -404,6 +429,13 @@ export function computeDelayRiskModel(input) {
 
   collectIropsSignals(state, input.originHub, input.originIrops, 'origin');
   collectIropsSignals(state, input.destinationHub, input.destinationIrops, 'destination');
+
+  // Planned TMI signals (forward-looking NAS operations plan)
+  if (input.plannedTmis) {
+    collectPlannedTmiSignals(state, input.originHub, input.plannedTmis, 'origin');
+    collectPlannedTmiSignals(state, input.destinationHub, input.plannedTmis, 'destination');
+  }
+
   collectCompoundSignal(state, input);
 
   return finalize(state);

--- a/tests/delay-risk.test.js
+++ b/tests/delay-risk.test.js
@@ -93,4 +93,96 @@ describe('computeDelayRiskModel', () => {
 
     expect(result.factors).toContain('Late evening - high cascade risk');
   });
+
+  it('handles numeric avgDelay from JSON endpoint', () => {
+    const result = computeDelayRiskModel({
+      nowMs: Date.parse('2026-03-18T17:00:00Z'),
+      scheduledTime: '2026-03-18T18:00:00Z',
+      originHub: 'LGA',
+      destinationHub: 'ORD',
+      timeZone: 'America/New_York',
+      originFaa: { groundDelay: true, avgDelay: 95, maxDelay: 120 },
+    });
+
+    expect(result.score).toBeGreaterThanOrEqual(25);
+    expect(result.factors.some(f => f.includes('Ground delay program'))).toBe(true);
+    expect(result.factors.some(f => f.includes('120m'))).toBe(true);
+  });
+
+  it('handles string avgDelay from XML fallback', () => {
+    // parseDelayNumber extracts max number from string: "5 hours and 45 minutes" → 45
+    // In new API, server normalizes to numeric minutes. Old parseDelayNumber is defensive fallback.
+    const result = computeDelayRiskModel({
+      nowMs: Date.parse('2026-03-18T17:00:00Z'),
+      scheduledTime: '2026-03-18T18:00:00Z',
+      originHub: 'LGA',
+      destinationHub: 'ORD',
+      timeZone: 'America/New_York',
+      originFaa: { groundDelay: true, avgDelay: '5 hours and 45 minutes' },
+    });
+
+    expect(result.score).toBeGreaterThanOrEqual(20);
+    expect(result.factors.some(f => f.includes('Ground delay program'))).toBe(true);
+  });
+
+  it('handles null avgDelay gracefully', () => {
+    const result = computeDelayRiskModel({
+      nowMs: Date.parse('2026-03-18T17:00:00Z'),
+      scheduledTime: '2026-03-18T18:00:00Z',
+      originHub: 'LGA',
+      destinationHub: 'ORD',
+      timeZone: 'America/New_York',
+      originFaa: { groundDelay: true, avgDelay: null, maxDelay: null },
+    });
+
+    expect(result.factors.some(f => f.includes('Ground delay program'))).toBe(true);
+  });
+
+  it('adds probability-of-extension signal for ground stops', () => {
+    const result = computeDelayRiskModel({
+      nowMs: Date.parse('2026-03-18T17:00:00Z'),
+      scheduledTime: '2026-03-18T18:00:00Z',
+      originHub: 'EWR',
+      destinationHub: 'ORD',
+      timeZone: 'America/New_York',
+      originFaa: {
+        groundStop: true,
+        probabilityOfExtension: 'HIGH',
+        programs: [{ type: 'ground_stop', probabilityOfExtension: 'HIGH' }],
+      },
+    });
+
+    expect(result.factors.some(f => f.includes('GS extension likely'))).toBe(true);
+    expect(result.components.some(c => c.id === 'origin-faa-gs-ext')).toBe(true);
+  });
+
+  it('adds arrival rate signal for reduced capacity', () => {
+    const result = computeDelayRiskModel({
+      nowMs: Date.parse('2026-03-18T17:00:00Z'),
+      scheduledTime: '2026-03-18T18:00:00Z',
+      originHub: 'SFO',
+      destinationHub: 'ORD',
+      timeZone: 'America/Los_Angeles',
+      originFaa: { runwayConfig: { arrivalRunways: '28L', departureRunways: '28R', arrivalRate: 20 } },
+    });
+
+    expect(result.factors.some(f => f.includes('Reduced arrival rate'))).toBe(true);
+    expect(result.components.some(c => c.id === 'origin-faa-rate')).toBe(true);
+  });
+
+  it('adds planned TMI signals for hub airports', () => {
+    const result = computeDelayRiskModel({
+      nowMs: Date.parse('2026-03-18T17:00:00Z'),
+      scheduledTime: '2026-03-18T18:00:00Z',
+      originHub: 'EWR',
+      destinationHub: 'ORD',
+      timeZone: 'America/New_York',
+      plannedTmis: [
+        { time: 'AFTER 1800', event: 'EWR GDP POSSIBLE', type: 'terminal', affectedAirports: ['EWR'] },
+      ],
+    });
+
+    expect(result.factors.some(f => f.includes('Planned ground delay'))).toBe(true);
+    expect(result.components.some(c => c.id === 'origin-planned-gdp')).toBe(true);
+  });
 });

--- a/tests/faa.test.js
+++ b/tests/faa.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { toArray } from '../api/faa.js';
+import { toArray, parseDelayMinutes } from '../api/faa.js';
 
 describe('toArray', () => {
   it('returns empty array for undefined', () => {
@@ -34,5 +34,53 @@ describe('toArray', () => {
 
   it('wraps a number in an array', () => {
     expect(toArray(42)).toEqual([42]);
+  });
+});
+
+describe('parseDelayMinutes', () => {
+  it('returns null for null/undefined/empty', () => {
+    expect(parseDelayMinutes(null)).toBe(null);
+    expect(parseDelayMinutes(undefined)).toBe(null);
+    expect(parseDelayMinutes('')).toBe(null);
+  });
+
+  it('parses numeric values directly', () => {
+    expect(parseDelayMinutes(18)).toBe(18);
+    expect(parseDelayMinutes(18.7)).toBe(19);
+    expect(parseDelayMinutes(0)).toBe(0);
+  });
+
+  it('parses numeric strings', () => {
+    expect(parseDelayMinutes('30')).toBe(30);
+    expect(parseDelayMinutes('45')).toBe(45);
+  });
+
+  it('parses "X minutes" format (XML fallback)', () => {
+    expect(parseDelayMinutes('31 minutes')).toBe(31);
+    expect(parseDelayMinutes('45 minutes')).toBe(45);
+  });
+
+  it('parses "X hours and Y minutes" format (XML fallback)', () => {
+    expect(parseDelayMinutes('5 hours and 45 minutes')).toBe(345);
+    expect(parseDelayMinutes('1 hour and 30 minutes')).toBe(90);
+    expect(parseDelayMinutes('24 hours')).toBe(1440);
+  });
+
+  it('returns null for NaN/Infinity', () => {
+    expect(parseDelayMinutes(NaN)).toBe(null);
+    expect(parseDelayMinutes(Infinity)).toBe(null);
+  });
+
+  it('returns null for non-parseable strings', () => {
+    expect(parseDelayMinutes('hello')).toBe(null);
+    expect(parseDelayMinutes('N/A')).toBe(null);
+  });
+
+  it('handles JSON numeric avgDelay (18.0)', () => {
+    expect(parseDelayMinutes(18.0)).toBe(18);
+  });
+
+  it('handles JSON numeric maxDelay (54)', () => {
+    expect(parseDelayMinutes(54)).toBe(54);
   });
 });

--- a/tests/fixtures/faa-airport-events-minimal.json
+++ b/tests/fixtures/faa-airport-events-minimal.json
@@ -1,0 +1,51 @@
+[
+  {
+    "airportId": "EWR",
+    "groundStop": {
+      "id": "test-gs-1",
+      "airportId": "EWR",
+      "createdAt": "2026-03-28T10:00:00Z",
+      "sourceTimeStamp": "2026-03-28T10:00:00Z",
+      "updatedAt": "2026-03-28T10:00:00Z",
+      "impactingCondition": "weather",
+      "startTime": "2026-03-28T10:00:00Z",
+      "endTime": "2026-03-28T14:00:00Z",
+      "center": "ZNY",
+      "advisoryUrl": "https://www.fly.faa.gov/adv/test",
+      "probabilityOfExtension": "HIGH",
+      "includedFacilities": ["ZNY", "ZBW"],
+      "includedFlights": ""
+    },
+    "groundDelay": null,
+    "airportClosure": null,
+    "freeForm": null,
+    "arrivalDelay": null,
+    "departureDelay": null,
+    "airportConfig": null,
+    "deicing": null,
+    "airportLongName": "Newark Liberty International",
+    "latitude": "40.6895",
+    "longitude": "-74.1745"
+  },
+  {
+    "airportId": "ORD",
+    "groundStop": null,
+    "groundDelay": null,
+    "airportClosure": null,
+    "freeForm": null,
+    "arrivalDelay": null,
+    "departureDelay": null,
+    "airportConfig": {
+      "id": "test-config-1",
+      "airportId": "ORD",
+      "arrivalRunwayConfig": "10L/10C",
+      "departureRunwayConfig": "10R/10C",
+      "arrivalRate": 76,
+      "sourceTimeStamp": "2026-03-28T10:00:00Z"
+    },
+    "deicing": true,
+    "airportLongName": "O'Hare International",
+    "latitude": "41.9742",
+    "longitude": "-87.9073"
+  }
+]

--- a/tests/fixtures/faa-airport-events.json
+++ b/tests/fixtures/faa-airport-events.json
@@ -1,0 +1,414 @@
+[
+    {
+        "airportId": "LAS",
+        "groundStop": null,
+        "groundDelay": null,
+        "airportClosure": null,
+        "freeForm": {
+            "id": "f848253d-ca96-412e-bd30-9955c18e550c",
+            "airportId": "LAS",
+            "createdAt": null,
+            "updatedAt": "2026-01-27T19:26:04Z",
+            "startTime": "2026-01-27T19:12:00Z",
+            "endTime": "2026-04-29T23:00:00Z",
+            "simpleText": "!LAS 01/129 LAS AD AP CLSD TO NON SKED TRANSIENT GA ACFT EXC 24HR PPR 702-261-7775 2601271912-2604292300",
+            "text": "TO NON SKED TRANSIENT GA ACFT EXC 24HR PPR 702-261-7775",
+            "notamNumber": 129,
+            "issuedDate": "2026-01-27T19:12:00Z"
+        },
+        "arrivalDelay": null,
+        "departureDelay": null,
+        "airportConfig": {
+            "id": "e85a0875-fdc2-49a0-9fd1-07874fd9e6c2",
+            "createdAt": "2026-03-28T12:53:54Z",
+            "airportId": "LAS",
+            "arrivalRunwayConfig": "19R/26L",
+            "departureRunwayConfig": "19L/26R",
+            "arrivalRate": 56,
+            "sourceTimeStamp": "2026-03-28T12:53:53Z"
+        },
+        "deicing": null,
+        "airportLongName": "Harry Reid International",
+        "latitude": "36.0840",
+        "longitude": "-115.1537"
+    },
+    {
+        "airportId": "LGA",
+        "groundStop": null,
+        "groundDelay": {
+            "id": "c0dafb47-fdb9-44e8-8ed2-30edee765baf",
+            "createdAt": "2026-03-28T10:50:49Z",
+            "airportId": "LGA",
+            "sourceTimeStamp": "2026-03-28T10:50:07Z",
+            "updatedAt": "2026-03-28T10:50:49Z",
+            "impactingCondition": "other",
+            "avgDelay": 18.0,
+            "maxDelay": 54,
+            "startTime": "2026-03-28T13:00:00Z",
+            "endTime": "2026-03-28T22:59:00Z",
+            "center": "ZNY",
+            "advisoryUrl": "https://www.fly.faa.gov/adv/adv_otherdis.jsp?advn=38&adv_date=03282026&facId=LGA&title=ATCSCC ADVZY 038 LGA/ZNY 03/28/2026 CDM GROUND DELAY PROGRAM&titleDate=03/28/2026",
+            "departureScope": null,
+            "includedFacilities": [
+                "ZLA",
+                "ZAU",
+                "ZLC",
+                "ZTL",
+                "ZDC",
+                "ZNY",
+                "ZHU",
+                "ZJX",
+                "ZFW",
+                "ZOB",
+                "ZDV",
+                "ZOA",
+                "ZSE",
+                "ZBW",
+                "ZMA",
+                "ZKC",
+                "ZME",
+                "ZID",
+                "ZAB",
+                "ZMP",
+                "CYHZ",
+                "CYOW",
+                "CYUL",
+                "CYYZ",
+                "CYTZ",
+                "CYQB"
+            ],
+            "fuelFlowAdvisoryDelayTime": {
+                "id": "324b1883-2e21-4a15-aa26-51609e669379",
+                "controlElement": "LGA",
+                "delayProgramType": "GDP",
+                "startTime": "2026-03-28T13:00:00Z",
+                "endTime": "2026-03-28T22:59:00Z",
+                "dasDelays": {
+                    "delayTimeAmount": "2026-03-28T13:00:00.000+00:00",
+                    "dasDelay": [
+                        {
+                            "delay": 4,
+                            "seq": 1
+                        },
+                        {
+                            "delay": 18,
+                            "seq": 2
+                        },
+                        {
+                            "delay": 21,
+                            "seq": 3
+                        },
+                        {
+                            "delay": 22,
+                            "seq": 4
+                        },
+                        {
+                            "delay": 15,
+                            "seq": 5
+                        },
+                        {
+                            "delay": 14,
+                            "seq": 6
+                        },
+                        {
+                            "delay": 12,
+                            "seq": 7
+                        },
+                        {
+                            "delay": 18,
+                            "seq": 8
+                        },
+                        {
+                            "delay": 11,
+                            "seq": 9
+                        },
+                        {
+                            "delay": 16,
+                            "seq": 10
+                        },
+                        {
+                            "delay": 18,
+                            "seq": 11
+                        },
+                        {
+                            "delay": 15,
+                            "seq": 12
+                        },
+                        {
+                            "delay": 6,
+                            "seq": 13
+                        },
+                        {
+                            "delay": 0,
+                            "seq": 14
+                        },
+                        {
+                            "delay": 0,
+                            "seq": 15
+                        },
+                        {
+                            "delay": 5,
+                            "seq": 16
+                        },
+                        {
+                            "delay": 0,
+                            "seq": 17
+                        },
+                        {
+                            "delay": 4,
+                            "seq": 18
+                        },
+                        {
+                            "delay": 1,
+                            "seq": 19
+                        },
+                        {
+                            "delay": 2,
+                            "seq": 20
+                        },
+                        {
+                            "delay": 4,
+                            "seq": 21
+                        },
+                        {
+                            "delay": 9,
+                            "seq": 22
+                        },
+                        {
+                            "delay": 11,
+                            "seq": 23
+                        },
+                        {
+                            "delay": 11,
+                            "seq": 24
+                        },
+                        {
+                            "delay": 5,
+                            "seq": 25
+                        },
+                        {
+                            "delay": 17,
+                            "seq": 26
+                        },
+                        {
+                            "delay": 27,
+                            "seq": 27
+                        },
+                        {
+                            "delay": 27,
+                            "seq": 28
+                        },
+                        {
+                            "delay": 36,
+                            "seq": 29
+                        },
+                        {
+                            "delay": 37,
+                            "seq": 30
+                        },
+                        {
+                            "delay": 40,
+                            "seq": 31
+                        },
+                        {
+                            "delay": 34,
+                            "seq": 32
+                        },
+                        {
+                            "delay": 34,
+                            "seq": 33
+                        },
+                        {
+                            "delay": 36,
+                            "seq": 34
+                        },
+                        {
+                            "delay": 33,
+                            "seq": 35
+                        },
+                        {
+                            "delay": 28,
+                            "seq": 36
+                        },
+                        {
+                            "delay": 25,
+                            "seq": 37
+                        },
+                        {
+                            "delay": 18,
+                            "seq": 38
+                        },
+                        {
+                            "delay": 13,
+                            "seq": 39
+                        },
+                        {
+                            "delay": 4,
+                            "seq": 40
+                        }
+                    ]
+                },
+                "sourceTimeStamp": "2026-03-28T10:50:07Z",
+                "createdAt": "2026-03-03T21:15:49Z",
+                "updatedAt": "2026-03-28T10:51:41Z"
+            },
+            "includedFlights": ": ALL CONTIGUOUS US DEP",
+            "fadtParamType": "GDP",
+            "gsCancelReceivedTs": null,
+            "gsCancelSourceTs": null,
+            "compression": false,
+            "blanket": false
+        },
+        "airportClosure": null,
+        "freeForm": null,
+        "arrivalDelay": null,
+        "departureDelay": null,
+        "airportConfig": {
+            "id": "5761f06f-1a9e-41b0-955b-f2375760b2e6",
+            "createdAt": "2026-03-28T11:25:30Z",
+            "airportId": "LGA",
+            "arrivalRunwayConfig": "RNAV  X 31",
+            "departureRunwayConfig": "04",
+            "arrivalRate": 25,
+            "sourceTimeStamp": "2026-03-28T11:25:29Z"
+        },
+        "deicing": null,
+        "airportLongName": "La Guardia",
+        "latitude": "40.7769",
+        "longitude": "-73.8740"
+    },
+    {
+        "airportId": "RSW",
+        "groundStop": null,
+        "groundDelay": null,
+        "airportClosure": null,
+        "freeForm": null,
+        "arrivalDelay": null,
+        "departureDelay": {
+            "airportId": "RSW",
+            "reason": "VOL:Volume",
+            "arrivalDeparture": {
+                "type": "Departure",
+                "min": "31 minutes",
+                "max": "45 minutes",
+                "trend": "Increasing"
+            },
+            "updateTime": "2026-03-28T16:12:00Z",
+            "averageDelay": "30",
+            "trend": "increasing"
+        },
+        "airportConfig": {
+            "id": "073f7cfc-f033-4a81-b2e1-38a6bd38e2ac",
+            "createdAt": "2026-03-28T10:32:55Z",
+            "airportId": "RSW",
+            "arrivalRunwayConfig": "06",
+            "departureRunwayConfig": "06",
+            "arrivalRate": 25,
+            "sourceTimeStamp": "2026-03-28T10:32:54Z"
+        },
+        "deicing": null,
+        "airportLongName": "Southwest Florida International",
+        "latitude": "26.5337",
+        "longitude": "-81.7553"
+    },
+    {
+        "airportId": "SAN",
+        "groundStop": null,
+        "groundDelay": null,
+        "airportClosure": null,
+        "freeForm": {
+            "id": "f2f51852-e2ae-4954-8d47-f068cc6f752e",
+            "airportId": "SAN",
+            "createdAt": null,
+            "updatedAt": "2026-03-18T14:00:33Z",
+            "startTime": "2026-03-18T13:00:00Z",
+            "endTime": "2026-10-01T08:00:00Z",
+            "simpleText": "!SAN 03/071 SAN AD AP CLSD TO NON SKED TRANSIENT GA ACFT EXC PPR 619-298-7704 2603181300-2610010800",
+            "text": "TO NON SKED TRANSIENT GA ACFT EXC PPR 619-298-7704",
+            "notamNumber": 71,
+            "issuedDate": "2026-03-18T13:49:00Z"
+        },
+        "arrivalDelay": null,
+        "departureDelay": null,
+        "airportConfig": {
+            "id": "4a56e746-b06c-4c01-bc23-54cbe0017867",
+            "createdAt": "2026-03-28T16:37:56Z",
+            "airportId": "SAN",
+            "arrivalRunwayConfig": "27",
+            "departureRunwayConfig": "27",
+            "arrivalRate": 24,
+            "sourceTimeStamp": "2026-03-28T16:37:52Z"
+        },
+        "deicing": null,
+        "airportLongName": "San Diego-Lindbergh Field",
+        "latitude": "32.7338",
+        "longitude": "-117.1933"
+    },
+    {
+        "airportId": "SLC",
+        "groundStop": null,
+        "groundDelay": null,
+        "airportClosure": null,
+        "freeForm": null,
+        "arrivalDelay": null,
+        "departureDelay": {
+            "airportId": "SLC",
+            "reason": "RWY:Maintenance",
+            "arrivalDeparture": {
+                "type": "Departure",
+                "min": "16 minutes",
+                "max": "30 minutes",
+                "trend": "Increasing"
+            },
+            "updateTime": "2026-03-28T16:20:00Z",
+            "averageDelay": "15",
+            "trend": "increasing"
+        },
+        "airportConfig": {
+            "id": "51ff50f9-146e-49da-a9e6-7eb3aa2b67e4",
+            "createdAt": "2026-03-28T17:41:47Z",
+            "airportId": "SLC",
+            "arrivalRunwayConfig": "17",
+            "departureRunwayConfig": "16L",
+            "arrivalRate": 40,
+            "sourceTimeStamp": "2026-03-28T17:41:43Z"
+        },
+        "deicing": null,
+        "airportLongName": "Salt Lake City International",
+        "latitude": "40.7899",
+        "longitude": "-111.9791"
+    },
+    {
+        "airportId": "STX",
+        "groundStop": null,
+        "groundDelay": null,
+        "airportClosure": null,
+        "freeForm": {
+            "id": "400103a2-8069-4564-962d-47c4f5d11f04",
+            "airportId": "STX",
+            "createdAt": null,
+            "updatedAt": "2026-02-27T22:39:29Z",
+            "startTime": "2026-02-27T22:22:00Z",
+            "endTime": "2026-04-30T21:00:00Z",
+            "simpleText": "!TISX 02/050 STX AD AP CLSD TO NON SKED TRANSIENT GA ACFT EXC PPR 340-201-4645 2602272222-2604302100",
+            "text": "TO NON SKED TRANSIENT GA ACFT EXC PPR 340-201-4645",
+            "notamNumber": 50,
+            "issuedDate": "2026-02-27T22:32:00Z"
+        },
+        "arrivalDelay": null,
+        "departureDelay": null,
+        "airportConfig": {
+            "id": "bcd06cb0-42a5-468c-ae35-40f89be949d8",
+            "createdAt": "2026-03-28T10:11:29Z",
+            "airportId": "STX",
+            "arrivalRunwayConfig": "10",
+            "departureRunwayConfig": "10",
+            "arrivalRate": 18,
+            "sourceTimeStamp": "2026-03-28T10:11:28Z"
+        },
+        "deicing": null,
+        "airportLongName": "Henry E. Rohlsen International Airport",
+        "latitude": "17.699169349916396",
+        "longitude": "-64.79710263171633"
+    }
+]

--- a/tests/fixtures/faa-enroute-events.json
+++ b/tests/fixtures/faa-enroute-events.json
@@ -1,0 +1,1096 @@
+[
+    {
+        "airspaceFlowProgram": {
+            "id": "38886545-e05d-4ddb-8542-778b46fcb738",
+            "createdAt": "2026-03-28T09:35:51Z",
+            "afpName": "FCAMUN",
+            "impactingCondition": "airport volume",
+            "startTime": "2026-03-28T14:00:00Z",
+            "endTime": "2026-03-28T21:59:00Z",
+            "sourceTimeStamp": "2026-03-28T09:34:09Z",
+            "avgDelay": 99.30000305175781,
+            "lowerAltitude": "000",
+            "upperAltitude": "600",
+            "updatedAt": "2026-03-28T09:35:51Z",
+            "fuelFlowAdvisoryDelayTime": {
+                "id": "4d5b4ff9-3844-4e33-a56c-0563e9fa2fea",
+                "controlElement": "FCAMUN",
+                "delayProgramType": "AFP",
+                "startTime": "2026-03-28T14:00:00Z",
+                "endTime": "2026-03-28T21:59:00Z",
+                "dasDelays": {
+                    "delayTimeAmount": "2026-03-28T14:00:00.000+00:00",
+                    "dasDelay": [
+                        {
+                            "delay": 17,
+                            "seq": 1
+                        },
+                        {
+                            "delay": 26,
+                            "seq": 2
+                        },
+                        {
+                            "delay": 35,
+                            "seq": 3
+                        },
+                        {
+                            "delay": 45,
+                            "seq": 4
+                        },
+                        {
+                            "delay": 54,
+                            "seq": 5
+                        },
+                        {
+                            "delay": 61,
+                            "seq": 6
+                        },
+                        {
+                            "delay": 65,
+                            "seq": 7
+                        },
+                        {
+                            "delay": 69,
+                            "seq": 8
+                        },
+                        {
+                            "delay": 73,
+                            "seq": 9
+                        },
+                        {
+                            "delay": 78,
+                            "seq": 10
+                        },
+                        {
+                            "delay": 86,
+                            "seq": 11
+                        },
+                        {
+                            "delay": 93,
+                            "seq": 12
+                        },
+                        {
+                            "delay": 101,
+                            "seq": 13
+                        },
+                        {
+                            "delay": 109,
+                            "seq": 14
+                        },
+                        {
+                            "delay": 117,
+                            "seq": 15
+                        },
+                        {
+                            "delay": 123,
+                            "seq": 16
+                        },
+                        {
+                            "delay": 126,
+                            "seq": 17
+                        },
+                        {
+                            "delay": 131,
+                            "seq": 18
+                        },
+                        {
+                            "delay": 135,
+                            "seq": 19
+                        },
+                        {
+                            "delay": 134,
+                            "seq": 20
+                        },
+                        {
+                            "delay": 135,
+                            "seq": 21
+                        },
+                        {
+                            "delay": 138,
+                            "seq": 22
+                        },
+                        {
+                            "delay": 141,
+                            "seq": 23
+                        },
+                        {
+                            "delay": 141,
+                            "seq": 24
+                        },
+                        {
+                            "delay": 142,
+                            "seq": 25
+                        },
+                        {
+                            "delay": 147,
+                            "seq": 26
+                        },
+                        {
+                            "delay": 152,
+                            "seq": 27
+                        },
+                        {
+                            "delay": 152,
+                            "seq": 28
+                        },
+                        {
+                            "delay": 149,
+                            "seq": 29
+                        },
+                        {
+                            "delay": 144,
+                            "seq": 30
+                        },
+                        {
+                            "delay": 136,
+                            "seq": 31
+                        },
+                        {
+                            "delay": 129,
+                            "seq": 32
+                        }
+                    ]
+                },
+                "sourceTimeStamp": "2026-03-28T09:34:09Z",
+                "createdAt": "2026-02-15T10:12:44Z",
+                "updatedAt": "2026-03-28T09:36:01Z"
+            },
+            "fadtParamType": "AFP",
+            "compression": false
+        },
+        "arrivesNone": "",
+        "arrivesAny": "MMUN",
+        "departsNone": "",
+        "departsAny": "",
+        "isAnyConditions": false,
+        "polygon": null,
+        "circle": {
+            "ceiling": 600,
+            "floor": 0,
+            "points": {
+                "point": [
+                    {
+                        "latitude": "21.0333333",
+                        "longitude": "-86.8833333"
+                    }
+                ]
+            },
+            "center": {
+                "latitude": "21.0333333",
+                "longitude": "-86.8833333"
+            },
+            "radius": 10
+        },
+        "line": null,
+        "comments": null,
+        "advisoryUrl": "https://www.fly.faa.gov/adv/adv_otherdis.jsp?advn=30&adv_date=03282026&facId=ATCSCC&title=ATCSCC ADVZY 030 FCAMUN 03/28/2026 CDM AIRSPACE FLOW PROGRAM&titleDate=03/28/2026",
+        "fcaAirport": null,
+        "fcaArtcc": null,
+        "fcaSectorName": null,
+        "fcaBaseSector": null,
+        "fcaSuaName": null,
+        "fcaFixName": null,
+        "fcaTraconName": null,
+        "fcaBaseTracon": null,
+        "fcaHeadingDirection": null
+    },
+    {
+        "airspaceFlowProgram": {
+            "id": "5a335b5a-a89a-4381-93f6-466c098c5284",
+            "createdAt": "2026-03-28T10:56:01Z",
+            "afpName": "FCAPV2",
+            "impactingCondition": "airport volume",
+            "startTime": "2026-03-28T14:00:00Z",
+            "endTime": "2026-03-28T20:59:00Z",
+            "sourceTimeStamp": "2026-03-28T10:55:06Z",
+            "avgDelay": 35.099998474121094,
+            "lowerAltitude": "000",
+            "upperAltitude": "600",
+            "updatedAt": "2026-03-28T10:56:01Z",
+            "fuelFlowAdvisoryDelayTime": {
+                "id": "e7ef547a-3b95-4748-9994-3e20163ebb34",
+                "controlElement": "FCAPV2",
+                "delayProgramType": "AFP",
+                "startTime": "2026-03-28T14:00:00Z",
+                "endTime": "2026-03-28T20:59:00Z",
+                "dasDelays": {
+                    "delayTimeAmount": "2026-03-28T14:00:00.000+00:00",
+                    "dasDelay": [
+                        {
+                            "delay": 87,
+                            "seq": 1
+                        },
+                        {
+                            "delay": 84,
+                            "seq": 2
+                        },
+                        {
+                            "delay": 72,
+                            "seq": 3
+                        },
+                        {
+                            "delay": 60,
+                            "seq": 4
+                        },
+                        {
+                            "delay": 52,
+                            "seq": 5
+                        },
+                        {
+                            "delay": 46,
+                            "seq": 6
+                        },
+                        {
+                            "delay": 42,
+                            "seq": 7
+                        },
+                        {
+                            "delay": 40,
+                            "seq": 8
+                        },
+                        {
+                            "delay": 38,
+                            "seq": 9
+                        },
+                        {
+                            "delay": 37,
+                            "seq": 10
+                        },
+                        {
+                            "delay": 34,
+                            "seq": 11
+                        },
+                        {
+                            "delay": 32,
+                            "seq": 12
+                        },
+                        {
+                            "delay": 31,
+                            "seq": 13
+                        },
+                        {
+                            "delay": 30,
+                            "seq": 14
+                        },
+                        {
+                            "delay": 30,
+                            "seq": 15
+                        },
+                        {
+                            "delay": 30,
+                            "seq": 16
+                        },
+                        {
+                            "delay": 30,
+                            "seq": 17
+                        },
+                        {
+                            "delay": 29,
+                            "seq": 18
+                        },
+                        {
+                            "delay": 28,
+                            "seq": 19
+                        },
+                        {
+                            "delay": 25,
+                            "seq": 20
+                        },
+                        {
+                            "delay": 22,
+                            "seq": 21
+                        },
+                        {
+                            "delay": 17,
+                            "seq": 22
+                        },
+                        {
+                            "delay": 13,
+                            "seq": 23
+                        },
+                        {
+                            "delay": 11,
+                            "seq": 24
+                        },
+                        {
+                            "delay": 9,
+                            "seq": 25
+                        },
+                        {
+                            "delay": 6,
+                            "seq": 26
+                        },
+                        {
+                            "delay": 6,
+                            "seq": 27
+                        },
+                        {
+                            "delay": 7,
+                            "seq": 28
+                        }
+                    ]
+                },
+                "sourceTimeStamp": "2026-03-28T10:55:06Z",
+                "createdAt": "2026-03-28T10:56:09Z",
+                "updatedAt": "2026-03-28T10:56:09Z"
+            },
+            "fadtParamType": "AFP",
+            "compression": false
+        },
+        "arrivesNone": "",
+        "arrivesAny": "MBPV",
+        "departsNone": "",
+        "departsAny": "",
+        "isAnyConditions": false,
+        "polygon": null,
+        "circle": {
+            "ceiling": 600,
+            "floor": 0,
+            "points": {
+                "point": [
+                    {
+                        "latitude": "21.7666667",
+                        "longitude": "-72.2666667"
+                    }
+                ]
+            },
+            "center": {
+                "latitude": "21.7666667",
+                "longitude": "-72.2666667"
+            },
+            "radius": 7
+        },
+        "line": null,
+        "comments": null,
+        "advisoryUrl": "https://www.fly.faa.gov/adv/adv_otherdis.jsp?advn=40&adv_date=03282026&facId=ATCSCC&title=ATCSCC ADVZY 040 FCAPV2 03/28/2026 CDM AIRSPACE FLOW PROGRAM&titleDate=03/28/2026",
+        "fcaAirport": null,
+        "fcaArtcc": null,
+        "fcaSectorName": null,
+        "fcaBaseSector": null,
+        "fcaSuaName": null,
+        "fcaFixName": null,
+        "fcaTraconName": null,
+        "fcaBaseTracon": null,
+        "fcaHeadingDirection": null
+    },
+    {
+        "airspaceFlowProgram": {
+            "id": "8dae13a0-3ae4-46cc-ad7e-e28b40b2310a",
+            "createdAt": "2026-03-28T10:57:34Z",
+            "afpName": "FCAPV3",
+            "impactingCondition": "airport volume",
+            "startTime": "2026-03-28T14:00:00Z",
+            "endTime": "2026-03-28T20:59:00Z",
+            "sourceTimeStamp": "2026-03-28T10:56:38Z",
+            "avgDelay": 224.10000610351562,
+            "lowerAltitude": "000",
+            "upperAltitude": "600",
+            "updatedAt": "2026-03-28T10:57:34Z",
+            "fuelFlowAdvisoryDelayTime": {
+                "id": "c5f87362-8bb8-45b5-863e-8e9b7cc4fa6b",
+                "controlElement": "FCAPV3",
+                "delayProgramType": "AFP",
+                "startTime": "2026-03-28T14:00:00Z",
+                "endTime": "2026-03-28T20:59:00Z",
+                "dasDelays": {
+                    "delayTimeAmount": "2026-03-28T14:00:00.000+00:00",
+                    "dasDelay": [
+                        {
+                            "delay": 316,
+                            "seq": 1
+                        },
+                        {
+                            "delay": 317,
+                            "seq": 2
+                        },
+                        {
+                            "delay": 320,
+                            "seq": 3
+                        },
+                        {
+                            "delay": 323,
+                            "seq": 4
+                        },
+                        {
+                            "delay": 326,
+                            "seq": 5
+                        },
+                        {
+                            "delay": 327,
+                            "seq": 6
+                        },
+                        {
+                            "delay": 324,
+                            "seq": 7
+                        },
+                        {
+                            "delay": 316,
+                            "seq": 8
+                        },
+                        {
+                            "delay": 306,
+                            "seq": 9
+                        },
+                        {
+                            "delay": 295,
+                            "seq": 10
+                        },
+                        {
+                            "delay": 281,
+                            "seq": 11
+                        },
+                        {
+                            "delay": 268,
+                            "seq": 12
+                        },
+                        {
+                            "delay": 254,
+                            "seq": 13
+                        },
+                        {
+                            "delay": 242,
+                            "seq": 14
+                        },
+                        {
+                            "delay": 229,
+                            "seq": 15
+                        },
+                        {
+                            "delay": 217,
+                            "seq": 16
+                        },
+                        {
+                            "delay": 205,
+                            "seq": 17
+                        },
+                        {
+                            "delay": 194,
+                            "seq": 18
+                        },
+                        {
+                            "delay": 183,
+                            "seq": 19
+                        },
+                        {
+                            "delay": 172,
+                            "seq": 20
+                        },
+                        {
+                            "delay": 161,
+                            "seq": 21
+                        },
+                        {
+                            "delay": 152,
+                            "seq": 22
+                        },
+                        {
+                            "delay": 147,
+                            "seq": 23
+                        },
+                        {
+                            "delay": 147,
+                            "seq": 24
+                        },
+                        {
+                            "delay": 146,
+                            "seq": 25
+                        },
+                        {
+                            "delay": 146,
+                            "seq": 26
+                        },
+                        {
+                            "delay": 145,
+                            "seq": 27
+                        },
+                        {
+                            "delay": 145,
+                            "seq": 28
+                        }
+                    ]
+                },
+                "sourceTimeStamp": "2026-03-28T10:56:38Z",
+                "createdAt": "2026-03-28T10:57:55Z",
+                "updatedAt": "2026-03-28T10:57:55Z"
+            },
+            "fadtParamType": "AFP",
+            "compression": false
+        },
+        "arrivesNone": "",
+        "arrivesAny": "MBPV",
+        "departsNone": "",
+        "departsAny": "",
+        "isAnyConditions": false,
+        "polygon": null,
+        "circle": {
+            "ceiling": 600,
+            "floor": 0,
+            "points": {
+                "point": [
+                    {
+                        "latitude": "21.7666667",
+                        "longitude": "-72.2666667"
+                    }
+                ]
+            },
+            "center": {
+                "latitude": "21.7666667",
+                "longitude": "-72.2666667"
+            },
+            "radius": 7
+        },
+        "line": null,
+        "comments": null,
+        "advisoryUrl": "https://www.fly.faa.gov/adv/adv_otherdis.jsp?advn=41&adv_date=03282026&facId=ATCSCC&title=ATCSCC ADVZY 041 FCAPV3 03/28/2026 CDM AIRSPACE FLOW PROGRAM&titleDate=03/28/2026",
+        "fcaAirport": null,
+        "fcaArtcc": null,
+        "fcaSectorName": null,
+        "fcaBaseSector": null,
+        "fcaSuaName": null,
+        "fcaFixName": null,
+        "fcaTraconName": null,
+        "fcaBaseTracon": null,
+        "fcaHeadingDirection": null
+    },
+    {
+        "airspaceFlowProgram": {
+            "id": "c3f8aa6e-2a73-4280-ac82-6473f711fcec",
+            "createdAt": "2026-03-28T13:07:34Z",
+            "afpName": "FCASD1",
+            "impactingCondition": "airport volume",
+            "startTime": "2026-03-28T17:00:00Z",
+            "endTime": "2026-03-28T21:59:00Z",
+            "sourceTimeStamp": "2026-03-28T13:07:05Z",
+            "avgDelay": 20.299999237060547,
+            "lowerAltitude": "000",
+            "upperAltitude": "600",
+            "updatedAt": "2026-03-28T13:07:34Z",
+            "fuelFlowAdvisoryDelayTime": {
+                "id": "0da5bf09-d7eb-4930-802b-139666db1160",
+                "controlElement": "FCASD1",
+                "delayProgramType": "AFP",
+                "startTime": "2026-03-28T17:00:00Z",
+                "endTime": "2026-03-28T21:59:00Z",
+                "dasDelays": {
+                    "delayTimeAmount": "2026-03-28T17:00:00.000+00:00",
+                    "dasDelay": [
+                        {
+                            "delay": 12,
+                            "seq": 1
+                        },
+                        {
+                            "delay": 9,
+                            "seq": 2
+                        },
+                        {
+                            "delay": 12,
+                            "seq": 3
+                        },
+                        {
+                            "delay": 17,
+                            "seq": 4
+                        },
+                        {
+                            "delay": 22,
+                            "seq": 5
+                        },
+                        {
+                            "delay": 21,
+                            "seq": 6
+                        },
+                        {
+                            "delay": 16,
+                            "seq": 7
+                        },
+                        {
+                            "delay": 19,
+                            "seq": 8
+                        },
+                        {
+                            "delay": 26,
+                            "seq": 9
+                        },
+                        {
+                            "delay": 33,
+                            "seq": 10
+                        },
+                        {
+                            "delay": 34,
+                            "seq": 11
+                        },
+                        {
+                            "delay": 34,
+                            "seq": 12
+                        },
+                        {
+                            "delay": 24,
+                            "seq": 13
+                        },
+                        {
+                            "delay": 27,
+                            "seq": 14
+                        },
+                        {
+                            "delay": 24,
+                            "seq": 15
+                        },
+                        {
+                            "delay": 18,
+                            "seq": 16
+                        },
+                        {
+                            "delay": 15,
+                            "seq": 17
+                        },
+                        {
+                            "delay": 9,
+                            "seq": 18
+                        },
+                        {
+                            "delay": 10,
+                            "seq": 19
+                        },
+                        {
+                            "delay": 12,
+                            "seq": 20
+                        }
+                    ]
+                },
+                "sourceTimeStamp": "2026-03-28T13:07:05Z",
+                "createdAt": "2026-03-28T13:07:56Z",
+                "updatedAt": "2026-03-28T13:07:57Z"
+            },
+            "fadtParamType": "AFP",
+            "compression": false
+        },
+        "arrivesNone": "",
+        "arrivesAny": "MMSD",
+        "departsNone": "",
+        "departsAny": "",
+        "isAnyConditions": false,
+        "polygon": null,
+        "circle": {
+            "ceiling": 600,
+            "floor": 0,
+            "points": {
+                "point": [
+                    {
+                        "latitude": "23.15",
+                        "longitude": "-109.7166667"
+                    }
+                ]
+            },
+            "center": {
+                "latitude": "23.15",
+                "longitude": "-109.7166667"
+            },
+            "radius": 25
+        },
+        "line": null,
+        "comments": null,
+        "advisoryUrl": "https://www.fly.faa.gov/adv/adv_otherdis.jsp?advn=56&adv_date=03282026&facId=ATCSCC&title=ATCSCC ADVZY 056 FCASD1 03/28/2026 CDM AIRSPACE FLOW PROGRAM&titleDate=03/28/2026",
+        "fcaAirport": null,
+        "fcaArtcc": null,
+        "fcaSectorName": null,
+        "fcaBaseSector": null,
+        "fcaSuaName": null,
+        "fcaFixName": null,
+        "fcaTraconName": null,
+        "fcaBaseTracon": null,
+        "fcaHeadingDirection": null
+    },
+    {
+        "airspaceFlowProgram": {
+            "id": "de85416e-6b4c-41fb-bddd-cc592f251a85",
+            "createdAt": "2026-03-28T10:59:38Z",
+            "afpName": "FCAMA5",
+            "impactingCondition": "airspace volume",
+            "startTime": "2026-03-28T15:30:00Z",
+            "endTime": "2026-03-28T23:59:00Z",
+            "sourceTimeStamp": "2026-03-28T10:59:01Z",
+            "avgDelay": 121.9000015258789,
+            "lowerAltitude": "000",
+            "upperAltitude": "600",
+            "updatedAt": "2026-03-28T10:59:38Z",
+            "fuelFlowAdvisoryDelayTime": {
+                "id": "3836de51-d082-423d-995f-572e7d5de9ec",
+                "controlElement": "FCAMA5",
+                "delayProgramType": "AFP",
+                "startTime": "2026-03-28T15:30:00Z",
+                "endTime": "2026-03-28T23:59:00Z",
+                "dasDelays": {
+                    "delayTimeAmount": "2026-03-28T15:30:00.000+00:00",
+                    "dasDelay": [
+                        {
+                            "delay": 77,
+                            "seq": 1
+                        },
+                        {
+                            "delay": 83,
+                            "seq": 2
+                        },
+                        {
+                            "delay": 90,
+                            "seq": 3
+                        },
+                        {
+                            "delay": 99,
+                            "seq": 4
+                        },
+                        {
+                            "delay": 108,
+                            "seq": 5
+                        },
+                        {
+                            "delay": 117,
+                            "seq": 6
+                        },
+                        {
+                            "delay": 126,
+                            "seq": 7
+                        },
+                        {
+                            "delay": 135,
+                            "seq": 8
+                        },
+                        {
+                            "delay": 144,
+                            "seq": 9
+                        },
+                        {
+                            "delay": 154,
+                            "seq": 10
+                        },
+                        {
+                            "delay": 164,
+                            "seq": 11
+                        },
+                        {
+                            "delay": 174,
+                            "seq": 12
+                        },
+                        {
+                            "delay": 183,
+                            "seq": 13
+                        },
+                        {
+                            "delay": 191,
+                            "seq": 14
+                        },
+                        {
+                            "delay": 197,
+                            "seq": 15
+                        },
+                        {
+                            "delay": 200,
+                            "seq": 16
+                        },
+                        {
+                            "delay": 201,
+                            "seq": 17
+                        },
+                        {
+                            "delay": 198,
+                            "seq": 18
+                        },
+                        {
+                            "delay": 193,
+                            "seq": 19
+                        },
+                        {
+                            "delay": 185,
+                            "seq": 20
+                        },
+                        {
+                            "delay": 175,
+                            "seq": 21
+                        },
+                        {
+                            "delay": 162,
+                            "seq": 22
+                        },
+                        {
+                            "delay": 147,
+                            "seq": 23
+                        },
+                        {
+                            "delay": 132,
+                            "seq": 24
+                        },
+                        {
+                            "delay": 117,
+                            "seq": 25
+                        },
+                        {
+                            "delay": 102,
+                            "seq": 26
+                        },
+                        {
+                            "delay": 89,
+                            "seq": 27
+                        },
+                        {
+                            "delay": 78,
+                            "seq": 28
+                        },
+                        {
+                            "delay": 67,
+                            "seq": 29
+                        },
+                        {
+                            "delay": 57,
+                            "seq": 30
+                        },
+                        {
+                            "delay": 49,
+                            "seq": 31
+                        },
+                        {
+                            "delay": 43,
+                            "seq": 32
+                        },
+                        {
+                            "delay": 38,
+                            "seq": 33
+                        },
+                        {
+                            "delay": 33,
+                            "seq": 34
+                        }
+                    ]
+                },
+                "sourceTimeStamp": "2026-03-28T10:59:01Z",
+                "createdAt": "2026-02-21T11:52:54Z",
+                "updatedAt": "2026-03-28T10:59:55Z"
+            },
+            "fadtParamType": "AFP",
+            "compression": false
+        },
+        "arrivesNone": "MBPV",
+        "arrivesAny": "",
+        "departsNone": "",
+        "departsAny": "",
+        "isAnyConditions": false,
+        "polygon": null,
+        "circle": null,
+        "line": {
+            "ceiling": 600,
+            "floor": 0,
+            "points": {
+                "point": [
+                    {
+                        "latitude": "19.93",
+                        "longitude": "-73.42"
+                    },
+                    {
+                        "latitude": "25.0",
+                        "longitude": "-70.88"
+                    },
+                    {
+                        "latitude": "25.0",
+                        "longitude": "-68.5"
+                    }
+                ]
+            },
+            "direction": 0,
+            "speed": 0,
+            "drawing": "TRUE"
+        },
+        "comments": null,
+        "advisoryUrl": "https://www.fly.faa.gov/adv/adv_otherdis.jsp?advn=42&adv_date=03282026&facId=ATCSCC&title=ATCSCC ADVZY 042 FCAMA5 03/28/2026 CDM AIRSPACE FLOW PROGRAM&titleDate=03/28/2026",
+        "fcaAirport": null,
+        "fcaArtcc": null,
+        "fcaSectorName": null,
+        "fcaBaseSector": null,
+        "fcaSuaName": null,
+        "fcaFixName": null,
+        "fcaTraconName": null,
+        "fcaBaseTracon": null,
+        "fcaHeadingDirection": "southeast"
+    },
+    {
+        "airspaceFlowProgram": {
+            "id": "e59fe237-1494-47be-8e4c-f2960b2ae909",
+            "createdAt": "2026-03-28T12:13:04Z",
+            "afpName": "FCAJX1",
+            "impactingCondition": "airspace volume",
+            "startTime": "2026-03-28T14:00:00Z",
+            "endTime": "2026-03-28T20:59:00Z",
+            "sourceTimeStamp": "2026-03-28T12:11:58Z",
+            "avgDelay": 22.100000381469727,
+            "lowerAltitude": "180",
+            "upperAltitude": "600",
+            "updatedAt": "2026-03-28T12:13:12Z",
+            "fuelFlowAdvisoryDelayTime": {
+                "id": "c35851f7-052b-426d-9c24-9a1e908c37b3",
+                "controlElement": "FCAJX1",
+                "delayProgramType": "AFP",
+                "startTime": "2026-03-28T14:00:00Z",
+                "endTime": "2026-03-28T20:59:00Z",
+                "dasDelays": {
+                    "delayTimeAmount": "2026-03-28T14:00:00.000+00:00",
+                    "dasDelay": [
+                        {
+                            "delay": 12,
+                            "seq": 1
+                        },
+                        {
+                            "delay": 20,
+                            "seq": 2
+                        },
+                        {
+                            "delay": 22,
+                            "seq": 3
+                        },
+                        {
+                            "delay": 21,
+                            "seq": 4
+                        },
+                        {
+                            "delay": 22,
+                            "seq": 5
+                        },
+                        {
+                            "delay": 19,
+                            "seq": 6
+                        },
+                        {
+                            "delay": 13,
+                            "seq": 7
+                        },
+                        {
+                            "delay": 22,
+                            "seq": 8
+                        },
+                        {
+                            "delay": 31,
+                            "seq": 9
+                        },
+                        {
+                            "delay": 36,
+                            "seq": 10
+                        },
+                        {
+                            "delay": 39,
+                            "seq": 11
+                        },
+                        {
+                            "delay": 37,
+                            "seq": 12
+                        },
+                        {
+                            "delay": 40,
+                            "seq": 13
+                        },
+                        {
+                            "delay": 38,
+                            "seq": 14
+                        },
+                        {
+                            "delay": 32,
+                            "seq": 15
+                        },
+                        {
+                            "delay": 30,
+                            "seq": 16
+                        },
+                        {
+                            "delay": 27,
+                            "seq": 17
+                        },
+                        {
+                            "delay": 29,
+                            "seq": 18
+                        },
+                        {
+                            "delay": 21,
+                            "seq": 19
+                        },
+                        {
+                            "delay": 23,
+                            "seq": 20
+                        },
+                        {
+                            "delay": 21,
+                            "seq": 21
+                        },
+                        {
+                            "delay": 12,
+                            "seq": 22
+                        },
+                        {
+                            "delay": 11,
+                            "seq": 23
+                        },
+                        {
+                            "delay": 10,
+                            "seq": 24
+                        },
+                        {
+                            "delay": 3,
+                            "seq": 25
+                        },
+                        {
+                            "delay": 2,
+                            "seq": 26
+                        },
+                        {
+                            "delay": 3,
+                            "seq": 27
+                        },
+                        {
+                            "delay": 2,
+                            "seq": 28
+                        }
+                    ]
+                },
+                "sourceTimeStamp": "2026-03-28T12:11:58Z",
+                "createdAt": "2026-02-27T20:57:32Z",
+                "updatedAt": "2026-03-28T12:13:16Z"
+            },
+            "fadtParamType": "AFP",
+            "compression": false
+        },
+        "arrivesNone": "",
+        "arrivesAny": "",
+        "departsNone": "",
+        "departsAny": "",
+        "isAnyConditions": false,
+        "polygon": null,
+        "circle": null,
+        "line": {
+            "ceiling": 600,
+            "floor": 180,
+            "points": {
+                "point": [
+                    {
+                        "latitude": "30.55",
+                        "longitude": "-79.68"
+                    },
+                    {
+                        "latitude": "29.97",
+                        "longitude": "-82.02"
+                    },
+                    {
+                        "latitude": "28.52",
+                        "longitude": "-83.9"
+                    }
+                ]
+            },
+            "direction": 0,
+            "speed": 0,
+            "drawing": "TRUE"
+        },
+        "comments": null,
+        "advisoryUrl": "https://www.fly.faa.gov/adv/adv_otherdis.jsp?advn=53&adv_date=03282026&facId=ATCSCC&title=ATCSCC ADVZY 053 FCAJX1 03/28/2026 CDM AIRSPACE FLOW PROGRAM&titleDate=03/28/2026",
+        "fcaAirport": null,
+        "fcaArtcc": null,
+        "fcaSectorName": null,
+        "fcaBaseSector": null,
+        "fcaSuaName": null,
+        "fcaFixName": null,
+        "fcaTraconName": null,
+        "fcaBaseTracon": null,
+        "fcaHeadingDirection": "southbound"
+    }
+]

--- a/tests/fixtures/faa-operations-plan.json
+++ b/tests/fixtures/faa-operations-plan.json
@@ -1,0 +1,10 @@
+{
+    "link": "https://www.fly.faa.gov/adv/adv_otherdis.jsp?advn=75&adv_date=03282026&facId=ATCSCC&title=ATCSCC ADVZY 075 DCC 03/28/2026 OPERATIONS PLAN&titleDate=03/28/2026",
+    "terminalPlanned": [],
+    "enRoutePlanned": [
+        {
+            "time": "AFTER 1800",
+            "event": "-SOUTH FLORIDA CDRS/SWAP POSSIBLE"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Upgrades the FAA data integration from the legacy XML feed to the FAA's rich JSON API (`/api/airport-events`), the same endpoint their own dashboard uses. Also adds a new `/api/nas` endpoint that fetches en-route flow programs and the NAS operations plan.

**What users see:**
- Hub weather cards now show runway configurations, arrival rates, de-icing badges, delay trends, and extension probability for ground stops
- 2-tier disclosure on hub cards: scan tier for glanceable status, click to expand for full program details, advisories, NOTAMs
- NAS STATUS panel below the radar map shows active en-route programs and planned TMIs with decoded FAA shorthand and plain-English ARTCC names
- Link to full ATCSCC advisory when available

**What the delay risk model gets:**
- Numeric delay values (no more string parsing from XML)
- Probability-of-extension signal for ground stops (+3/+5pts)
- Arrival rate signal for capacity constraints (+4pts when <25/hr)
- Planned TMI signal for GDP/GS forecasts (+2/+3pts)

**What the AI delay explainer gets:**
- Runway config, trends, extension probability, de-icing status in context

**Architecture:**
- JSON primary with XML fallback (schema validation, exponential backoff)
- Per-airport response shape with `programs[]` array (fixes field clobbering from old flat shape)
- `buildFaaIndex()` extracted from 3 duplicated blocks in main.js
- 4 real FAA response fixtures committed for schema drift detection

## Pre-Landing Review
Codex review: PASS (0 P1, 3 P2 — all 3 fixed: planned TMIs wired, legacy delays enriched, minDelay preserved).
Autoplan: CEO + Design + Eng reviews all cleared.
Design review: 7 findings, 4 fixed (hardcoded hex → CSS vars, badge specs, a11y on expand toggle).

## Test Coverage
Tests: 31 pass across 3 files (+19 new test cases)
- `parseDelayMinutes`: numeric, string, null, edge cases
- Delay risk: numeric/string avgDelay, extension probability, arrival rate, planned TMIs
- Existing tests: all pass unchanged

## Test plan
- [x] All tests pass (31/31, 0 failures)
- [x] Build succeeds (38 pages)
- [ ] Visual: weather tab shows runway config in scan tier
- [ ] Visual: NAS STATUS panel renders when en-route programs active
- [ ] Fallback: break JSON URL → XML fallback activates with numeric delays

🤖 Generated with [Claude Code](https://claude.com/claude-code)