### PR TITLE
fix(vercel): redirect www homepage to apex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.5] - 2026-04-16
+
+### Fixed
+- `www.theblueboard.co/` (homepage) now redirects to apex `theblueboard.co/`. The existing `/:path*` rule in `vercel.json` doesn't match the empty root segment, so the homepage on `www` was serving 200 directly and duplicating the canonical URL. All non-root paths (`/fleet`, `/hubs/*`, `/news/*`) were already redirecting correctly. Adds an explicit `/` redirect alongside the catch-all. Caught by the 2026-04-17 canary run.
+
 ## [1.5.4] - 2026-04-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "packageManager": "bun@1.3.11",
   "scripts": {
     "dev": "bun scripts/run-astro-dev.mjs",

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,14 @@
   "cleanUrls": true,
     "redirects": [
         {
+            "source": "/",
+            "has": [
+                { "type": "host", "value": "www.theblueboard.co" }
+            ],
+            "destination": "https://theblueboard.co/",
+            "permanent": true
+        },
+        {
             "source": "/:path*",
             "has": [
                 { "type": "host", "value": "www.theblueboard.co" }


### PR DESCRIPTION
## Summary

- Fixes `www.theblueboard.co/` serving 200 directly instead of 308 redirecting to apex `theblueboard.co/`.
- Root cause: Vercel's `/:path*` pattern doesn't match an empty root segment. All deeper paths (`/fleet`, `/hubs/*`, `/news/*`) redirect correctly — only `/` was broken.
- One-line config fix: adds an explicit `/` rule before the catch-all in `vercel.json`.
- Bumps version to 1.5.5 and logs the fix in CHANGELOG.

## Why it matters

- **SEO**: www and apex were serving identical content under different canonical URLs.
- **CORS**: CSP `access-control-allow-origin` is scoped to `https://theblueboard.co` for `/api/*`. Any user landing on www who triggered an API-backed feature would hit a CORS error.

Caught by the 2026-04-17 canary run — every other page on the site was green, stable hashes across 10 iterations, p95 under 250ms.

## Test plan

- [ ] After Vercel deploy: `curl -sSI https://www.theblueboard.co/` returns `308` (not `200`).
- [ ] `curl -sSI https://www.theblueboard.co/fleet` still returns `308` (regression check).
- [ ] `curl -sSI https://theblueboard.co/` still returns `200` (apex unchanged).
- [ ] Browse to `https://www.theblueboard.co/` in a fresh tab — lands on apex.

## Note on CI tests

Existing `bun run test` has 24 pre-existing vitest transform failures (`Tsconfig not found` from bunx-fetched vitest) unrelated to this config change. Verified by stashing the fix and re-running — identical failure set. 183 actual test assertions pass, 0 assertion failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)