### PR TITLE
Protect schedule fallback credits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.9] - 2026-05-16
+
+### Fixed
+- Schedule outages no longer burn FR24 official API credits from background warming. The cron warmer now requests schedule data with official fallback disabled, so a public FR24 scrape outage cannot silently drain paid credits across every hub and day window.
+- Empty partial schedule responses now cache briefly and report as degraded. Users still see the upstream outage state, but Vercel no longer keeps 0% schedule payloads around like healthy data, and cron no longer counts partial empty schedules as successfully warmed.
+- Official FR24 fallback now stops immediately on exhausted credits or invalid summary windows instead of retrying. The schedule fallback is opt-in via `SCHEDULE_OFFICIAL_FALLBACK_ENABLED`, limited to same-day windows, and guarded by a 30-minute quota block after a 402.
+- The dashboard no longer retries known first-page schedule outages three times in the browser. It still retries partial page/deadline failures, but it does not multiply traffic when the upstream source fails before returning any flights.
+
 ## [1.5.8] - 2026-05-03
 
 ### Fixed

--- a/api/cron/warm-schedules.ts
+++ b/api/cron/warm-schedules.ts
@@ -57,9 +57,19 @@ export function buildWarmPlan(nowMs = Date.now()): WarmTask[] {
   return plan;
 }
 
+export function buildScheduleWarmUrl(hub: string, dir: string, timestamp: number): string {
+  const params = new URLSearchParams({
+    hub,
+    dir,
+    timestamp: String(timestamp),
+    officialFallback: '0',
+  });
+  return `${BASE_URL}/api/schedule?${params}`;
+}
+
 async function warmOne(hub: string, dir: string, timestamp: number, label: string): Promise<{ key: string; result: any }> {
   const key = `${hub}-${dir}-${label}`;
-  const url = `${BASE_URL}/api/schedule?hub=${hub}&dir=${dir}&timestamp=${timestamp}`;
+  const url = buildScheduleWarmUrl(hub, dir, timestamp);
   try {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 55000);
@@ -71,7 +81,23 @@ async function warmOne(hub: string, dir: string, timestamp: number, label: strin
     const cdnStatus = resp.headers.get('x-vercel-cache') || 'unknown';
     if (resp.ok) {
       const data = await resp.json() as any;
-      return { key, result: { status: 'ok', flights: data.total || 0, partial: data.partial || false, cached: data.cached || false, cdn: cdnStatus } };
+      const flights = Number(data.total || 0);
+      const partial = data.partial === true;
+      const status = partial
+        ? flights > 0 ? 'degraded_partial' : 'degraded_empty'
+        : 'ok';
+      return {
+        key,
+        result: {
+          status,
+          flights,
+          partial,
+          cached: data.cached || false,
+          cdn: cdnStatus,
+          partialReason: data.meta?.partialReason,
+          completeness: data.meta?.completeness,
+        }
+      };
     }
     return { key, result: { status: `http_${resp.status}`, cdn: cdnStatus } };
   } catch (e: any) {

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -9,6 +9,7 @@ const isRateLimited = createRateLimiter('schedule', 30);
 
 type ScheduleFetchOptions = {
   allowTargetedOfficialRescue?: boolean;
+  disableOfficialSource?: boolean;
 };
 
 // In-memory LRU cache for FR24 schedule data
@@ -164,11 +165,14 @@ function buildDegradedResponse(
 
 function shouldAttemptTargetedOfficialRescue(hub: string, ts: number, options?: ScheduleFetchOptions): boolean {
   if (!options?.allowTargetedOfficialRescue || !process.env.FR24_API_TOKEN) return false;
+  if (!['1', 'true', 'yes', 'on'].includes(String(process.env.SCHEDULE_OFFICIAL_FALLBACK_ENABLED || '').toLowerCase())) {
+    return false;
+  }
   const hubUpper = hub.toUpperCase();
   if (!TARGETED_OFFICIAL_RESCUE_HUBS.has(hubUpper)) return false;
 
   const startOfToday = getStartOfDayForHub(hubUpper);
-  return ts === startOfToday || ts === startOfToday + 86400;
+  return ts === startOfToday;
 }
 
 function cacheSet(key: string, data: any, ttlMs: number): void {
@@ -177,6 +181,23 @@ function cacheSet(key: string, data: any, ttlMs: number): void {
     if (firstKey !== undefined) cache.delete(firstKey);
   }
   cache.set(key, { data, expires: Date.now() + ttlMs, time: Date.now() });
+}
+
+function setAggregateCacheHeader(res: VercelResponse, data: any, cdnMaxAge: number, swr: number): void {
+  const isPartial = data?.partial === true;
+  const maxAge = isPartial ? 30 : cdnMaxAge;
+  const stale = isPartial ? 60 : swr;
+  res.setHeader('Cache-Control', `s-maxage=${maxAge}, stale-while-revalidate=${stale}`);
+}
+
+function getSingleQueryValue(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? value[0] || '' : value || '';
+}
+
+function shouldDisableOfficialFallback(req: VercelRequest): boolean {
+  const queryValue = getSingleQueryValue((req.query as Record<string, string | string[] | undefined>)?.officialFallback).toLowerCase();
+  const headerValue = getSingleQueryValue(req.headers?.['x-blueboard-official-fallback'] as string | string[] | undefined).toLowerCase();
+  return ['0', 'false', 'off', 'no'].includes(queryValue) || ['0', 'false', 'off', 'no'].includes(headerValue);
 }
 
 async function fetchWithTimeout(url: string, deadlineMs?: number): Promise<Response> {
@@ -384,6 +405,8 @@ function normalizeSummaryFlight(f: any) {
 }
 
 const OFFICIAL_API_PAGE_SIZE = 10000; // FR24 API allows up to 20,000 per request; use 10k to get most hubs in a single page
+const OFFICIAL_QUOTA_BLOCK_MS = 30 * 60 * 1000;
+let officialQuotaBlockedUntil = 0;
 
 function parseRetryAfterMs(headerValue: string | null): number {
   if (!headerValue) return 0;
@@ -397,11 +420,25 @@ function parseRetryAfterMs(headerValue: string | null): number {
   return 0;
 }
 
+function isOfficialQuotaBlocked(): boolean {
+  return Date.now() < officialQuotaBlockedUntil;
+}
+
+function blockOfficialQuota(reason: string): void {
+  officialQuotaBlockedUntil = Date.now() + OFFICIAL_QUOTA_BLOCK_MS;
+  console.warn(`Official FR24 API quota blocked for 30m: ${reason}`);
+}
+
 async function fetchViaOfficialAPI(hub: string, dir: string, ts: number, timeoutMs?: number) {
   const logHub = String(hub);
   const token = process.env.FR24_API_TOKEN;
   if (!token) {
     console.log('Official FR24 API: no FR24_API_TOKEN configured');
+    return null;
+  }
+  if (isOfficialQuotaBlocked()) {
+    const secondsRemaining = Math.ceil((officialQuotaBlockedUntil - Date.now()) / 1000);
+    console.warn(`Official FR24 API: quota block active for ${logHub}, skipping for ${secondsRemaining}s`);
     return null;
   }
 
@@ -460,6 +497,15 @@ async function fetchViaOfficialAPI(hub: string, dir: string, ts: number, timeout
       if (!resp.ok) {
         const body = await resp.text().catch(() => '');
         console.error(`Official FR24 API returned ${resp.status} for ${logHub} (page ${page}): ${body.slice(0, 200)}`);
+
+        if (resp.status === 402) {
+          blockOfficialQuota(body || `HTTP ${resp.status}`);
+          return null;
+        }
+
+        if ([400, 401, 403].includes(resp.status)) {
+          return null;
+        }
 
         if ([429, 503].includes(resp.status) && Date.now() < deadline - 2500) {
           const retryAfterMs = parseRetryAfterMs(resp.headers.get('retry-after'));
@@ -666,6 +712,11 @@ const FALLBACK_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
 const MAX_FALLBACKS_PER_WINDOW = 5;
 
 export function shouldAttemptOfficialFallback(): boolean {
+  if (isOfficialQuotaBlocked()) {
+    const secondsRemaining = Math.ceil((officialQuotaBlockedUntil - Date.now()) / 1000);
+    console.warn(`Circuit breaker tripped: official API quota block active for ${secondsRemaining}s, skipping`);
+    return false;
+  }
   const now = Date.now();
   while (fallbackLog.length && fallbackLog[0] < now - FALLBACK_WINDOW_MS) fallbackLog.shift();
   if (fallbackLog.length >= MAX_FALLBACKS_PER_WINDOW) {
@@ -681,6 +732,7 @@ export function recordFallback(): void {
 
 export function resetFallbackBreaker(): void {
   fallbackLog.length = 0;
+  officialQuotaBlockedUntil = 0;
 }
 
 async function tryOfficialFallback(
@@ -715,7 +767,9 @@ async function fetchAllPages(
   const allowTargetedOfficialRescue = shouldAttemptTargetedOfficialRescue(logHub, ts, options);
 
   // ── Source routing decision tree ──
-  const srcPriority = (process.env.SCHEDULE_SOURCE_PRIORITY || 'scrape').toLowerCase();
+  const srcPriority = options.disableOfficialSource
+    ? 'scrape-only'
+    : (process.env.SCHEDULE_SOURCE_PRIORITY || 'scrape').toLowerCase();
 
   if (!['scrape', 'official', 'scrape-only'].includes(srcPriority)) {
     console.warn(`Unrecognized SCHEDULE_SOURCE_PRIORITY: '${srcPriority}', using scrape-only`);
@@ -981,6 +1035,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const ttl = isOld ? 600000 : 900000;
     const cdnMaxAge = isOld ? 3600 : 900;
     swr = 600;
+    const allowOfficialFallback = !shouldDisableOfficialFallback(req);
 
     // Single page mode (backward compat)
     if (page !== undefined) {
@@ -1009,13 +1064,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     const cached = cacheGet(currentAggKey);
     if (cached) {
-      res.setHeader('Cache-Control', `s-maxage=${cdnMaxAge}, stale-while-revalidate=${swr}`);
+      setAggregateCacheHeader(res, cached.data, cdnMaxAge, swr);
       return res.status(200).json({ ...cached.data, cached: true });
     }
 
     const stale = cacheGetStale(currentAggKey);
     if (stale && !stale.data.partial) {
-      triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, { allowTargetedOfficialRescue: false });
+      triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, {
+        allowTargetedOfficialRescue: false,
+        disableOfficialSource: !allowOfficialFallback,
+      });
       res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
       return res.status(200).json({ ...stale.data, cached: true, stale: true });
     }
@@ -1023,7 +1081,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const exactLastComplete = getLastComplete(currentAggKey);
     const fallbackComplete = exactLastComplete || getLastCompleteByHubDir(hub, dir, ts);
     if (fallbackComplete) {
-      triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, { allowTargetedOfficialRescue: false });
+      triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, {
+        allowTargetedOfficialRescue: false,
+        disableOfficialSource: !allowOfficialFallback,
+      });
       res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
       return res.status(200).json(buildDegradedResponse(fallbackComplete, exactLastComplete ? 'exact' : 'hub_dir'));
     }
@@ -1031,7 +1092,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const persistentFallback = await getPersistentFallback(currentAggKey);
     if (persistentFallback) {
       triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, {
-        allowTargetedOfficialRescue: persistentFallback.fallbackScope === 'persistent_partial'
+        allowTargetedOfficialRescue: allowOfficialFallback && persistentFallback.fallbackScope === 'persistent_partial',
+        disableOfficialSource: !allowOfficialFallback,
       });
       res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
       return res.status(200).json(buildDegradedResponse(persistentFallback, persistentFallback.fallbackScope));
@@ -1040,13 +1102,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (pendingAggs.has(currentAggKey)) {
       const result = await pendingAggs.get(currentAggKey);
       if (result) {
-        res.setHeader('Cache-Control', `s-maxage=${cdnMaxAge}, stale-while-revalidate=${swr}`);
+        setAggregateCacheHeader(res, result, cdnMaxAge, swr);
         return res.status(200).json({ ...result, cached: true });
       }
     }
 
     const aggPromise = fetchAllPages(hub, dir, ts, undefined, functionDeadline, {
-      allowTargetedOfficialRescue: true
+      allowTargetedOfficialRescue: allowOfficialFallback,
+      disableOfficialSource: !allowOfficialFallback,
     }).then(async result => {
       cacheSet(currentAggKey, result, result.partial ? 60000 : ttl);
       saveComplete(currentAggKey, result);
@@ -1071,7 +1134,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           return res.status(200).json(buildDegradedResponse(persistentResult, 'persistent'));
         }
       }
-      res.setHeader('Cache-Control', `s-maxage=${cdnMaxAge}, stale-while-revalidate=${swr}`);
+      setAggregateCacheHeader(res, result, cdnMaxAge, swr);
       return res.status(200).json(result);
     } finally {
       pendingAggs.delete(currentAggKey);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "packageManager": "bun@1.3.11",
   "scripts": {
     "dev": "bun scripts/run-astro-dev.mjs",

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -3655,8 +3655,10 @@ async function loadScheduleData() {
         }
         result = await fetchScheduleAggregated(schedCurrentHub, schedCurrentDir, timestamp);
         lastErr = null;
-        // Auto-retry partial results silently (don't accept partial until last attempt)
-        if (result.partial && attempt < MAX_RETRIES - 1) {
+        // Retry partial page/deadline fetches, but do not hammer a known first-page outage.
+        const partialReason = result.meta?.partialReason || '';
+        const failedBeforeAnyFlight = partialReason === 'first_page_failed' && Number(result.total || 0) === 0;
+        if (result.partial && !failedBeforeAnyFlight && attempt < MAX_RETRIES - 1) {
           delete schedCache[`agg-${schedCurrentHub}-${schedCurrentDir}-${timestamp}`];
           continue;
         }

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -51,6 +51,7 @@ describe('schedule API', () => {
   afterEach(() => {
     delete process.env.FR24_API_TOKEN;
     delete process.env.SCHEDULE_SOURCE_PRIORITY;
+    delete process.env.SCHEDULE_OFFICIAL_FALLBACK_ENABLED;
     resetFallbackBreaker();
   });
 
@@ -406,8 +407,9 @@ describe('schedule API', () => {
     }
   });
 
-  it('scrape-first: tomorrow uses official fallback when scraping fails', async () => {
+  it('scrape-first: today uses official fallback when explicitly enabled and scraping fails', async () => {
     process.env.FR24_API_TOKEN = 'test-token-12345678';
+    process.env.SCHEDULE_OFFICIAL_FALLBACK_ENABLED = '1';
 
     let officialUrl = '';
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
@@ -432,7 +434,7 @@ describe('schedule API', () => {
       return { ok: false, status: 403, text: async () => 'Forbidden', headers: { get: () => null } };
     });
 
-    const ts = getStartOfDayForHub('LAX') + 86400;
+    const ts = getStartOfDayForHub('LAX');
     const req = {
       method: 'GET',
       headers: { origin: 'http://localhost:3000' },
@@ -447,6 +449,104 @@ describe('schedule API', () => {
     expect(res.body.meta.fallbackFrom).toBe('scraping');
     expect(officialUrl).toContain(`flight_datetime_from=${encodeURIComponent(formatForFR24Test(new Date(ts * 1000)))}`);
     expect(officialUrl).toContain(`flight_datetime_to=${encodeURIComponent(formatForFR24Test(new Date((ts + 86400 - 1) * 1000)))}`);
+  });
+
+  it('does not retry official API while FR24 credits are exhausted', async () => {
+    process.env.FR24_API_TOKEN = 'test-token-12345678';
+    process.env.SCHEDULE_SOURCE_PRIORITY = 'official';
+
+    let officialCalls = 0;
+    let scrapeCalls = 0;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes('fr24api.flightradar24.com')) {
+        officialCalls++;
+        return {
+          ok: false,
+          status: 402,
+          text: async () => '{"message":"Forbidden","details":"Credit limit reached. Please top up your account."}',
+        };
+      }
+
+      scrapeCalls++;
+      return {
+        ok: true,
+        json: async () => ({
+          result: {
+            response: {
+              airport: {
+                pluginData: {
+                  schedule: {
+                    arrivals: {
+                      page: { current: 1, total: 1 },
+                      data: []
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }),
+      };
+    });
+
+    const ts1 = Math.floor(Date.now() / 1000) - 42000;
+    const req1 = {
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'DEN', dir: 'arrivals', timestamp: String(ts1) }
+    };
+    const res1 = createRes();
+
+    await handler(req1, res1);
+
+    const ts2 = ts1 + 60;
+    const req2 = {
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'EWR', dir: 'arrivals', timestamp: String(ts2) }
+    };
+    const res2 = createRes();
+
+    await handler(req2, res2);
+
+    expect(res1.statusCode).toBe(200);
+    expect(res2.statusCode).toBe(200);
+    expect(officialCalls).toBe(1);
+    expect(scrapeCalls).toBe(2);
+    expect(res2.body.meta.source).toBe('scraping');
+  });
+
+  it('honors officialFallback=0 when scraping fails', async () => {
+    process.env.FR24_API_TOKEN = 'test-token-12345678';
+    process.env.SCHEDULE_OFFICIAL_FALLBACK_ENABLED = '1';
+    process.env.SCHEDULE_SOURCE_PRIORITY = 'official';
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes('fr24api.flightradar24.com')) {
+        throw new Error('Official API should not be called when officialFallback=0');
+      }
+      return { ok: false, status: 403, text: async () => 'Forbidden', headers: { get: () => null } };
+    });
+
+    const ts = getStartOfDayForHub('IAH') + 86400;
+    const req = {
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'IAH', dir: 'departures', timestamp: String(ts), officialFallback: '0' }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.partial).toBe(true);
+    expect(res.body.meta.source).toBe('scraping');
+    expect(res.body.meta.partialReason).toBe('first_page_failed');
+    for (const call of fetchSpy.mock.calls) {
+      expect(String(call[0])).not.toContain('fr24api.flightradar24.com');
+    }
   });
 
   it('circuit breaker trips after repeated fallbacks', () => {
@@ -821,6 +921,7 @@ describe('schedule API', () => {
         })
       })
     }));
+    expect(res.headers['Cache-Control']).toContain('s-maxage=30');
   });
 
   it('scrape-first: rate-limited mid-loop pauses and continues fetching', { timeout: 15000 }, async () => {
@@ -951,8 +1052,9 @@ describe('schedule API', () => {
     expect(pagesFetched).not.toContain(8);
   });
 
-  it('scrape-first: heavy rate limiting uses official rescue on targeted windows', { timeout: 15000 }, async () => {
+  it('scrape-first: heavy rate limiting uses official rescue on targeted windows when explicitly enabled', { timeout: 15000 }, async () => {
     process.env.FR24_API_TOKEN = 'test-token-12345678';
+    process.env.SCHEDULE_OFFICIAL_FALLBACK_ENABLED = '1';
 
     let pagesFetched = [];
     let officialCalls = 0;
@@ -1015,7 +1117,7 @@ describe('schedule API', () => {
       };
     });
 
-    const ts = getStartOfDayForHub('DEN') + 86400;
+    const ts = getStartOfDayForHub('DEN');
     const req = {
       method: 'GET',
       headers: { origin: 'http://localhost:3000' },

--- a/tests/warm-schedules.test.js
+++ b/tests/warm-schedules.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildWarmPlan } from '../api/cron/warm-schedules.js';
+import { buildScheduleWarmUrl, buildWarmPlan } from '../api/cron/warm-schedules.js';
 
 describe('warm-schedules buildWarmPlan', () => {
   const HUBS = ['ORD', 'DEN', 'IAH', 'EWR', 'SFO', 'IAD', 'LAX', 'NRT', 'GUM'];
@@ -62,5 +62,14 @@ describe('warm-schedules buildWarmPlan', () => {
     // Default is 4 tasks per run
     expect(plan.length).toBeLessThanOrEqual(8);
     expect(plan.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('disables official FR24 fallback for background schedule warming', () => {
+    const url = buildScheduleWarmUrl('ORD', 'departures', 1778907600);
+    expect(url).toContain('/api/schedule?');
+    expect(url).toContain('hub=ORD');
+    expect(url).toContain('dir=departures');
+    expect(url).toContain('timestamp=1778907600');
+    expect(url).toContain('officialFallback=0');
   });
 });


### PR DESCRIPTION
## Summary
- Prevent background schedule warming from using the paid FR24 official fallback by adding `officialFallback=0` to cron warm requests and honoring that switch even if official-first mode is configured.
- Treat empty partial schedule payloads as degraded instead of successfully warmed, and shorten CDN caching for partial aggregate responses.
- Stop retrying FR24 official API on quota/invalid-window responses and gate targeted official schedule rescue behind `SCHEDULE_OFFICIAL_FALLBACK_ENABLED`.
- Avoid browser retries for known first-page schedule outages so the dashboard does not multiply load during upstream failure.

## Production findings
- `theblueboard.co` is served by Vercel project `united-noc-vercel`.
- FR24 public schedule scraping is currently blocked with 403s.
- After the 30k credit top-up, official FR24 `flight-summary/light` no longer returns 402, but for schedule use it returns sparse actual-only records for today and rejects tomorrow windows with HTTP 400. It is not a reliable schedule source in its current usage.

## Tests
- `bun run test tests/schedule.test.js tests/warm-schedules.test.js`
- `bun run build`
- `git diff --check`