### PR TITLE
Add structured schedule provider fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,11 @@ FLEET_SHEET_ID=your-sheet-id-here
 # FR24 schedule source routing: 'scrape' (default) | 'official' | 'scrape-only'
 SCHEDULE_SOURCE_PRIORITY=scrape
 
+# Optional airport schedule fallback used only for direct schedule requests.
+# Cron warmers pass providerFallback=0 so the free tier is not drained in the background.
+AERODATABOX_API_KEY=
+# AERODATABOX_BASE_URL=https://prod.api.market/api/v1/aedbx/aerodatabox
+
 # Vercel Cron Secret (required for cron job auth)
 CRON_SECRET=
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.11] - 2026-05-16
+
+### Added
+- Schedule recovery now has an optional AeroDataBox airport FIDS fallback. When public FR24 scraping fails on a direct user request, the API can fetch structured scheduled departures/arrivals, normalize them into the existing dashboard flight shape, and persist them through the normal schedule snapshot cache.
+
+### Fixed
+- Background schedule warming now also disables provider fallback with `providerFallback=0`, so the free AeroDataBox tier is reserved for users who are actively loading schedules.
+- Empty partial schedule cache entries are bypassed when a provider key is available, so users are not kept on a known-bad 0-flight outage response while a structured fallback could recover rows.
+
 ## [1.5.10] - 2026-05-16
 
 ### Fixed

--- a/api/_schedule-aerodatabox.ts
+++ b/api/_schedule-aerodatabox.ts
@@ -1,0 +1,352 @@
+import { HUB_TZ } from './irops.js';
+import { icaoToIata, isInternationalRoute } from '../src/lib/airport-metadata.js';
+
+const AERODATABOX_BASE_URL = 'https://prod.api.market/api/v1/aedbx/aerodatabox';
+
+const UNITED_HUB_TERMINALS: Record<string, { domestic: string; international: string }> = {
+  ORD: { domestic: '1', international: '1' },
+  DEN: { domestic: 'B', international: 'B' },
+  EWR: { domestic: 'C', international: 'C' },
+  IAH: { domestic: 'C', international: 'E' },
+  SFO: { domestic: '3', international: 'G' },
+  LAX: { domestic: '7', international: '7' },
+  IAD: { domestic: 'C', international: 'D' },
+  NRT: { domestic: '1', international: '1' },
+  GUM: { domestic: '1', international: '1' },
+};
+
+function getHubTerminal(iata: string, isIntl: boolean): string {
+  const hub = UNITED_HUB_TERMINALS[iata.toUpperCase()];
+  if (!hub) return '';
+  return isIntl ? hub.international : hub.domestic;
+}
+
+function partsToObj(parts: Intl.DateTimeFormatPart[]): Record<string, string> {
+  const o: Record<string, string> = {};
+  for (const p of parts) o[p.type] = p.value;
+  if (o.hour === '24') o.hour = '00';
+  return o;
+}
+
+function hubLocalDate(hub: string, ts: number): string {
+  const tz = HUB_TZ[hub.toUpperCase()] || 'America/New_York';
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(new Date(ts * 1000));
+  const p = partsToObj(parts);
+  return `${p.year}-${p.month}-${p.day}`;
+}
+
+function normalizeAirportCode(airport: any): string {
+  const iata = String(airport?.iata || '').trim().toUpperCase();
+  if (iata) return iata;
+  return icaoToIata(String(airport?.icao || '').trim().toUpperCase());
+}
+
+function airportName(airport: any): string {
+  return String(airport?.name || airport?.shortName || airport?.municipalityName || '').trim();
+}
+
+function normalizeFlightId(value: any): string {
+  return String(value || '').trim().replace(/\s+/g, '').toUpperCase();
+}
+
+function normalizeUnitedFlightNumber(number: any, callSign?: any): string {
+  const primary = normalizeFlightId(number);
+  const fallback = normalizeFlightId(callSign);
+  const value = primary || fallback;
+  if (!value) return '';
+  const ual = /^UAL(\d+[A-Z]?)$/.exec(value);
+  if (ual) return `UA${ual[1]}`;
+  const ua = /^UA(\d+[A-Z]?)$/.exec(value);
+  if (ua) return `UA${ua[1]}`;
+  return value;
+}
+
+function toUnixDateTime(value: any): number | null {
+  if (!value) return null;
+  if (typeof value === 'number') return value > 1e12 ? Math.floor(value / 1000) : Math.floor(value);
+  if (typeof value === 'string') {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return numeric > 1e12 ? Math.floor(numeric / 1000) : Math.floor(numeric);
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? Math.floor(parsed / 1000) : null;
+  }
+  return toUnixDateTime(value.utc || value.local);
+}
+
+function mapAeroStatus(status: any) {
+  const s = String(status || '').trim();
+  let text = 'scheduled';
+  let type = '';
+  let diverted = false;
+  let live = false;
+  let icon = '';
+
+  if (s === 'Canceled' || s === 'CanceledUncertain') {
+    type = 'canceled';
+    text = 'canceled';
+    icon = 'red';
+  } else if (s === 'Diverted') {
+    diverted = true;
+    text = 'landed';
+    icon = 'red';
+  } else if (s === 'Arrived') {
+    text = 'landed';
+    icon = 'green';
+  } else if (s === 'EnRoute' || s === 'Approaching') {
+    text = 'en-route';
+    live = true;
+    icon = 'green';
+  } else if (s === 'Departed') {
+    text = 'departed';
+    live = true;
+    icon = 'green';
+  } else if (s === 'Delayed') {
+    text = 'estimated';
+    icon = 'yellow';
+  }
+
+  return {
+    generic: { status: { text, diverted }, type },
+    text: s.toLowerCase(),
+    icon,
+    live,
+  };
+}
+
+function isUnitedFlight(flight: any): boolean {
+  if (flight?.isCargo === true) return false;
+  const airlineIata = normalizeFlightId(flight?.airline?.iata);
+  const airlineIcao = normalizeFlightId(flight?.airline?.icao);
+  const number = normalizeFlightId(flight?.number);
+  const callSign = normalizeFlightId(flight?.callSign);
+  return (
+    airlineIata === 'UA' ||
+    airlineIcao === 'UAL' ||
+    /^UA\d/.test(number) ||
+    /^UAL\d/.test(number) ||
+    /^UAL\d/.test(callSign)
+  );
+}
+
+function normalizeFlight(flight: any, hub: string, dir: string) {
+  if (!isUnitedFlight(flight)) return null;
+
+  const hubUpper = hub.toUpperCase();
+  const isDeparture = dir === 'departures';
+  const departure = flight?.departure;
+  const arrival = flight?.arrival;
+  const movement = flight?.movement;
+
+  let originAirport = departure?.airport || (isDeparture && departure ? { iata: hubUpper, name: hubUpper } : null);
+  let destinationAirport = arrival?.airport || (!isDeparture && arrival ? { iata: hubUpper, name: hubUpper } : null);
+  let departureMovement = departure;
+  let arrivalMovement = arrival;
+
+  if (!departure && !arrival && movement) {
+    if (isDeparture) {
+      originAirport = { iata: hubUpper, name: hubUpper };
+      destinationAirport = movement.airport;
+      departureMovement = movement;
+      arrivalMovement = null;
+    } else {
+      originAirport = movement.airport;
+      destinationAirport = { iata: hubUpper, name: hubUpper };
+      departureMovement = null;
+      arrivalMovement = movement;
+    }
+  }
+
+  const origIata = normalizeAirportCode(originAirport);
+  const destIata = normalizeAirportCode(destinationAirport);
+  if (isDeparture && origIata !== hubUpper) return null;
+  if (!isDeparture && destIata !== hubUpper) return null;
+
+  const flightNum = normalizeUnitedFlightNumber(flight?.number, flight?.callSign);
+  if (!flightNum) return null;
+
+  const schedDep = toUnixDateTime(departureMovement?.scheduledTime);
+  const schedArr = toUnixDateTime(arrivalMovement?.scheduledTime);
+  const revisedDep = toUnixDateTime(departureMovement?.revisedTime);
+  const revisedArr = toUnixDateTime(arrivalMovement?.revisedTime);
+  const runwayDep = toUnixDateTime(departureMovement?.runwayTime);
+  const runwayArr = toUnixDateTime(arrivalMovement?.runwayTime);
+
+  const status = String(flight?.status || '');
+  const departedLike = ['Departed', 'EnRoute', 'Approaching', 'Arrived', 'Diverted'].includes(status);
+  const arrivedLike = ['Arrived', 'Diverted'].includes(status);
+  const realDep = departedLike ? (runwayDep || revisedDep) : null;
+  const realArr = arrivedLike ? (runwayArr || revisedArr) : null;
+  const estDep = !realDep ? (revisedDep || toUnixDateTime(departureMovement?.predictedTime)) : null;
+  const estArr = !realArr ? (revisedArr || toUnixDateTime(arrivalMovement?.predictedTime)) : null;
+
+  const origGate = String(departureMovement?.gate || '').trim();
+  const destGate = String(arrivalMovement?.gate || '').trim();
+  const origTerminalRaw = String(departureMovement?.terminal || '').trim();
+  const destTerminalRaw = String(arrivalMovement?.terminal || '').trim();
+  const intl = isInternationalRoute(origIata, destIata);
+  const origTerminal = origTerminalRaw || getHubTerminal(origIata, intl);
+  const destTerminal = destTerminalRaw || getHubTerminal(destIata, intl);
+
+  return {
+    identification: { number: { default: flightNum }, callsign: normalizeFlightId(flight?.callSign) },
+    airline: { code: { iata: 'UA' }, name: flight?.airline?.name || 'United Airlines' },
+    status: mapAeroStatus(status),
+    time: {
+      scheduled: { departure: schedDep, arrival: schedArr },
+      real: { departure: realDep, arrival: realArr },
+      estimated: { departure: estDep, arrival: estArr },
+    },
+    airport: {
+      origin: {
+        code: { iata: origIata },
+        name: airportName(originAirport),
+        info: { gate: origGate, terminal: origTerminal },
+      },
+      destination: {
+        code: { iata: destIata },
+        name: airportName(destinationAirport),
+        info: { gate: destGate, terminal: destTerminal },
+      },
+    },
+    aircraft: {
+      model: { code: '', text: flight?.aircraft?.model || '' },
+      registration: flight?.aircraft?.reg || '',
+    },
+    _source: {
+      provider: 'aerodatabox',
+      quality: [
+        ...(departureMovement?.quality || []),
+        ...(arrivalMovement?.quality || []),
+        ...(movement?.quality || []),
+      ],
+    },
+  };
+}
+
+async function fetchWindow(
+  hub: string,
+  dir: string,
+  fromLocal: string,
+  toLocal: string,
+  timeoutMs: number
+): Promise<{ ok: true; flights: any[] } | { ok: false }> {
+  const token = process.env.AERODATABOX_API_KEY;
+  if (!token) return { ok: false };
+
+  const base = (process.env.AERODATABOX_BASE_URL || AERODATABOX_BASE_URL).replace(/\/+$/, '');
+  const direction = dir === 'departures' ? 'Departure' : 'Arrival';
+  const url = new URL(
+    `${base}/flights/airports/iata/${encodeURIComponent(hub.toUpperCase())}/${encodeURIComponent(fromLocal)}/${encodeURIComponent(toLocal)}`
+  );
+  url.searchParams.set('direction', direction);
+  url.searchParams.set('withLeg', 'true');
+  url.searchParams.set('withCancelled', 'true');
+  url.searchParams.set('withCodeshared', 'true');
+  url.searchParams.set('withCargo', 'false');
+  url.searchParams.set('withPrivate', 'false');
+  url.searchParams.set('withLocation', 'false');
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const resp = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        'x-magicapi-key': token,
+        'Accept': 'application/json',
+        'User-Agent': 'TheBlueBoardDashboard/1.0 (https://theblueboard.co)',
+      },
+    });
+    clearTimeout(timeout);
+
+    if (resp.status === 204) return { ok: true, flights: [] };
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => '');
+      console.error(`AeroDataBox schedule returned ${resp.status} for ${hub} ${dir}: ${body.slice(0, 200)}`);
+      return { ok: false };
+    }
+
+    const data = await resp.json() as any;
+    const flights = dir === 'departures' ? (data?.departures || []) : (data?.arrivals || []);
+    return { ok: true, flights: Array.isArray(flights) ? flights : [] };
+  } catch (e: any) {
+    clearTimeout(timeout);
+    if (e.name === 'AbortError') {
+      console.error(`AeroDataBox schedule timeout for ${hub} ${dir}`);
+    } else {
+      console.error(`AeroDataBox schedule error for ${hub} ${dir}:`, e.message);
+    }
+    return { ok: false };
+  }
+}
+
+export async function fetchViaAeroDataBox(hub: string, dir: string, ts: number, timeoutMs = 12000) {
+  if (!process.env.AERODATABOX_API_KEY) return null;
+
+  const startTime = Date.now();
+  const date = hubLocalDate(hub, ts);
+  const windows = [
+    [`${date}T00:00`, `${date}T11:59`],
+    [`${date}T12:00`, `${date}T23:59`],
+  ];
+
+  const rawFlights: any[] = [];
+  const failedWindows: number[] = [];
+  const perWindowTimeout = Math.max(2000, Math.floor(timeoutMs / windows.length));
+
+  for (let i = 0; i < windows.length; i++) {
+    const [fromLocal, toLocal] = windows[i];
+    const result = await fetchWindow(hub, dir, fromLocal, toLocal, perWindowTimeout);
+    if (result.ok) {
+      rawFlights.push(...result.flights);
+    } else {
+      failedWindows.push(i + 1);
+    }
+  }
+
+  const seen = new Set<string>();
+  const flights: any[] = [];
+  for (const raw of rawFlights) {
+    const normalized = normalizeFlight(raw, hub, dir);
+    if (!normalized) continue;
+    const scheduleKey = dir === 'departures'
+      ? normalized.time?.scheduled?.departure
+      : normalized.time?.scheduled?.arrival;
+    const key = `${normalized.identification?.number?.default || ''}:${scheduleKey || ''}:${normalized.airport?.origin?.code?.iata || ''}:${normalized.airport?.destination?.code?.iata || ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    flights.push(normalized);
+  }
+
+  const partial = failedWindows.length > 0;
+  const pagesRequested = windows.length;
+  const pagesFailed = failedWindows.length;
+  const pagesSucceeded = pagesRequested - pagesFailed;
+
+  return {
+    flights,
+    total: flights.length,
+    totalFetched: rawFlights.length,
+    pagesScanned: pagesRequested,
+    totalPages: pagesRequested,
+    cached: false,
+    partial,
+    hub,
+    dir,
+    meta: {
+      partialReason: partial ? 'provider_partial' : null,
+      pagesRequested,
+      pagesSucceeded,
+      pagesFailed,
+      missingPages: failedWindows,
+      completeness: pagesRequested > 0 ? Math.round((pagesSucceeded / pagesRequested) * 100) / 100 : 1,
+      elapsedMs: Date.now() - startTime,
+      source: 'aerodatabox',
+    },
+  };
+}

--- a/api/cron/warm-schedules.ts
+++ b/api/cron/warm-schedules.ts
@@ -63,6 +63,7 @@ export function buildScheduleWarmUrl(hub: string, dir: string, timestamp: number
     dir,
     timestamp: String(timestamp),
     officialFallback: '0',
+    providerFallback: '0',
   });
   return `${BASE_URL}/api/schedule?${params}`;
 }

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -1,6 +1,7 @@
 import type { VercelRequest, VercelResponse } from './types.js';
 import { createRateLimiter } from './_rate-limit.js';
 import { loadScheduleSnapshot, saveScheduleSnapshot } from './_schedule-snapshots.js';
+import { fetchViaAeroDataBox } from './_schedule-aerodatabox.js';
 import { getStartOfDayForHub } from './irops.js';
 import { waitUntil } from '@vercel/functions';
 import { icaoToIata, isInternationalRoute } from '../src/lib/airport-metadata.js';
@@ -10,6 +11,7 @@ const isRateLimited = createRateLimiter('schedule', 30);
 type ScheduleFetchOptions = {
   allowTargetedOfficialRescue?: boolean;
   disableOfficialSource?: boolean;
+  disableProviderFallback?: boolean;
 };
 
 // In-memory LRU cache for FR24 schedule data
@@ -198,6 +200,12 @@ function getSingleQueryValue(value: string | string[] | undefined): string {
 function shouldDisableOfficialFallback(req: VercelRequest): boolean {
   const queryValue = getSingleQueryValue((req.query as Record<string, string | string[] | undefined>)?.officialFallback).toLowerCase();
   const headerValue = getSingleQueryValue(req.headers?.['x-blueboard-official-fallback'] as string | string[] | undefined).toLowerCase();
+  return ['0', 'false', 'off', 'no'].includes(queryValue) || ['0', 'false', 'off', 'no'].includes(headerValue);
+}
+
+function shouldDisableProviderFallback(req: VercelRequest): boolean {
+  const queryValue = getSingleQueryValue((req.query as Record<string, string | string[] | undefined>)?.providerFallback).toLowerCase();
+  const headerValue = getSingleQueryValue(req.headers?.['x-blueboard-provider-fallback'] as string | string[] | undefined).toLowerCase();
   return ['0', 'false', 'off', 'no'].includes(queryValue) || ['0', 'false', 'off', 'no'].includes(headerValue);
 }
 
@@ -791,6 +799,42 @@ async function tryOfficialFallback(
   return null;
 }
 
+async function tryScheduleProviderFallback(
+  logHub: string, dir: string, ts: number, effectiveDeadline: number
+): Promise<any | null> {
+  if (!process.env.AERODATABOX_API_KEY) return null;
+  try {
+    const remaining = Math.max(0, effectiveDeadline - Date.now() - 1000);
+    if (remaining < 2000) return null;
+    const result = await fetchViaAeroDataBox(logHub, dir, ts, Math.min(remaining, 12000));
+    if (result && result.total > 0) {
+      result.meta = { ...(result.meta as any), fallbackFrom: 'scraping' };
+      return result;
+    }
+  } catch (e: any) {
+    console.error(`AeroDataBox schedule fallback failed for ${logHub}:`, e.message);
+  }
+  return null;
+}
+
+async function tryScheduleRescue(
+  logHub: string,
+  dir: string,
+  ts: number,
+  effectiveDeadline: number,
+  allowProviderFallback: boolean,
+  allowOfficialFallback: boolean
+): Promise<any | null> {
+  if (allowProviderFallback) {
+    const providerFallback = await tryScheduleProviderFallback(logHub, dir, ts, effectiveDeadline);
+    if (providerFallback) return providerFallback;
+  }
+  if (allowOfficialFallback) {
+    return await tryOfficialFallback(logHub, dir, ts, effectiveDeadline);
+  }
+  return null;
+}
+
 async function fetchAllPages(
   hub: string,
   dir: string,
@@ -803,6 +847,7 @@ async function fetchAllPages(
   const now = Date.now();
   const effectiveDeadline = overallDeadline || (now + (timeoutMs || HUB_TIMEOUT_MS[logHub.toUpperCase()] || 45000));
   const allowTargetedOfficialRescue = shouldAttemptTargetedOfficialRescue(logHub, ts, options);
+  const allowProviderFallback = !options.disableProviderFallback;
 
   // ── Source routing decision tree ──
   const srcPriority = options.disableOfficialSource
@@ -857,10 +902,9 @@ async function fetchAllPages(
   const startTime = Date.now();
   const firstPage = await fetchOnePage(logHub, dir, ts, 1, deadline);
   if (!firstPage || firstPage._rateLimited) {
-    // Targeted rescue: only spend official credits for missing high-priority windows.
-    if (srcPriority === 'scrape' && allowTargetedOfficialRescue) {
-      console.log(`Scraping failed on first page for ${logHub} ${dir}, trying official API fallback`);
-      const fallback = await tryOfficialFallback(logHub, dir, ts, effectiveDeadline);
+    if (srcPriority === 'scrape' && (allowProviderFallback || allowTargetedOfficialRescue)) {
+      console.log(`Scraping failed on first page for ${logHub} ${dir}, trying schedule fallback`);
+      const fallback = await tryScheduleRescue(logHub, dir, ts, effectiveDeadline, allowProviderFallback, allowTargetedOfficialRescue);
       if (fallback) return fallback;
     }
     return { flights: [], total: 0, totalFetched: 0, pagesScanned: 0, totalPages: 1, cached: false, partial: true, hub: logHub, dir,
@@ -1019,15 +1063,15 @@ async function fetchAllPages(
     Date.now() < deadline - MIN_REMAINING_MS_FOR_OFFICIAL_RESCUE
   ) {
     attemptedOfficialRescue = true;
-    console.log(`Scraping hit repeated FR24 rate limits for ${logHub} ${dir}, trying official API fallback`);
-    const fallback = await tryOfficialFallback(logHub, dir, ts, effectiveDeadline);
+    console.log(`Scraping hit repeated FR24 rate limits for ${logHub} ${dir}, trying schedule fallback`);
+    const fallback = await tryScheduleRescue(logHub, dir, ts, effectiveDeadline, allowProviderFallback, allowTargetedOfficialRescue);
     if (fallback) return fallback;
   }
 
   // Scrape-first fallback: if scraping failed completely, try official API (with circuit breaker)
-  if (!attemptedOfficialRescue && srcPriority === 'scrape' && allowTargetedOfficialRescue && scrapeResult.total === 0 && scrapeResult.partial) {
-    console.log(`Scraping returned 0 flights for ${logHub} ${dir}, trying official API fallback`);
-    const fallback = await tryOfficialFallback(logHub, dir, ts, effectiveDeadline);
+  if (!attemptedOfficialRescue && srcPriority === 'scrape' && (allowProviderFallback || allowTargetedOfficialRescue) && scrapeResult.total === 0 && scrapeResult.partial) {
+    console.log(`Scraping returned 0 flights for ${logHub} ${dir}, trying schedule fallback`);
+    const fallback = await tryScheduleRescue(logHub, dir, ts, effectiveDeadline, allowProviderFallback, allowTargetedOfficialRescue);
     if (fallback) return fallback;
   }
 
@@ -1074,6 +1118,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const cdnMaxAge = isOld ? 3600 : 900;
     swr = 600;
     const allowOfficialFallback = !shouldDisableOfficialFallback(req);
+    const allowProviderFallback = !shouldDisableProviderFallback(req);
 
     // Single page mode (backward compat)
     if (page !== undefined) {
@@ -1101,7 +1146,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     aggKey = currentAggKey;
 
     const cached = cacheGet(currentAggKey);
-    if (cached) {
+    const shouldBypassEmptyPartialCache = cached?.data?.partial === true && Number(cached?.data?.total || 0) === 0 && allowProviderFallback && !!process.env.AERODATABOX_API_KEY;
+    if (cached && !shouldBypassEmptyPartialCache) {
       setAggregateCacheHeader(res, cached.data, cdnMaxAge, swr);
       return res.status(200).json({ ...cached.data, cached: true });
     }
@@ -1111,6 +1157,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, {
         allowTargetedOfficialRescue: false,
         disableOfficialSource: !allowOfficialFallback,
+        disableProviderFallback: true,
       });
       res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
       return res.status(200).json({ ...stale.data, cached: true, stale: true });
@@ -1122,19 +1169,27 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, {
         allowTargetedOfficialRescue: false,
         disableOfficialSource: !allowOfficialFallback,
+        disableProviderFallback: true,
       });
       res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
       return res.status(200).json(buildDegradedResponse(fallbackComplete, exactLastComplete ? 'exact' : 'hub_dir'));
     }
 
+    let partialPersistentFallback: Awaited<ReturnType<typeof getPersistentFallback>> | null = null;
     const persistentFallback = await getPersistentFallback(currentAggKey);
     if (persistentFallback) {
-      triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, {
-        allowTargetedOfficialRescue: allowOfficialFallback && persistentFallback.fallbackScope === 'persistent_partial',
-        disableOfficialSource: !allowOfficialFallback,
-      });
-      res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
-      return res.status(200).json(buildDegradedResponse(persistentFallback, persistentFallback.fallbackScope));
+      const canAttemptProviderNow = persistentFallback.fallbackScope === 'persistent_partial' && allowProviderFallback && !!process.env.AERODATABOX_API_KEY;
+      if (canAttemptProviderNow) {
+        partialPersistentFallback = persistentFallback;
+      } else {
+        triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, {
+          allowTargetedOfficialRescue: allowOfficialFallback && persistentFallback.fallbackScope === 'persistent_partial',
+          disableOfficialSource: !allowOfficialFallback,
+          disableProviderFallback: true,
+        });
+        res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
+        return res.status(200).json(buildDegradedResponse(persistentFallback, persistentFallback.fallbackScope));
+      }
     }
 
     if (pendingAggs.has(currentAggKey)) {
@@ -1148,6 +1203,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const aggPromise = fetchAllPages(hub, dir, ts, undefined, functionDeadline, {
       allowTargetedOfficialRescue: allowOfficialFallback,
       disableOfficialSource: !allowOfficialFallback,
+      disableProviderFallback: !allowProviderFallback,
     }).then(async result => {
       cacheSet(currentAggKey, result, result.partial ? 60000 : ttl);
       saveComplete(currentAggKey, result);
@@ -1170,6 +1226,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         if (persistentResult && persistentResult.fallbackScope === 'persistent') {
           res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
           return res.status(200).json(buildDegradedResponse(persistentResult, 'persistent'));
+        }
+        if (partialPersistentFallback) {
+          res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
+          return res.status(200).json(buildDegradedResponse(partialPersistentFallback, 'persistent_partial'));
         }
       }
       setAggregateCacheHeader(res, result, cdnMaxAge, swr);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "packageManager": "bun@1.3.11",
   "scripts": {
     "dev": "bun scripts/run-astro-dev.mjs",

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -50,6 +50,8 @@ describe('schedule API', () => {
 
   afterEach(() => {
     delete process.env.FR24_API_TOKEN;
+    delete process.env.AERODATABOX_API_KEY;
+    delete process.env.AERODATABOX_BASE_URL;
     delete process.env.SCHEDULE_SOURCE_PRIORITY;
     delete process.env.SCHEDULE_OFFICIAL_FALLBACK_ENABLED;
     resetFallbackBreaker();
@@ -639,6 +641,112 @@ describe('schedule API', () => {
     expect(res.body.meta.partialReason).toBe('first_page_failed');
     for (const call of fetchSpy.mock.calls) {
       expect(String(call[0])).not.toContain('fr24api.flightradar24.com');
+    }
+  });
+
+  it('uses AeroDataBox schedule fallback before FR24 official fallback when scraping fails', async () => {
+    process.env.FR24_API_TOKEN = 'test-token-12345678';
+    process.env.AERODATABOX_API_KEY = 'adb-test-key';
+
+    const ts = getStartOfDayForHub('GUM') + 86400;
+    const depTime = ts + 9 * 3600;
+    const arrTime = ts + 12 * 3600;
+    let aeroCalls = 0;
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url, init) => {
+      const urlStr = String(url);
+      if (urlStr.includes('fr24api.flightradar24.com')) {
+        throw new Error('Official API should not be called after provider success');
+      }
+      if (urlStr.includes('prod.api.market/api/v1/aedbx/aerodatabox')) {
+        aeroCalls++;
+        expect(init?.headers?.['x-magicapi-key']).toBe('adb-test-key');
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            departures: aeroCalls === 1 ? [{
+              number: 'UA150',
+              callSign: 'UAL150',
+              status: 'Expected',
+              codeshareStatus: 'IsOperator',
+              isCargo: false,
+              airline: { iata: 'UA', icao: 'UAL', name: 'United Airlines' },
+              departure: {
+                airport: { iata: 'GUM', icao: 'PGUM', name: 'Guam' },
+                scheduledTime: { utc: new Date(depTime * 1000).toISOString(), local: '2026-05-17T09:00:00+10:00' },
+                terminal: '1',
+                gate: '4',
+                quality: ['Basic'],
+              },
+              arrival: {
+                airport: { iata: 'NRT', icao: 'RJAA', name: 'Tokyo Narita' },
+                scheduledTime: { utc: new Date(arrTime * 1000).toISOString(), local: '2026-05-17T12:00:00+09:00' },
+                quality: ['Basic'],
+              },
+              aircraft: { model: 'Boeing 737-800', reg: 'N37267' },
+            }] : [],
+          }),
+        };
+      }
+      return { ok: false, status: 500, text: async () => 'FR24 unavailable', headers: { get: () => null } };
+    });
+
+    const req = {
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'GUM', dir: 'departures', timestamp: String(ts) }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.total).toBe(1);
+    expect(res.body.partial).toBe(false);
+    expect(res.body.meta.source).toBe('aerodatabox');
+    expect(res.body.meta.fallbackFrom).toBe('scraping');
+    expect(aeroCalls).toBe(2);
+    expect(fetchSpy.mock.calls.some(call => String(call[0]).includes('fr24api.flightradar24.com'))).toBe(false);
+
+    const flight = res.body.flights[0];
+    expect(flight.identification.number.default).toBe('UA150');
+    expect(flight.airport.origin.code.iata).toBe('GUM');
+    expect(flight.airport.destination.code.iata).toBe('NRT');
+    expect(flight.airport.origin.info.gate).toBe('4');
+    expect(flight.airport.origin.info.terminal).toBe('1');
+    expect(flight.aircraft.registration).toBe('N37267');
+    expect(flight.time.scheduled.departure).toBe(depTime);
+    expect(flight.time.scheduled.arrival).toBe(arrTime);
+  });
+
+  it('honors providerFallback=0 when scraping fails', async () => {
+    process.env.AERODATABOX_API_KEY = 'adb-test-key';
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes('prod.api.market/api/v1/aedbx/aerodatabox')) {
+        throw new Error('AeroDataBox should not be called when providerFallback=0');
+      }
+      return { ok: false, status: 500, text: async () => 'FR24 unavailable', headers: { get: () => null } };
+    });
+
+    const ts = getStartOfDayForHub('LAX') + 2 * 86400;
+    const req = {
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'LAX', dir: 'arrivals', timestamp: String(ts), providerFallback: '0' }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.partial).toBe(true);
+    expect(res.body.meta.source).toBe('scraping');
+    expect(res.body.meta.partialReason).toBe('first_page_failed');
+    for (const call of fetchSpy.mock.calls) {
+      expect(String(call[0])).not.toContain('prod.api.market/api/v1/aedbx/aerodatabox');
     }
   });
 

--- a/tests/warm-schedules.test.js
+++ b/tests/warm-schedules.test.js
@@ -64,12 +64,13 @@ describe('warm-schedules buildWarmPlan', () => {
     expect(plan.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('disables official FR24 fallback for background schedule warming', () => {
+  it('disables paid/provider fallbacks for background schedule warming', () => {
     const url = buildScheduleWarmUrl('ORD', 'departures', 1778907600);
     expect(url).toContain('/api/schedule?');
     expect(url).toContain('hub=ORD');
     expect(url).toContain('dir=departures');
     expect(url).toContain('timestamp=1778907600');
     expect(url).toContain('officialFallback=0');
+    expect(url).toContain('providerFallback=0');
   });
 });


### PR DESCRIPTION
## Summary
- add an optional AeroDataBox airport FIDS fallback for `/api/schedule` when public FR24 scraping fails
- normalize AeroDataBox departures/arrivals into the existing dashboard flight shape, including UA flight identity, route, scheduled/revised times, status, gate/terminal, aircraft model, and registration
- keep cron warming from consuming provider quota with `providerFallback=0`, and bypass known-bad empty partial cache entries when a provider key is available

## User Impact
Users get schedule rows from a structured schedule source when FR24 scraping is blocked, instead of staying on a 0-flight degraded schedule response. Background jobs still avoid burning paid/free provider credits.

## Config
Set `AERODATABOX_API_KEY` in Vercel to enable this fallback. Optional override: `AERODATABOX_BASE_URL`.

## Verification
- `bun run test tests/schedule.test.js tests/warm-schedules.test.js`
- `bun run build`
- `bun run test` (41 files, 578 tests)
- `git diff --check`

## Notes
- A repo-wide `bunx tsc --noEmit` is still blocked by pre-existing script/module typing issues unrelated to this change (`scripts/prewarm-cache.ts` top-level await and JS declaration gaps for `src/lib/airport-metadata.js`). The production build and Vitest suite pass.
