### PR TITLE
fix: NAS status panel hidden in weather tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2026-03-28
+
+### Fixed
+- **NAS Status panel now visible** in the weather tab. The panel was rendered but hidden inside the radar map container (`overflow:hidden` clipping). Moved to the scrollable detail panel between IROPS bar and hub cards.
+- NAS panel styling moved from inline styles to proper CSS classes using design system variables (`--font-mono`, `--font-display`, `--ua-amber`). Padding matches DESIGN.md highlight box spec.
+- Added mobile responsive margin for NAS panel (10px to match hub card padding on small screens).
+- Fixed CSS cascade bug where desktop `#nas-status-panel` margin rule overrode the mobile media query override (caught by Codex review).
+
 ## [Unreleased] - 2026-03-26
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "packageManager": "bun@1.3.11",
   "scripts": {
     "dev": "bun scripts/run-astro-dev.mjs",

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -678,6 +678,14 @@ tbody td{padding:5px 8px;white-space:nowrap}
 .irops-score.med{background:rgba(245,158,11,.15);color:#f59e0b}
 .irops-score.high{background:rgba(239,68,68,.15);color:#ef4444}
 .irops-empty{text-align:center;padding:12px;color:var(--ua-muted);font-size:10px}
+/* NAS Status Panel — highlight box in detail panel */
+#nas-status-panel{background:var(--ua-panel);border-left:3px solid var(--ua-amber);border-radius:0 6px 6px 0;padding:12px 16px;margin:0 14px;flex-shrink:0;font-size:12px}
+#nas-status-panel .nas-label{font-family:var(--font-mono);font-size:10px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;color:var(--ua-amber);margin-bottom:8px}
+#nas-status-panel .nas-section-title{font-family:var(--font-display);font-size:11px;font-weight:600;color:var(--ua-text);margin-bottom:4px}
+#nas-status-panel .nas-item{font-family:var(--font-mono);font-size:10px;color:var(--ua-muted);margin-bottom:3px}
+#nas-status-panel .nas-item.hub-affected{color:var(--ua-text);font-weight:500}
+#nas-status-panel .nas-advisory{margin-top:6px}
+#nas-status-panel .nas-advisory a{font-size:9px;color:var(--ua-amber);text-decoration:underline}
 .hub-cards{position:relative}
 .hub-cards::after{content:'';position:sticky;bottom:0;left:0;right:0;height:24px;background:linear-gradient(to bottom,transparent,var(--bg-body));pointer-events:none;display:block}
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -385,6 +385,14 @@ tbody td{padding:5px 8px;white-space:nowrap}
 .hub-faa.normal{color:var(--ua-green)}.hub-faa.delay{color:var(--ua-red)}
 .hub-explainer{padding:6px 14px;font-size:10px;line-height:1.5;color:var(--ua-muted)}
 .hub-raw{padding:6px 14px 10px;font-size:9px;color:var(--ua-accent);opacity:.7;word-break:break-all;font-family:var(--mono)}
+/* NAS Status Panel — highlight box in detail panel */
+#nas-status-panel{background:var(--ua-panel);border-left:3px solid var(--ua-amber);border-radius:0 6px 6px 0;padding:12px 16px;margin:0 14px;flex-shrink:0;font-size:12px}
+#nas-status-panel .nas-label{font-family:var(--font-mono);font-size:10px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;color:var(--ua-amber);margin-bottom:8px}
+#nas-status-panel .nas-section-title{font-family:var(--font-display);font-size:11px;font-weight:600;color:var(--ua-text);margin-bottom:4px}
+#nas-status-panel .nas-item{font-family:var(--font-mono);font-size:10px;color:var(--ua-muted);margin-bottom:3px}
+#nas-status-panel .nas-item.hub-affected{color:var(--ua-text);font-weight:500}
+#nas-status-panel .nas-advisory{margin-top:6px}
+#nas-status-panel .nas-advisory a{font-size:9px;color:var(--ua-amber);text-decoration:underline}
 
 /* ═══ TAB 4: ANALYTICS ═══ */
 #tab-analytics{padding:16px;flex:1;min-height:0;overflow-y:auto}
@@ -679,14 +687,6 @@ tbody td{padding:5px 8px;white-space:nowrap}
 .irops-score.med{background:rgba(245,158,11,.15);color:#f59e0b}
 .irops-score.high{background:rgba(239,68,68,.15);color:#ef4444}
 .irops-empty{text-align:center;padding:12px;color:var(--ua-muted);font-size:10px}
-/* NAS Status Panel — highlight box in detail panel */
-#nas-status-panel{background:var(--ua-panel);border-left:3px solid var(--ua-amber);border-radius:0 6px 6px 0;padding:12px 16px;margin:0 14px;flex-shrink:0;font-size:12px}
-#nas-status-panel .nas-label{font-family:var(--font-mono);font-size:10px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;color:var(--ua-amber);margin-bottom:8px}
-#nas-status-panel .nas-section-title{font-family:var(--font-display);font-size:11px;font-weight:600;color:var(--ua-text);margin-bottom:4px}
-#nas-status-panel .nas-item{font-family:var(--font-mono);font-size:10px;color:var(--ua-muted);margin-bottom:3px}
-#nas-status-panel .nas-item.hub-affected{color:var(--ua-text);font-weight:500}
-#nas-status-panel .nas-advisory{margin-top:6px}
-#nas-status-panel .nas-advisory a{font-size:9px;color:var(--ua-amber);text-decoration:underline}
 .hub-cards{position:relative}
 .hub-cards::after{content:'';position:sticky;bottom:0;left:0;right:0;height:24px;background:linear-gradient(to bottom,transparent,var(--bg-body));pointer-events:none;display:block}
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -527,6 +527,7 @@ tbody td{padding:5px 8px;white-space:nowrap}
   #radar-map{height:260px}
   .wx-detail-panel{flex:1;border-left:none;border-top:1px solid var(--ua-border)}
   .hub-cards{padding:10px}
+  #nas-status-panel{margin:0 10px}
   .irops-bar{flex-wrap:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;padding:4px 10px;gap:0}
   .irops-bar::-webkit-scrollbar{display:none}
   .irops-bar-sep{display:none}

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -2624,7 +2624,6 @@ function renderNasPanel() {
   if (!panelEl) {
     panelEl = document.createElement('div');
     panelEl.id = 'nas-status-panel';
-    panelEl.style.cssText = 'background:var(--ua-panel);border-left:3px solid var(--ua-amber);border-radius:0 6px 6px 0;padding:10px 14px;margin:0 14px;flex-shrink:0';
     const scrollHint = document.getElementById('wx-scroll-hint');
     if (scrollHint && scrollHint.parentNode) {
       scrollHint.parentNode.insertBefore(panelEl, scrollHint);
@@ -2635,29 +2634,29 @@ function renderNasPanel() {
   }
 
   panelEl.style.display = 'block';
-  let html = `<div style="font-family:'JetBrains Mono',monospace;font-size:10px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;color:var(--ua-amber);margin-bottom:8px">NAS STATUS</div>`;
+  // All content values are pre-sanitized via escapeHtml before insertion
+  let html = `<div class="nas-label">NAS STATUS</div>`;
 
   // Active en-route programs
   if (nasData.active && nasData.active.length) {
-    html += `<div style="font-family:Satoshi,sans-serif;font-size:11px;font-weight:600;color:var(--ua-text);margin-bottom:4px">Active</div>`;
+    html += `<div class="nas-section-title">Active</div>`;
     for (const prog of nasData.active) {
-      html += `<div style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--ua-muted);margin-bottom:3px">${escapeHtml(prog.name)} — ${escapeHtml(prog.reason)}${prog.avgDelay ? ` (avg ${prog.avgDelay}m)` : ''}</div>`;
+      html += `<div class="nas-item">${escapeHtml(prog.name)} — ${escapeHtml(prog.reason)}${prog.avgDelay ? ` (avg ${escapeHtml(String(prog.avgDelay))}m)` : ''}</div>`;
     }
   }
 
   // Planned TMIs
   if (nasData.planned && nasData.planned.length) {
-    html += `<div style="font-family:Satoshi,sans-serif;font-size:11px;font-weight:600;color:var(--ua-text);margin-top:8px;margin-bottom:4px">Planned</div>`;
+    html += `<div class="nas-section-title" style="margin-top:8px">Planned</div>`;
     for (const tmi of nasData.planned) {
       const isHub = tmi.affectedAirports && tmi.affectedAirports.some(a => UA_HUBS.has(a));
-      const highlight = isHub ? 'color:var(--ua-text);font-weight:500' : 'color:var(--ua-muted)';
-      html += `<div style="font-family:'JetBrains Mono',monospace;font-size:10px;${highlight};margin-bottom:3px">${escapeHtml(tmi.time || '')} — ${escapeHtml(tmi.decoded || tmi.event)}</div>`;
+      html += `<div class="nas-item${isHub ? ' hub-affected' : ''}">${escapeHtml(tmi.time || '')} — ${escapeHtml(tmi.decoded || tmi.event)}</div>`;
     }
   }
 
   // Advisory link
   if (nasData.advisoryUrl) {
-    html += `<div style="margin-top:6px"><a href="${escapeHtml(nasData.advisoryUrl)}" target="_blank" rel="noopener noreferrer" style="font-size:9px;color:var(--ua-amber);text-decoration:underline">View full ATCSCC advisory →</a></div>`;
+    html += `<div class="nas-advisory"><a href="${escapeHtml(nasData.advisoryUrl)}" target="_blank" rel="noopener noreferrer">View full ATCSCC advisory →</a></div>`;
   }
 
   panelEl.innerHTML = html;

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -2619,14 +2619,15 @@ function renderNasPanel() {
     return;
   }
 
-  // Create panel if it doesn't exist — insert after radar map
+  // Create panel if it doesn't exist — insert into the detail panel (right side)
+  // between the IROPS section and the hub-cards scroll hint
   if (!panelEl) {
     panelEl = document.createElement('div');
     panelEl.id = 'nas-status-panel';
-    panelEl.style.cssText = 'background:var(--ua-panel);border-left:3px solid var(--ua-amber);border-radius:0 6px 6px 0;padding:10px 14px;margin-top:12px';
-    const radarMap = document.getElementById('radar-map');
-    if (radarMap && radarMap.parentNode) {
-      radarMap.parentNode.insertBefore(panelEl, radarMap.nextSibling);
+    panelEl.style.cssText = 'background:var(--ua-panel);border-left:3px solid var(--ua-amber);border-radius:0 6px 6px 0;padding:10px 14px;margin:0 14px;flex-shrink:0';
+    const scrollHint = document.getElementById('wx-scroll-hint');
+    if (scrollHint && scrollHint.parentNode) {
+      scrollHint.parentNode.insertBefore(panelEl, scrollHint);
     } else {
       const hubCards = document.getElementById('hub-cards');
       if (hubCards) hubCards.parentNode.insertBefore(panelEl, hubCards);


### PR DESCRIPTION
## Summary

The NAS Status panel in the weather tab was being rendered but was invisible to users. The panel was inserted inside `.wx-hero` (the radar map container), which is clipped by `#tab-weather`'s `overflow:hidden`. Despite having live data (active en-route programs, planned TMIs, ATCSCC advisory link), users could never see it.

**Fixes:**
- **Moved NAS panel** from `.wx-hero` (hidden) to `.wx-detail-panel` (scrollable right panel), inserted between IROPS bar and hub cards
- **Replaced inline styles** with proper CSS classes using design system variables (`--font-mono`, `--font-display`, `--ua-amber`), padding matched to DESIGN.md highlight box spec
- **Added mobile responsive margin** (10px to match hub card padding)
- **Fixed CSS cascade bug** where desktop rule overrode mobile media query (Codex review catch)

## Test Coverage

No new application code paths. The `renderNasPanel()` function retains the same control flow, just a different DOM insertion target and CSS classes instead of inline styles.

## Pre-Landing Review

No issues found. CSS-only changes + DOM insertion point fix.

## Test plan
- [x] All Vitest tests pass (322 tests, 23 files)
- [x] Codex review: PASS (1 P3 finding, fixed)
- [x] NAS panel DOM verified on production site (exists, has content, was clipped)
- [x] Insertion point elements (`#wx-scroll-hint`, `#hub-cards`) verified present

🤖 Generated with [Claude Code](https://claude.com/claude-code)