### PR TITLE
v1.5.8 fix(api): harden Starlink endpoints and migrate to documented /api/check-flight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.8] - 2026-05-03
+
+### Fixed
+- Starlink badges no longer waste 10s of function time per request when the upstream is unreachable. `api/predict-flight.ts` now keeps a 60s negative cache: the first connect failure poisons the in-memory flag, and every subsequent call inside that window returns 502 immediately without re-attempting the dead host. Upstream timeout tightened from 10s to 4s. The flag clears on the first successful response, so recovery is automatic.
+- ICAO callsigns like `UAL123` now normalize to `UA123` before being forwarded upstream. Previous logic treated `UAL123` as already prefixed and sent it through unchanged, which the upstream rejects. Same fix applied to both `api/predict-flight.ts` and the new `api/check-flight.ts`.
+- Dashboard Starlink-badge fetcher now uses local-date formatting (`toLocaleDateString('en-CA')`) instead of UTC. Users west of UTC after roughly 5 PM local were silently sending tomorrow's date and getting no matches every evening.
+- Dashboard prediction cache is now keyed on `flight|date`, so leaving the tab open across midnight or revisiting a recurring flight number on consecutive days no longer reuses yesterday's result.
+
+### Added
+- `api/check-flight.ts` — a new proxy targeting upstream's documented `/api/check-flight` endpoint (the contract the upstream maintainer has committed to keeping stable). Server-side adapter maps `{hasStarlink, confidence: "verified"|"likely"}` to a probability score so existing badge UI renders without changes. Same defenses as predict-flight: origin gate, per-IP rate limit (20/min), 4s timeout, 30-min positive cache, 60s negative cache.
+- Dashboard now calls `/api/check-flight` instead of `/api/predict-flight`. Predict-flight stays in place (with the new defenses) for any external consumers; the dashboard migration moves us off an undocumented upstream endpoint.
+- `tests/check-flight.test.js` — 14 tests covering the proxy: 405/400 paths, upstream connection failure, status forwarding, the three adapter cases (verified/likely/no-match), UAL prefix normalization, User-Agent header, both negative-cache behaviors (in-window short-circuit and post-window probe).
+- `tests/predict-flight.test.js` — 3 new tests: UAL prefix normalization, in-window negative-cache short-circuit, and post-window upstream probe via `vi.useFakeTimers`.
+
 ## [1.5.7] - 2026-05-03
 
 ### Fixed

--- a/TODOS.md
+++ b/TODOS.md
@@ -11,7 +11,7 @@
 - [ ] Migrate inline event handlers (`onclick`, `onkeydown`, `onload`) at `public/index.html:75`, `src/dashboard/main.js:2956/3704/3717` to delegated `data-action` attributes.
 - [ ] Tighten CSP: drop `style-src 'unsafe-inline'` after inline-style audit.
 - [ ] Cost alerting: Anthropic + FR24 spend anomaly detection via Vercel log drain.
-- [ ] Circuit breakers / graceful degradation for FR24, Anthropic, Resend, Supabase.
+- [ ] Circuit breakers / graceful degradation for FR24, Anthropic, Resend, Supabase. (partial: 60s negative cache + 4s timeout shipped for `api/predict-flight.ts` and `api/check-flight.ts` in v1.5.8)
 - [ ] Feature kill-switches for non-core (waitlist, news-notify, delay-explain) via env flags.
 
 ### Security hygiene (backlog)

--- a/api/check-flight.ts
+++ b/api/check-flight.ts
@@ -1,0 +1,148 @@
+// Proxy endpoint for Starlink flight status (documented upstream contract).
+// Wraps unitedstarlinktracker.com/api/check-flight and adapts the
+// {hasStarlink, confidence, flights} shape into a probability-bearing payload
+// so the existing dashboard render code keeps working.
+
+import type { VercelRequest, VercelResponse } from './types.js';
+import { createRateLimiter } from './_rate-limit.js';
+
+const UPSTREAM_URL = 'https://unitedstarlinktracker.com/api/check-flight';
+const isRateLimited = createRateLimiter('check-flight', 20);
+
+const cache = new Map<string, { data: AdaptedResponse; ts: number }>();
+const CACHE_TTL = 30 * 60 * 1000;
+
+const NEGATIVE_TTL = 60 * 1000;
+let upstreamUnhealthyUntil = 0;
+
+export function _resetCacheForTest(): void {
+  cache.clear();
+  upstreamUnhealthyUntil = 0;
+}
+
+interface UpstreamFlight {
+  tail_number?: string;
+  aircraft_type?: string;
+  flight_number?: string;
+  ua_flight_number?: string;
+  departure_airport?: string;
+  arrival_airport?: string;
+  departure_time?: number;
+  arrival_time?: number;
+  departure_time_formatted?: string;
+  arrival_time_formatted?: string;
+  operated_by?: string | null;
+  fleet_type?: string | null;
+}
+
+interface UpstreamResponse {
+  hasStarlink: boolean;
+  confidence?: 'verified' | 'likely';
+  flights?: UpstreamFlight[];
+  message?: string;
+}
+
+interface AdaptedResponse {
+  hasStarlink: boolean;
+  probability: number;
+  confidence: 'verified' | 'likely' | 'none';
+  n_observations: number;
+  flights: UpstreamFlight[];
+}
+
+// Maps upstream's discrete {hasStarlink, confidence} into a 0..1 score the
+// existing badge UI can render. Verified matches read as 95%, likely as 70%,
+// no-match as 0% (the dashboard hides the badge below 5%).
+function adapt(u: UpstreamResponse): AdaptedResponse {
+  const hasStarlink = !!u.hasStarlink;
+  const confidence = u.confidence ?? (hasStarlink ? 'likely' : 'none');
+  const probability = !hasStarlink ? 0 : confidence === 'verified' ? 0.95 : 0.7;
+  return {
+    hasStarlink,
+    probability,
+    confidence,
+    n_observations: u.flights?.length ?? 0,
+    flights: u.flights ?? [],
+  };
+}
+
+function isValidDate(s: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(s);
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const origin = req.headers.origin as string | undefined;
+  if (origin && origin !== 'https://theblueboard.co' && !/^http:\/\/localhost(:\d+)?$/.test(origin)) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  res.setHeader('Access-Control-Allow-Origin', origin || 'https://theblueboard.co');
+
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const flightNumber = (req.query.flight_number as string || '').trim();
+  if (!flightNumber) {
+    return res.status(400).json({ error: 'Missing flight_number parameter' });
+  }
+  const date = (req.query.date as string || '').trim();
+  if (!date || !isValidDate(date)) {
+    return res.status(400).json({ error: 'Missing or invalid date parameter (YYYY-MM-DD)' });
+  }
+
+  // Strip ICAO 'UAL' prefix first, then ensure 'UA'. Without the strip-first
+  // order, 'UAL123' would pass the startsWith('UA') check unchanged.
+  const stripped = flightNumber.toUpperCase().replace(/^UAL/, '');
+  const normalized = stripped.startsWith('UA') ? stripped : 'UA' + stripped;
+  const cacheKey = `${normalized}|${date}`;
+
+  try {
+    if (isRateLimited(req)) {
+      return res.status(429).json({ error: 'Too many requests' });
+    }
+
+    const cached = cache.get(cacheKey);
+    if (cached && Date.now() - cached.ts < CACHE_TTL) {
+      res.setHeader('Cache-Control', 'public, s-maxage=1800, stale-while-revalidate=300');
+      return res.status(200).json(cached.data);
+    }
+
+    if (Date.now() < upstreamUnhealthyUntil) {
+      return res.status(502).json({ error: 'Check-flight service unavailable' });
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 4000);
+
+    const url = `${UPSTREAM_URL}?flight_number=${encodeURIComponent(normalized)}&date=${encodeURIComponent(date)}`;
+    const resp = await fetch(url, {
+      signal: controller.signal,
+      headers: { 'User-Agent': 'BlueBoard-CheckFlight/1.0' },
+    });
+    clearTimeout(timeout);
+
+    if (!resp.ok) {
+      return res.status(resp.status).json({ error: `Upstream returned ${resp.status}` });
+    }
+
+    const upstream = await resp.json() as UpstreamResponse;
+    const adapted = adapt(upstream);
+
+    upstreamUnhealthyUntil = 0;
+    cache.set(cacheKey, { data: adapted, ts: Date.now() });
+
+    if (cache.size > 500) {
+      const now = Date.now();
+      for (const [k, v] of cache) {
+        if (now - v.ts > CACHE_TTL) cache.delete(k);
+      }
+    }
+
+    res.setHeader('Cache-Control', 'public, s-maxage=1800, stale-while-revalidate=300');
+    return res.status(200).json(adapted);
+  } catch (err: any) {
+    upstreamUnhealthyUntil = Date.now() + NEGATIVE_TTL;
+    console.error('Check-flight error:', err);
+    return res.status(502).json({ error: 'Check-flight service unavailable' });
+  }
+}

--- a/api/predict-flight.ts
+++ b/api/predict-flight.ts
@@ -11,6 +11,18 @@ const isRateLimited = createRateLimiter('predict-flight', 20);
 const cache = new Map<string, { data: any; ts: number }>();
 const CACHE_TTL = 30 * 60 * 1000; // 30 minutes
 
+// Negative cache: when upstream connection fails, short-circuit subsequent
+// requests for NEGATIVE_TTL ms so we don't burn function-seconds re-attempting
+// a known-dead host. Cleared on the first successful upstream response.
+const NEGATIVE_TTL = 60 * 1000; // 60 seconds
+let upstreamUnhealthyUntil = 0;
+
+// Test-only: reset module-level state. Imported by tests/predict-flight.test.js.
+export function _resetCacheForTest(): void {
+  cache.clear();
+  upstreamUnhealthyUntil = 0;
+}
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const origin = req.headers.origin as string | undefined;
   if (origin && origin !== 'https://theblueboard.co' && !/^http:\/\/localhost(:\d+)?$/.test(origin)) {
@@ -27,10 +39,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(400).json({ error: 'Missing flight_number parameter' });
   }
 
-  // Normalize: ensure UA prefix
-  const normalized = flightNumber.toUpperCase().startsWith('UA')
-    ? flightNumber.toUpperCase()
-    : 'UA' + flightNumber.replace(/^UAL/i, '');
+  // Normalize: strip ICAO 'UAL' prefix first, then ensure 'UA'.
+  // Without the strip-first order, 'UAL123' would pass startsWith('UA') and
+  // be sent as-is, which the upstream rejects.
+  const stripped = flightNumber.toUpperCase().replace(/^UAL/, '');
+  const normalized = stripped.startsWith('UA') ? stripped : 'UA' + stripped;
 
   try {
     // Rate limit every request — including cache hits. An attacker sending 500+
@@ -47,8 +60,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return res.status(200).json(cached.data);
     }
 
+    // Short-circuit while upstream is known-unhealthy: don't re-attempt a dead
+    // host, just fail fast. Surfaces as the same 502 the catch block produces.
+    if (Date.now() < upstreamUnhealthyUntil) {
+      return res.status(502).json({ error: 'Prediction service unavailable' });
+    }
+
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 10000);
+    const timeout = setTimeout(() => controller.abort(), 4000);
 
     const resp = await fetch(`${UPSTREAM_URL}?flight_number=${encodeURIComponent(normalized)}`, {
       signal: controller.signal,
@@ -62,7 +81,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     const data = await resp.json();
 
-    // Cache it
+    upstreamUnhealthyUntil = 0;
     cache.set(normalized, { data, ts: Date.now() });
 
     // Evict old entries periodically
@@ -76,6 +95,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     res.setHeader('Cache-Control', 'public, s-maxage=1800, stale-while-revalidate=300');
     return res.status(200).json(data);
   } catch (err: any) {
+    upstreamUnhealthyUntil = Date.now() + NEGATIVE_TTL;
     console.error('Predict-flight error:', err);
     return res.status(502).json({ error: 'Prediction service unavailable' });
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "packageManager": "bun@1.3.11",
   "scripts": {
     "dev": "bun scripts/run-astro-dev.mjs",

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -1474,25 +1474,29 @@ function splitAtAntimeridian(pts) {
 const starlinkPredictionCache = new Map();
 
 function fetchStarlinkPredictions() {
+  // en-CA emits YYYY-MM-DD in the user's local timezone, which matches the
+  // operational date of the displayed flights. Plain toISOString() is UTC and
+  // would query tomorrow's date for west-of-UTC users after local afternoon.
+  const today = new Date().toLocaleDateString('en-CA');
   document.querySelectorAll('.starlink-predict').forEach(el => {
     const flight = el.getAttribute('data-flight');
     if (!flight || flight === 'N/A') { el.style.display = 'none'; return; }
 
-    // Check cache first
-    const cached = starlinkPredictionCache.get(flight);
+    const cacheKey = flight + '|' + today;
+    const cached = starlinkPredictionCache.get(cacheKey);
     if (cached) {
       applyStarlinkPrediction(el, cached);
       return;
     }
 
-    fetch('/api/predict-flight?flight_number=' + encodeURIComponent(flight))
+    fetch('/api/check-flight?flight_number=' + encodeURIComponent(flight) + '&date=' + today)
       .then(r => r.ok ? r.json() : null)
       .then(data => {
         if (!data || data.probability === undefined) {
           el.style.display = 'none';
           return;
         }
-        starlinkPredictionCache.set(flight, data);
+        starlinkPredictionCache.set(cacheKey, data);
         applyStarlinkPrediction(el, data);
       })
       .catch(() => { el.style.display = 'none'; });

--- a/tests/check-flight.test.js
+++ b/tests/check-flight.test.js
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import handler, { _resetCacheForTest } from '../api/check-flight.js';
+
+function createRes() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: null,
+    setHeader(name, value) { this.headers[name] = value; },
+    status(code) { this.statusCode = code; return this; },
+    json(payload) { this.body = payload; return this; },
+  };
+}
+
+function makeReq(overrides = {}) {
+  return {
+    method: 'GET',
+    headers: {},
+    query: {},
+    ...overrides,
+  };
+}
+
+describe('check-flight API', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    _resetCacheForTest();
+  });
+
+  it('rejects non-GET requests', async () => {
+    const res = createRes();
+    await handler(makeReq({ method: 'POST', query: { flight_number: 'UA100', date: '2026-05-03' } }), res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it('returns 400 when flight_number is missing', async () => {
+    const res = createRes();
+    await handler(makeReq({ query: { date: '2026-05-03' } }), res);
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toMatch(/flight_number/);
+  });
+
+  it('returns 400 when date is missing', async () => {
+    const res = createRes();
+    await handler(makeReq({ query: { flight_number: 'UA100' } }), res);
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toMatch(/date/);
+  });
+
+  it('returns 400 when date is malformed', async () => {
+    const res = createRes();
+    await handler(makeReq({ query: { flight_number: 'UA100', date: '05/03/2026' } }), res);
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toMatch(/date/);
+  });
+
+  it('returns 502 on upstream connection failure', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+    const res = createRes();
+    await handler(makeReq({ query: { flight_number: 'UA100', date: '2026-05-03' } }), res);
+    expect(res.statusCode).toBe(502);
+  });
+
+  it('forwards upstream non-2xx status', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 404 });
+    const res = createRes();
+    await handler(makeReq({ query: { flight_number: 'UA999', date: '2026-05-03' } }), res);
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('adapts a verified Starlink match to high probability', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        hasStarlink: true,
+        confidence: 'verified',
+        flights: [
+          { tail_number: 'N127SY', flight_number: 'UA100', departure_airport: 'ORD', arrival_airport: 'LAX' },
+        ],
+      }),
+    });
+    const res = createRes();
+    await handler(makeReq({ query: { flight_number: 'UA100', date: '2026-05-03' } }), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.hasStarlink).toBe(true);
+    expect(res.body.probability).toBeCloseTo(0.95, 2);
+    expect(res.body.confidence).toBe('verified');
+    expect(res.body.n_observations).toBe(1);
+  });
+
+  it('adapts a likely Starlink match to a moderate probability', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        hasStarlink: true,
+        confidence: 'likely',
+        flights: [{ tail_number: 'N127SY' }, { tail_number: 'N128SY' }],
+      }),
+    });
+    const res = createRes();
+    await handler(makeReq({ query: { flight_number: 'UA200', date: '2026-05-03' } }), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.probability).toBeCloseTo(0.7, 2);
+    expect(res.body.confidence).toBe('likely');
+    expect(res.body.n_observations).toBe(2);
+  });
+
+  it('adapts a no-match response to zero probability', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ hasStarlink: false, message: 'no match', flights: [] }),
+    });
+    const res = createRes();
+    await handler(makeReq({ query: { flight_number: 'UA300', date: '2026-05-03' } }), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.hasStarlink).toBe(false);
+    expect(res.body.probability).toBe(0);
+    expect(res.body.confidence).toBe('none');
+    expect(res.body.n_observations).toBe(0);
+  });
+
+  it('strips ICAO UAL prefix before forwarding to upstream', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ hasStarlink: false, flights: [] }),
+    });
+    const res = createRes();
+    await handler(makeReq({ query: { flight_number: 'UAL123', date: '2026-05-03' } }), res);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('flight_number=UA123'),
+      expect.any(Object)
+    );
+    expect(fetchSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('flight_number=UAL'),
+      expect.any(Object)
+    );
+  });
+
+  it('passes flight_number and date to upstream with UA prefix normalization', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ hasStarlink: false, flights: [] }),
+    });
+    const res = createRes();
+    await handler(makeReq({ query: { flight_number: '1234', date: '2026-05-03' } }), res);
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/flight_number=UA1234/),
+      expect.any(Object)
+    );
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/date=2026-05-03/),
+      expect.any(Object)
+    );
+  });
+
+  it('short-circuits to 502 inside the negative-cache window', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+
+    await handler(makeReq({ query: { flight_number: 'UA400', date: '2026-05-03' } }), createRes());
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    const res2 = createRes();
+    await handler(makeReq({ query: { flight_number: 'UA401', date: '2026-05-03' } }), res2);
+    expect(res2.statusCode).toBe(502);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('probes upstream again after the negative-cache window expires', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch')
+        .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+        .mockResolvedValue({
+          ok: true,
+          json: async () => ({ hasStarlink: true, confidence: 'verified', flights: [{ tail_number: 'N1' }] }),
+        });
+
+      await handler(makeReq({ query: { flight_number: 'UA500', date: '2026-05-03' } }), createRes());
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(61 * 1000);
+
+      const resOk = createRes();
+      await handler(makeReq({ query: { flight_number: 'UA501', date: '2026-05-03' } }), resOk);
+      expect(resOk.statusCode).toBe(200);
+      expect(resOk.body.probability).toBeCloseTo(0.95, 2);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('sends correct User-Agent header to upstream', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ hasStarlink: false, flights: [] }),
+    });
+    const res = createRes();
+    await handler(makeReq({ query: { flight_number: 'UA600', date: '2026-05-03' } }), res);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: { 'User-Agent': 'BlueBoard-CheckFlight/1.0' },
+      })
+    );
+  });
+});

--- a/tests/predict-flight.test.js
+++ b/tests/predict-flight.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import handler from '../api/predict-flight.js';
+import handler, { _resetCacheForTest } from '../api/predict-flight.js';
 
 function createRes() {
   return {
@@ -24,6 +24,7 @@ function makeReq(overrides = {}) {
 describe('predict-flight API', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    _resetCacheForTest();
   });
 
   it('rejects non-GET requests', async () => {
@@ -84,6 +85,25 @@ describe('predict-flight API', () => {
     );
   });
 
+  it('strips ICAO UAL prefix and sends UA-prefixed callsign upstream', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ flightNumber: 'UA123' }),
+    });
+
+    const res = createRes();
+    await handler(makeReq({ query: { flight_number: 'UAL123' } }), res);
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('flight_number=UA123'),
+      expect.any(Object)
+    );
+    expect(fetchSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('flight_number=UAL'),
+      expect.any(Object)
+    );
+  });
+
   it('uppercases existing UA prefix', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: true,
@@ -127,5 +147,53 @@ describe('predict-flight API', () => {
         headers: { 'User-Agent': 'BlueBoard-PredictFlight/1.0' },
       })
     );
+  });
+
+  it('short-circuits to 502 without re-fetching after upstream connection failure', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+
+    // First call: upstream errors, sets unhealthy flag
+    const res1 = createRes();
+    await handler(makeReq({ query: { flight_number: 'UA400' } }), res1);
+    expect(res1.statusCode).toBe(502);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Second call (different flight, same module state): must short-circuit
+    // without hitting the network again
+    const res2 = createRes();
+    await handler(makeReq({ query: { flight_number: 'UA401' } }), res2);
+    expect(res2.statusCode).toBe(502);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('probes upstream again once the negative-cache window expires', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch')
+        .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+        .mockResolvedValue({
+          ok: true,
+          json: async () => ({ flight_number: 'UA502', probability: 0.8 }),
+        });
+
+      // Failure poisons the negative cache
+      await handler(makeReq({ query: { flight_number: 'UA500' } }), createRes());
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      // Inside the 60s window: short-circuit to 502, no upstream call
+      const resInside = createRes();
+      await handler(makeReq({ query: { flight_number: 'UA501' } }), resInside);
+      expect(resInside.statusCode).toBe(502);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      // After 61s: window expired, next call probes upstream (which now succeeds)
+      vi.advanceTimersByTime(61 * 1000);
+      const resOk = createRes();
+      await handler(makeReq({ query: { flight_number: 'UA502' } }), resOk);
+      expect(resOk.statusCode).toBe(200);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -26,6 +26,7 @@
         "api/cron/sync-starlink.ts": { "maxDuration": 30 },
         "api/starlink-data.ts": { "maxDuration": 20 },
         "api/predict-flight.ts": { "maxDuration": 15 },
+        "api/check-flight.ts": { "maxDuration": 15 },
         "api/news-notify.ts": { "maxDuration": 15 },
         "api/tsa.ts": { "maxDuration": 30 },
         "api/cron/refresh-tsa.ts": { "maxDuration": 30 }


### PR DESCRIPTION
## Summary

**Triggered by Vercel low-sev alert**: `/api/predict-flight` was returning 502s after the upstream `unitedstarlinktracker.com` host went unreachable on 2026-05-02 18:00 UTC. A single Clouvider scraper IP was hammering us at ~6 req/min, under our 20/min rate limit, and each call was burning the full 10s upstream timeout. Real users see no Starlink badges; rest of the dashboard is unaffected.

**Diagnosis** (see `/investigate` thread for full trace):
- Upstream host fully down, not just our endpoint (verified independently with curl: HTTP 000 / no TCP connect on `/`, `/api/check-flight`, `/api/predict-flight`, `/api/data`).
- Upstream's recent commits (memory-leak + Bun upgrade on 2026-05-03 00:55 UTC) didn't touch routes — that deploy happened 7 hours after the outage started.
- We were calling `/api/predict-flight`, which is registered upstream but **undocumented**. Their public contract per `martinamps/ua-starlink-tracker/CLAUDE.md` is only `/api/check-flight`. If they ever drop predict-flight, we get silent breakage.

**Two tracks**:

**Hardening** (`api/predict-flight.ts`):
- 60s negative cache: first connect failure flips an in-memory unhealthy flag; subsequent calls in-window return 502 immediately without re-attempting the dead host. Flag clears on first successful response.
- Upstream timeout: 10s → 4s.
- UAL→UA normalization fix (preexisting bug): `UAL123` was passing through unchanged because it starts with `UA`. Now strips `^UAL` first.

**Migration** (new `api/check-flight.ts` + dashboard):
- New proxy targeting upstream's documented `/api/check-flight`. Server-side adapter maps `{hasStarlink, confidence: "verified"|"likely"}` → a probability score, so existing badge UI renders without changes.
- Same defenses as predict-flight (origin gate, 20/min rate limit, 4s timeout, 30-min positive cache, 60s negative cache).
- Dashboard at `src/dashboard/main.js:1488` switched to `/api/check-flight` with a date param.
- Date now formatted via `toLocaleDateString('en-CA')` instead of `toISOString()`. Previous code silently sent tomorrow's UTC date for any user west of UTC after roughly 5 PM local — every evening, every west-coast user, no badges.
- Dashboard cache key now includes date so cross-midnight viewers don't get yesterday's result.
- `predict-flight.ts` stays in place (with the new defenses) for any external consumers — only the dashboard migrates.

## Test Coverage

41 test files, **571 tests passing**. Two new test files / additions for this PR:

- `tests/check-flight.test.js` (new, 14 tests) — 405/400 paths, upstream connection failure, status forwarding, the three adapter cases (verified/likely/no-match), UAL prefix normalization, User-Agent header, in-window negative-cache short-circuit, post-window upstream probe via `vi.useFakeTimers`.
- `tests/predict-flight.test.js` (3 new) — UAL prefix normalization, in-window short-circuit, post-window probe.

```
predict-flight API
  ✓ rejects non-GET requests
  ✓ returns 400 when flight_number is missing
  ✓ returns 400 when flight_number is empty string
  ✓ returns 502 on upstream failure
  ✓ forwards upstream error status codes
  ✓ normalizes flight numbers with UA prefix
  ✓ strips ICAO UAL prefix and sends UA-prefixed callsign upstream  ← new
  ✓ uppercases existing UA prefix
  ✓ sets cache control headers on success
  ✓ sends correct User-Agent header to upstream
  ✓ short-circuits to 502 without re-fetching after upstream connection failure  ← new
  ✓ probes upstream again once the negative-cache window expires  ← new

check-flight API (14 tests)
  ✓ all paths green
```

## Pre-Landing Review

**Codex review (gpt-5.5, reasoning: high)** — ran twice during this session.

First pass found 3 P2 findings (all fixed in the same branch before push):
1. **UTC vs local date** — `toISOString()` returns UTC; PDT users after 5 PM local would silently miss every evening. Fixed via `toLocaleDateString('en-CA')`.
2. **Cache key missing date** — `starlinkPredictionCache` was keyed on `flight` only despite request now being date-dependent. Now `flight|date`.
3. **UAL→UA normalization unreachable branch** — `'UAL123'.startsWith('UA')` is `true`, so the strip path never executed. Fixed in both routes.

Second pass (post-fix, fresh session): **GATE: PASS**, no findings.

> "The changed endpoint, dashboard wiring, tests, and Vercel config do not show a clear correctness issue introduced by this patch. I did not find any discrete bug that meets the review bar."

## TODOS

`TODOS.md` line 14 (`Circuit breakers / graceful degradation for FR24, Anthropic, Resend, Supabase`) annotated as partially complete — the negative-cache + 4s-timeout pattern shipped here covers `unitedstarlinktracker` for both Starlink endpoints. FR24/Anthropic/Resend/Supabase still need the same treatment.

## Test plan
- [x] All Vitest tests pass (571 tests)
- [x] Codex review (gpt-5.5, high): GATE PASS
- [ ] Smoke test in Vercel preview: dashboard loads, Starlink badges render correctly when upstream returns to health
- [ ] Verify 502 storm subsides on production once merged (Vercel anomaly should auto-resolve once the negative cache reduces upstream attempts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)