### PR TITLE
Fix actual-only schedule fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.10] - 2026-05-16
+
+### Fixed
+- Same-day schedules now recover visible rows when public FR24 scraping is challenged and the official FR24 summary API only returns actual takeoff/landing data. The API normalizes those actual-only records into degraded schedule rows with flight number, route, aircraft, registration, status, and time instead of returning 0 flights.
+- Actual-only schedule rows are marked as degraded and no longer feed the dashboard on-time calculation as if actual time equaled scheduled time. The banner now explains that same-day actual flight times are being shown because scheduled times are unavailable.
+- User-triggered same-day official fallback is enabled by default again, while cron warmers still opt out and `SCHEDULE_OFFICIAL_FALLBACK_ENABLED=0` remains a kill switch.
+
 ## [1.5.9] - 2026-05-16
 
 ### Fixed

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -165,7 +165,8 @@ function buildDegradedResponse(
 
 function shouldAttemptTargetedOfficialRescue(hub: string, ts: number, options?: ScheduleFetchOptions): boolean {
   if (!options?.allowTargetedOfficialRescue || !process.env.FR24_API_TOKEN) return false;
-  if (!['1', 'true', 'yes', 'on'].includes(String(process.env.SCHEDULE_OFFICIAL_FALLBACK_ENABLED || '').toLowerCase())) {
+  const fallbackSetting = String(process.env.SCHEDULE_OFFICIAL_FALLBACK_ENABLED || 'true').toLowerCase();
+  if (['0', 'false', 'off', 'no'].includes(fallbackSetting)) {
     return false;
   }
   const hubUpper = hub.toUpperCase();
@@ -302,6 +303,11 @@ function icaoFlightToIata(icaoFlight: string): string {
   return iataAirline ? iataAirline + match[2] : icaoFlight;
 }
 
+function normalizeFlightId(value: any): string {
+  if (!value) return '';
+  return String(value).trim().replace(/\s+/g, '').toUpperCase();
+}
+
 function toUnix(val: any): number | null {
   if (!val) return null;
   if (typeof val === 'number') return val > 1e12 ? Math.floor(val / 1000) : val;
@@ -358,23 +364,28 @@ function mapStatus(f: any) {
 }
 
 function normalizeSummaryFlight(f: any) {
-  const flightNum = f.flight_iata || f.flight_number?.iata || icaoFlightToIata(f.flight_icao || f.callsign || f.flight_number?.icao || '') || '';
-  const callsign = f.callsign || f.flight_icao || f.flight_number?.icao || '';
+  const rawFlightId = normalizeFlightId(f.flight_iata || f.flight_number?.iata || f.flight || f.flight_icao || f.callsign || f.flight_number?.icao || '');
+  const flightNum = icaoFlightToIata(rawFlightId);
+  const callsign = normalizeFlightId(f.callsign || f.flight_icao || f.flight_number?.icao || f.flight || '');
 
   const origIata = f.orig_iata || f.origin?.iata || icaoToIata(f.orig_icao || f.origin?.icao || '');
   const destIata = f.dest_iata || f.destination?.iata || icaoToIata(f.dest_icao_actual || f.dest_icao || f.destination?.icao || '');
   const origName = f.origin?.name || f.orig_name || '';
   const destName = f.destination?.name || f.dest_name || '';
 
-  const schedDep = toUnix(f.departure?.scheduled || f.scheduled_departure || f.datetime_scheduled_departure);
-  const schedArr = toUnix(f.arrival?.scheduled || f.scheduled_arrival || f.datetime_scheduled_arrival);
+  const rawSchedDep = toUnix(f.departure?.scheduled || f.scheduled_departure || f.datetime_scheduled_departure);
+  const rawSchedArr = toUnix(f.arrival?.scheduled || f.scheduled_arrival || f.datetime_scheduled_arrival);
   const realDep = toUnix(f.departure?.actual || f.actual_departure || f.datetime_takeoff || f.datetime_actual_departure);
   const realArr = toUnix(f.arrival?.actual || f.actual_arrival || f.datetime_landed || f.datetime_actual_arrival);
   const estDep = toUnix(f.departure?.estimated || f.estimated_departure || f.datetime_estimated_departure);
   const estArr = toUnix(f.arrival?.estimated || f.estimated_arrival || f.datetime_estimated_arrival);
+  const derivedScheduledDeparture = !rawSchedDep && !!realDep;
+  const derivedScheduledArrival = !rawSchedArr && !!realArr;
+  const schedDep = rawSchedDep || (derivedScheduledDeparture ? realDep : null);
+  const schedArr = rawSchedArr || (derivedScheduledArrival ? realArr : null);
 
   const acType = f.aircraft?.type || f.aircraft_type || f.type || '';
-  const acReg = f.aircraft?.registration || f.registration || '';
+  const acReg = f.aircraft?.registration || f.registration || f.reg || '';
 
   // Extract gate/terminal from API response if available (try multiple field name conventions)
   const origGate = f.origin?.gate || f.orig_gate || f.departure_gate || '';
@@ -400,7 +411,18 @@ function normalizeSummaryFlight(f: any) {
       origin: { code: { iata: origIata }, name: origName, info: { gate: origGate, terminal: fallbackOrigTerminal } },
       destination: { code: { iata: destIata }, name: destName, info: { gate: destGate, terminal: fallbackDestTerminal } }
     },
-    aircraft: { model: { code: acType, text: '' }, registration: acReg }
+    aircraft: { model: { code: acType, text: '' }, registration: acReg },
+    _source: {
+      officialApi: true,
+      hasOfficialScheduledTime: {
+        departure: !!rawSchedDep,
+        arrival: !!rawSchedArr
+      },
+      scheduleTimeDerivedFromActual: {
+        departure: derivedScheduledDeparture,
+        arrival: derivedScheduledArrival
+      }
+    }
   };
 }
 
@@ -623,26 +645,40 @@ async function fetchViaOfficialAPI(hub: string, dir: string, ts: number, timeout
     allUAFlights.push(normalizeSummaryFlight(f));
   }
 
-  // Quality gate: reject sparse payloads where most flights lack scheduled times
+  // Quality gate: reject sparse payloads where most flights lack any usable time,
+  // but keep FR24's actual-only summary rows as a degraded same-day fallback.
   const dirTimeKey = dir === 'departures' ? 'departure' : 'arrival';
   let sparseCount = 0;
+  let derivedScheduleCount = 0;
+  let officialScheduleCount = 0;
   const qualityFiltered: any[] = [];
   for (const fl of allUAFlights) {
     const schedTime = fl.time?.scheduled?.[dirTimeKey];
     if (schedTime && schedTime > 0) {
       qualityFiltered.push(fl);
+      if (fl._source?.scheduleTimeDerivedFromActual?.[dirTimeKey]) derivedScheduleCount++;
+      else officialScheduleCount++;
     } else {
       sparseCount++;
     }
   }
 
-  if (allUAFlights.length > 0 && sparseCount / allUAFlights.length > 0.5) {
+  if (allUAFlights.length > 0 && qualityFiltered.length === 0) {
+    console.warn(`Official FR24 API: ${allUAFlights.length} flights for ${logHub} ${dir} lack usable ${dirTimeKey} times — rejecting as sparse`);
+    return null;
+  }
+
+  if (allUAFlights.length > 0 && sparseCount / allUAFlights.length > 0.5 && derivedScheduleCount === 0) {
     console.warn(`Official FR24 API: ${sparseCount}/${allUAFlights.length} flights for ${logHub} ${dir} lack scheduled times — rejecting as sparse`);
     return null; // fall through to scraping fallback
   }
 
   const elapsedMs = Date.now() - startTime;
-  console.log(`Official FR24 API: ${allRawFlights.length} total flights (${totalPages} pages), ${qualityFiltered.length} ${dir} for ${logHub} in ${elapsedMs}ms${sparseCount > 0 ? ` (${sparseCount} sparse filtered)` : ''}`);
+  const hasDerivedScheduleTimes = derivedScheduleCount > 0;
+  const responsePartial = officialPartial || hasDerivedScheduleTimes;
+  const responsePartialReason = partialReason || (hasDerivedScheduleTimes ? 'actual_only_official' : null);
+  const completeness = hasDerivedScheduleTimes ? Math.max(0.25, Math.min(1, officialScheduleCount / qualityFiltered.length || 0.25)) : (officialPartial ? 0.9 : 1);
+  console.log(`Official FR24 API: ${allRawFlights.length} total flights (${totalPages} pages), ${qualityFiltered.length} ${dir} for ${logHub} in ${elapsedMs}ms${sparseCount > 0 ? ` (${sparseCount} sparse filtered)` : ''}${derivedScheduleCount > 0 ? ` (${derivedScheduleCount} actual-time fallback)` : ''}`);
 
   return {
     flights: qualityFiltered,
@@ -651,19 +687,21 @@ async function fetchViaOfficialAPI(hub: string, dir: string, ts: number, timeout
     pagesScanned: totalPages,
     totalPages,
     cached: false,
-    partial: officialPartial,
+    partial: responsePartial,
     hub: logHub,
     dir,
     meta: {
-      partialReason,
+      partialReason: responsePartialReason,
       pagesRequested: totalPages,
       pagesSucceeded: Math.max(0, totalPages - pagesFailed),
       pagesFailed,
       missingPages: [] as number[],
-      completeness: officialPartial ? 0.9 : 1,
+      completeness,
       elapsedMs,
       source: 'official-api',
-      sparseFiltered: sparseCount
+      sparseFiltered: sparseCount,
+      actualTimeFallbackCount: derivedScheduleCount,
+      officialScheduleCount
     }
   };
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "packageManager": "bun@1.3.11",
   "scripts": {
     "dev": "bun scripts/run-astro-dev.mjs",

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -3698,12 +3698,14 @@ async function loadScheduleData() {
         msg = 'The request timed out before all pages were fetched.';
       } else if (meta.partialReason === 'first_page_failed') {
         msg = 'The upstream data source is not responding.';
+      } else if (meta.partialReason === 'actual_only_official') {
+        msg = 'Showing same-day actual flight times; scheduled times are unavailable.';
       } else if (meta.partialReason === 'page_fetch_failed') {
         msg = `${meta.pagesFailed || 'Some'} page(s) failed to load.`;
       } else {
         msg = 'Some flights may be missing.';
       }
-      const pct = meta.completeness != null
+      const pct = meta.completeness != null && meta.partialReason !== 'actual_only_official'
         ? result.degraded && result.partial
           ? ` ${Math.round(meta.completeness * 100)}% previously loaded.`
           : !result.degraded
@@ -3913,9 +3915,12 @@ function renderScheduleTable() {
     const ident = fl.identification?.number?.default || '—';
     const schedTime = schedCurrentDir === 'departures' ? fl.time?.scheduled?.departure : fl.time?.scheduled?.arrival;
     const actualTime = schedCurrentDir === 'departures' ? (fl.time?.real?.departure || fl.time?.estimated?.departure) : (fl.time?.real?.arrival || fl.time?.estimated?.arrival);
+    const derivedScheduleTime = schedCurrentDir === 'departures' ? fl._source?.scheduleTimeDerivedFromActual?.departure : fl._source?.scheduleTimeDerivedFromActual?.arrival;
     const timeStr = formatSchedTime(schedTime, hub);
     let timeExtra = '';
-    if (actualTime && schedTime && actualTime !== schedTime) {
+    if (derivedScheduleTime) {
+      timeExtra = `<div class="sched-time-actual">actual</div>`;
+    } else if (actualTime && schedTime && actualTime !== schedTime) {
       const diff = Math.round((actualTime - schedTime) / 60);
       const actualStr = formatSchedTime(actualTime, hub);
       if (diff > 5) timeExtra = `<div class="sched-time-actual">→ ${actualStr} (+${diff}m)</div>`;
@@ -4064,9 +4069,10 @@ function renderScheduleStats(filtered) {
       return;
     }
     const schedT = schedCurrentDir === 'departures' ? fl.time?.scheduled?.departure : fl.time?.scheduled?.arrival;
+    const derivedScheduleTime = schedCurrentDir === 'departures' ? fl._source?.scheduleTimeDerivedFromActual?.departure : fl._source?.scheduleTimeDerivedFromActual?.arrival;
     const realT = fl.time?.real?.departure || fl.time?.real?.arrival;
     const actT = realT || (schedCurrentDir === 'departures' ? fl.time?.estimated?.departure : fl.time?.estimated?.arrival);
-    if (!schedT || !actT) return; // skip flights without usable timestamps
+    if (!schedT || !actT || derivedScheduleTime) return; // skip flights without a real schedule baseline
     if (actT > schedT + 1800) depDelayed++;
     else depOnTime++;
   });

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -407,9 +407,8 @@ describe('schedule API', () => {
     }
   });
 
-  it('scrape-first: today uses official fallback when explicitly enabled and scraping fails', async () => {
+  it('scrape-first: today uses official fallback by default when scraping fails', async () => {
     process.env.FR24_API_TOKEN = 'test-token-12345678';
-    process.env.SCHEDULE_OFFICIAL_FALLBACK_ENABLED = '1';
 
     let officialUrl = '';
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
@@ -449,6 +448,100 @@ describe('schedule API', () => {
     expect(res.body.meta.fallbackFrom).toBe('scraping');
     expect(officialUrl).toContain(`flight_datetime_from=${encodeURIComponent(formatForFR24Test(new Date(ts * 1000)))}`);
     expect(officialUrl).toContain(`flight_datetime_to=${encodeURIComponent(formatForFR24Test(new Date((ts + 86400 - 1) * 1000)))}`);
+  });
+
+  it('scrape-first: official fallback can still be disabled by env', async () => {
+    process.env.FR24_API_TOKEN = 'test-token-12345678';
+    process.env.SCHEDULE_OFFICIAL_FALLBACK_ENABLED = '0';
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes('fr24api.flightradar24.com')) {
+        throw new Error('Official API should not be called when fallback is disabled');
+      }
+      return { ok: false, status: 403, text: async () => 'Forbidden', headers: { get: () => null } };
+    });
+
+    const ts = getStartOfDayForHub('EWR');
+    const req = {
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'EWR', dir: 'departures', timestamp: String(ts) }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.partial).toBe(true);
+    expect(res.body.meta.source).toBe('scraping');
+    expect(res.body.meta.partialReason).toBe('first_page_failed');
+    for (const call of fetchSpy.mock.calls) {
+      expect(String(call[0])).not.toContain('fr24api.flightradar24.com');
+    }
+  });
+
+  it('scrape-first: renders actual-only official summary rows as degraded same-day data', async () => {
+    process.env.FR24_API_TOKEN = 'test-token-12345678';
+
+    const ts = getStartOfDayForHub('ORD');
+    const takeoff = ts + (10 * 60 * 60);
+    const landed = takeoff + (94 * 60);
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes('fr24api.flightradar24.com')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: [{
+              fr24_id: '3fb86069',
+              flight: 'UA795',
+              callsign: 'UAL795',
+              operating_as: 'UAL',
+              type: 'A21N',
+              reg: 'N44550',
+              orig_icao: 'KORD',
+              datetime_takeoff: new Date(takeoff * 1000).toISOString().replace('.000Z', 'Z'),
+              dest_icao: 'KEWR',
+              dest_icao_actual: 'KEWR',
+              datetime_landed: new Date(landed * 1000).toISOString().replace('.000Z', 'Z'),
+              flight_ended: true
+            }]
+          }),
+        };
+      }
+      return { ok: false, status: 403, text: async () => 'Forbidden', headers: { get: () => null } };
+    });
+
+    const req = {
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'ORD', dir: 'departures', timestamp: String(ts) }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.total).toBe(1);
+    expect(res.body.partial).toBe(true);
+    expect(res.body.meta.source).toBe('official-api');
+    expect(res.body.meta.fallbackFrom).toBe('scraping');
+    expect(res.body.meta.partialReason).toBe('actual_only_official');
+    expect(res.body.meta.actualTimeFallbackCount).toBe(1);
+    expect(res.body.meta.completeness).toBeGreaterThanOrEqual(0.25);
+
+    const flight = res.body.flights[0];
+    expect(flight.identification.number.default).toBe('UA795');
+    expect(flight.identification.callsign).toBe('UAL795');
+    expect(flight.airport.origin.code.iata).toBe('ORD');
+    expect(flight.airport.destination.code.iata).toBe('EWR');
+    expect(flight.aircraft.model.code).toBe('A21N');
+    expect(flight.aircraft.registration).toBe('N44550');
+    expect(flight.time.scheduled.departure).toBe(takeoff);
+    expect(flight.time.real.departure).toBe(takeoff);
+    expect(flight.time.real.arrival).toBe(landed);
+    expect(flight._source.scheduleTimeDerivedFromActual.departure).toBe(true);
   });
 
   it('does not retry official API while FR24 credits are exhausted', async () => {


### PR DESCRIPTION
## Summary
- normalize FR24 official actual-only summary records into degraded same-day schedule rows instead of returning 0 flights
- enable same-day official fallback for user requests by default while keeping cron warmers opted out and retaining the env kill switch
- mark actual-derived rows so dashboard banners explain the degraded state and OTP stats do not treat actual times as schedule baselines

## Verification
- bun run test tests/schedule.test.js tests/warm-schedules.test.js
- bun run build
- bun run test
- git diff --check