### PR TITLE
Fix schedules with production FR24 scraper transport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,18 @@ SCHEDULE_SOURCE_PRIORITY=scrape
 AERODATABOX_API_KEY=
 # AERODATABOX_BASE_URL=https://prod.api.market/api/v1/aedbx/aerodatabox
 
+# Optional FR24 scraping transport used only when direct FR24 scraping is blocked.
+# This still scrapes the existing FR24 schedule endpoint; it is not a schedule data API.
+# Cron warmers pass scraperFallback=0 so paid scraper credits are not drained in the background.
+SCRAPINGBEE_API_KEY=
+# SCHEDULE_SCRAPER_MODE=scrapingbee
+# SCHEDULE_SCRAPER_RENDER_JS=true
+# SCHEDULE_SCRAPER_PREMIUM_PROXY=true
+# SCHEDULE_SCRAPER_COUNTRY=us
+# Or point at a private scraper worker that accepts POST { url, method, headers, timeoutMs }.
+# SCHEDULE_SCRAPER_URL=
+# SCHEDULE_SCRAPER_TOKEN=
+
 # Vercel Cron Secret (required for cron job auth)
 CRON_SECRET=
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.12] - 2026-05-16
+
+### Added
+- Schedule scraping now has a production scraper transport for FR24 blocks. When the direct FR24 schedule JSON scrape hits a Cloudflare/rate-limit block, the API can fetch the same FR24 endpoint through a configured scraping transport, normalize the returned schedule, and keep provider APIs as later fallbacks rather than the primary rescue path.
+
+### Fixed
+- Background schedule warming now also disables scraper fallback with `scraperFallback=0`, so paid scraping credits are reserved for users actively loading schedules.
+- Empty partial schedule cache entries are bypassed when a scraper transport is configured, so users are not kept on a known-bad 0-flight response while the FR24 scraper can recover rows.
+
 ## [1.5.11] - 2026-05-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Curated United Airlines news hub with individual article pages, source links, an
 
 | Source | Data | Freshness | Notes |
 |--------|------|-----------|-------|
-| [Flightradar24](https://flightradar24.com) | Live positions, schedules, flight lookup | ~15s–60s | Server-side proxy with caching |
+| [Flightradar24](https://flightradar24.com) | Live positions, schedules, flight lookup | ~15s–60s | Server-side proxy with caching; schedules can recover through a configured FR24 scraper transport when direct fetches are blocked |
 | [Aviation Weather Center](https://aviationweather.gov) | METAR observations | ~5min | NOAA/CORS proxy, batched |
 | [FAA NAS Status](https://nasstatus.faa.gov) | Delays & ground stops | ~5min | XML→JSON proxy |
 | [United Fleet Site](https://unitedfleetsite.com/) | Fleet database | Daily | Community-maintained |

--- a/api/_fr24-scraper-transport.ts
+++ b/api/_fr24-scraper-transport.ts
@@ -1,0 +1,176 @@
+export const FR24_SCHEDULE_HEADERS: Record<string, string> = {
+  'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+  'Accept': 'application/json,text/plain,*/*',
+  'Accept-Language': 'en-US,en;q=0.9',
+  'Referer': 'https://www.flightradar24.com/',
+  'Origin': 'https://www.flightradar24.com',
+};
+
+type ScraperResult = {
+  data: any;
+  transport: 'scrapingbee' | 'http-json';
+};
+
+function remainingTimeout(deadlineMs?: number): number {
+  const remaining = deadlineMs ? deadlineMs - Date.now() - 500 : 20000;
+  return Math.max(1500, Math.min(remaining, 20000));
+}
+
+function scraperMode(): 'scrapingbee' | 'http-json' | 'off' {
+  const explicit = String(process.env.SCHEDULE_SCRAPER_MODE || '').trim().toLowerCase();
+  if (['0', 'false', 'off', 'none', 'disabled'].includes(explicit)) return 'off';
+  if (explicit === 'scrapingbee') return 'scrapingbee';
+  if (['http-json', 'generic', 'proxy'].includes(explicit)) return 'http-json';
+  if (process.env.SCHEDULE_SCRAPER_URL) return 'http-json';
+  if (process.env.SCRAPINGBEE_API_KEY) return 'scrapingbee';
+  return 'off';
+}
+
+export function hasConfiguredFr24ScraperTransport(): boolean {
+  const mode = scraperMode();
+  if (mode === 'scrapingbee') return Boolean(process.env.SCRAPINGBEE_API_KEY);
+  if (mode === 'http-json') return Boolean(process.env.SCHEDULE_SCRAPER_URL);
+  return false;
+}
+
+function parseJsonCandidate(value: any): any | null {
+  if (!value) return null;
+  if (typeof value === 'object') return value;
+  if (typeof value !== 'string') return null;
+
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    const preMatch = trimmed.match(/<pre[^>]*>([\s\S]*?)<\/pre>/i);
+    if (preMatch) {
+      const preBody = preMatch[1]
+        .replace(/&quot;/g, '"')
+        .replace(/&#34;/g, '"')
+        .replace(/&#x22;/gi, '"')
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>');
+      try {
+        return JSON.parse(preBody);
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }
+}
+
+function normalizeTransportPayload(payload: any): any | null {
+  const parsed = parseJsonCandidate(payload);
+  if (!parsed) return null;
+
+  if (parsed?.result?.response?.airport) return parsed;
+  if (parsed?.json) return normalizeTransportPayload(parsed.json);
+  if (parsed?.body) return normalizeTransportPayload(parsed.body);
+  if (parsed?.data?.result?.response?.airport) return parsed.data;
+  if (parsed?.data?.json || parsed?.data?.body) return normalizeTransportPayload(parsed.data);
+
+  return null;
+}
+
+async function readJsonFromResponse(resp: Response): Promise<any | null> {
+  const text = await resp.text().catch(() => '');
+  return normalizeTransportPayload(text);
+}
+
+async function fetchWithAbort(url: string, init: RequestInit, timeoutMs: number): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function fetchViaScrapingBee(targetUrl: string, deadlineMs?: number): Promise<ScraperResult | null> {
+  const apiKey = process.env.SCRAPINGBEE_API_KEY;
+  if (!apiKey) return null;
+
+  const timeoutMs = remainingTimeout(deadlineMs);
+  const url = new URL('https://app.scrapingbee.com/api/v1');
+  url.searchParams.set('api_key', apiKey);
+  url.searchParams.set('url', targetUrl);
+  url.searchParams.set('render_js', String(process.env.SCHEDULE_SCRAPER_RENDER_JS || 'true'));
+  url.searchParams.set('premium_proxy', String(process.env.SCHEDULE_SCRAPER_PREMIUM_PROXY || 'true'));
+  url.searchParams.set('country_code', process.env.SCHEDULE_SCRAPER_COUNTRY || 'us');
+
+  try {
+    const resp = await fetchWithAbort(url.toString(), {
+      headers: {
+        'Accept': 'application/json,text/plain,*/*',
+        'User-Agent': 'TheBlueBoardDashboard/1.0 (https://theblueboard.co)',
+      },
+    }, timeoutMs);
+
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => '');
+      console.error(`ScrapingBee FR24 schedule scrape returned ${resp.status}: ${body.slice(0, 200)}`);
+      return null;
+    }
+
+    const data = await readJsonFromResponse(resp);
+    return data ? { data, transport: 'scrapingbee' } : null;
+  } catch (e: any) {
+    console.error(`ScrapingBee FR24 schedule scrape failed: ${e?.message || e}`);
+    return null;
+  }
+}
+
+async function fetchViaHttpJsonTransport(targetUrl: string, deadlineMs?: number): Promise<ScraperResult | null> {
+  const endpoint = process.env.SCHEDULE_SCRAPER_URL;
+  if (!endpoint) return null;
+
+  const timeoutMs = remainingTimeout(deadlineMs);
+  const headers: Record<string, string> = {
+    'Accept': 'application/json,text/plain,*/*',
+    'Content-Type': 'application/json',
+    'User-Agent': 'TheBlueBoardDashboard/1.0 (https://theblueboard.co)',
+  };
+  if (process.env.SCHEDULE_SCRAPER_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.SCHEDULE_SCRAPER_TOKEN}`;
+  }
+
+  try {
+    const resp = await fetchWithAbort(endpoint, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        url: targetUrl,
+        method: 'GET',
+        headers: FR24_SCHEDULE_HEADERS,
+        timeoutMs,
+      }),
+    }, timeoutMs);
+
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => '');
+      console.error(`FR24 schedule scraper transport returned ${resp.status}: ${body.slice(0, 200)}`);
+      return null;
+    }
+
+    const payload = await readJsonFromResponse(resp);
+    return payload ? { data: payload, transport: 'http-json' } : null;
+  } catch (e: any) {
+    console.error(`FR24 schedule scraper transport failed: ${e?.message || e}`);
+    return null;
+  }
+}
+
+export async function fetchFr24ScheduleViaScraperTransport(targetUrl: string, deadlineMs?: number): Promise<ScraperResult | null> {
+  switch (scraperMode()) {
+    case 'scrapingbee':
+      return await fetchViaScrapingBee(targetUrl, deadlineMs);
+    case 'http-json':
+      return await fetchViaHttpJsonTransport(targetUrl, deadlineMs);
+    default:
+      return null;
+  }
+}

--- a/api/cron/warm-schedules.ts
+++ b/api/cron/warm-schedules.ts
@@ -64,6 +64,7 @@ export function buildScheduleWarmUrl(hub: string, dir: string, timestamp: number
     timestamp: String(timestamp),
     officialFallback: '0',
     providerFallback: '0',
+    scraperFallback: '0',
   });
   return `${BASE_URL}/api/schedule?${params}`;
 }

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -2,6 +2,11 @@ import type { VercelRequest, VercelResponse } from './types.js';
 import { createRateLimiter } from './_rate-limit.js';
 import { loadScheduleSnapshot, saveScheduleSnapshot } from './_schedule-snapshots.js';
 import { fetchViaAeroDataBox } from './_schedule-aerodatabox.js';
+import {
+  FR24_SCHEDULE_HEADERS,
+  fetchFr24ScheduleViaScraperTransport,
+  hasConfiguredFr24ScraperTransport,
+} from './_fr24-scraper-transport.js';
 import { getStartOfDayForHub } from './irops.js';
 import { waitUntil } from '@vercel/functions';
 import { icaoToIata, isInternationalRoute } from '../src/lib/airport-metadata.js';
@@ -12,6 +17,7 @@ type ScheduleFetchOptions = {
   allowTargetedOfficialRescue?: boolean;
   disableOfficialSource?: boolean;
   disableProviderFallback?: boolean;
+  disableScraperFallback?: boolean;
 };
 
 // In-memory LRU cache for FR24 schedule data
@@ -209,6 +215,12 @@ function shouldDisableProviderFallback(req: VercelRequest): boolean {
   return ['0', 'false', 'off', 'no'].includes(queryValue) || ['0', 'false', 'off', 'no'].includes(headerValue);
 }
 
+function shouldDisableScraperFallback(req: VercelRequest): boolean {
+  const queryValue = getSingleQueryValue((req.query as Record<string, string | string[] | undefined>)?.scraperFallback).toLowerCase();
+  const headerValue = getSingleQueryValue(req.headers?.['x-blueboard-scraper-fallback'] as string | string[] | undefined).toLowerCase();
+  return ['0', 'false', 'off', 'no'].includes(queryValue) || ['0', 'false', 'off', 'no'].includes(headerValue);
+}
+
 async function fetchWithTimeout(url: string, deadlineMs?: number): Promise<Response> {
   const remaining = deadlineMs ? Math.max(500, deadlineMs - Date.now()) : 45000;
   const fetchTimeout = Math.min(remaining, 45000);
@@ -218,13 +230,7 @@ async function fetchWithTimeout(url: string, deadlineMs?: number): Promise<Respo
   try {
     const resp = await fetch(url, {
       signal: controller.signal,
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
-        'Accept': 'application/json',
-        'Accept-Language': 'en-US,en;q=0.9',
-        'Referer': 'https://www.flightradar24.com/',
-        'Origin': 'https://www.flightradar24.com'
-      }
+      headers: FR24_SCHEDULE_HEADERS
     });
     clearTimeout(timeout);
     return resp;
@@ -234,8 +240,44 @@ async function fetchWithTimeout(url: string, deadlineMs?: number): Promise<Respo
   }
 }
 
+function extractFr24SchedulePayload(data: any, dir: string, page: number): any | null {
+  const airportData = data?.result?.response?.airport;
+  const sched = airportData?.pluginData?.schedule?.[dir];
+  if (!sched) {
+    if (airportData && page === 1) {
+      return { page: { current: page, total: 1 }, data: [] };
+    }
+    return null;
+  }
+  return sched;
+}
+
+function isDirectFr24Block(resp: Response): boolean {
+  const cfMitigated = String(resp.headers?.get?.('cf-mitigated') || '').toLowerCase();
+  return resp.status === 403 || resp.status === 429 || cfMitigated === 'challenge';
+}
+
+async function fetchOnePageViaScraperTransport(url: string, dir: string, page: number, deadlineMs?: number): Promise<any | null> {
+  const result = await fetchFr24ScheduleViaScraperTransport(url, deadlineMs);
+  if (!result) return null;
+
+  const sched = extractFr24SchedulePayload(result.data, dir, page);
+  if (!sched) return null;
+  return {
+    ...sched,
+    _scrapeTransport: result.transport,
+  };
+}
+
 // Resilient page fetch — returns null on failure instead of throwing (matches irops pattern)
-async function fetchOnePage(hub: string, dir: string, timestamp: number, page: number, deadlineMs?: number): Promise<any | null> {
+async function fetchOnePage(
+  hub: string,
+  dir: string,
+  timestamp: number,
+  page: number,
+  deadlineMs?: number,
+  options: Pick<ScheduleFetchOptions, 'disableScraperFallback'> = {}
+): Promise<any | null> {
   const url = `https://api.flightradar24.com/common/v1/airport.json?code=${encodeURIComponent(hub)}&plugin[]=schedule&plugin-setting[schedule][mode]=${encodeURIComponent(dir)}&plugin-setting[schedule][timestamp]=${timestamp}&page=${page}&limit=100`;
   const MAX_RETRIES = 2;
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
@@ -246,15 +288,20 @@ async function fetchOnePage(hub: string, dir: string, timestamp: number, page: n
       const resp = await fetchWithTimeout(url, deadlineMs);
       if (resp.ok) {
         const data = await resp.json();
-        const airportData = (data as any)?.result?.response?.airport;
-        const sched = airportData?.pluginData?.schedule?.[dir];
-        if (!sched) {
-          if (airportData && page === 1) {
-            return { page: { current: page, total: 1 }, data: [] };
-          }
-          return null;
-        }
+        const sched = extractFr24SchedulePayload(data, dir, page);
         return sched;
+      }
+      if (!options.disableScraperFallback && hasConfiguredFr24ScraperTransport() && isDirectFr24Block(resp)) {
+        const recovered = await fetchOnePageViaScraperTransport(url, dir, page, deadlineMs);
+        if (recovered) return recovered;
+        if (resp.status === 403) {
+          console.error(`FR24 direct scrape blocked for ${hub} page ${page}; configured scraper transport did not recover`);
+          return { _rateLimited: true };
+        }
+      }
+      if (resp.status === 403 && String(resp.headers?.get?.('cf-mitigated') || '').toLowerCase() === 'challenge') {
+        console.error(`FR24 Cloudflare challenge for ${hub} page ${page}`);
+        return { _rateLimited: true };
       }
       if ([403, 429, 502, 503].includes(resp.status) && attempt < MAX_RETRIES) {
         // Honor Retry-After header if present (capped at 30s)
@@ -848,6 +895,7 @@ async function fetchAllPages(
   const effectiveDeadline = overallDeadline || (now + (timeoutMs || HUB_TIMEOUT_MS[logHub.toUpperCase()] || 45000));
   const allowTargetedOfficialRescue = shouldAttemptTargetedOfficialRescue(logHub, ts, options);
   const allowProviderFallback = !options.disableProviderFallback;
+  const allowScraperFallback = !options.disableScraperFallback;
 
   // ── Source routing decision tree ──
   const srcPriority = options.disableOfficialSource
@@ -882,8 +930,14 @@ async function fetchAllPages(
   let stoppedForHeavyRateLimit = false;
   const BATCH_SIZE = 3;
   const MAX_PAGES = 50;
+  const scraperTransports = new Set<string>();
+  let scraperRecoveredPages = 0;
 
   function processPage(sched: any): boolean {
+    if (sched?._scrapeTransport) {
+      scraperTransports.add(String(sched._scrapeTransport));
+      scraperRecoveredPages++;
+    }
     if (!sched.data || sched.data.length === 0) return false;
     totalFetched += sched.data.length;
     for (const entry of sched.data) {
@@ -900,7 +954,9 @@ async function fetchAllPages(
   }
 
   const startTime = Date.now();
-  const firstPage = await fetchOnePage(logHub, dir, ts, 1, deadline);
+  const firstPage = await fetchOnePage(logHub, dir, ts, 1, deadline, {
+    disableScraperFallback: !allowScraperFallback,
+  });
   if (!firstPage || firstPage._rateLimited) {
     if (srcPriority === 'scrape' && (allowProviderFallback || allowTargetedOfficialRescue)) {
       console.log(`Scraping failed on first page for ${logHub} ${dir}, trying schedule fallback`);
@@ -927,7 +983,9 @@ async function fetchAllPages(
       for (let p = pageNum; p <= batchEnd; p++) batchPages.push(p);
 
       const batchResults = await Promise.allSettled(
-        batchPages.map(p => fetchOnePage(logHub, dir, ts, p, deadline))
+        batchPages.map(p => fetchOnePage(logHub, dir, ts, p, deadline, {
+          disableScraperFallback: !allowScraperFallback,
+        }))
       );
 
       let batchDone = false;
@@ -998,7 +1056,9 @@ async function fetchAllPages(
 
       const retryBatch = failedPages.slice(i, i + RETRY_BATCH);
       const retryResults = await Promise.allSettled(
-        retryBatch.map(p => fetchOnePage(logHub, dir, ts, p, deadline))
+        retryBatch.map(p => fetchOnePage(logHub, dir, ts, p, deadline, {
+          disableScraperFallback: !allowScraperFallback,
+        }))
       );
 
       for (let j = 0; j < retryResults.length; j++) {
@@ -1051,7 +1111,9 @@ async function fetchAllPages(
       missingPages: allFailedPages,
       completeness: pagesRequested > 0 ? Math.round(((pagesScanned - allFailedPages.length) / pagesRequested) * 100) / 100 : 1,
       elapsedMs,
-      source: 'scraping' as const
+      source: 'scraping' as const,
+      scrapeTransport: scraperTransports.size > 0 ? Array.from(scraperTransports).join(',') : 'direct',
+      scraperRecoveredPages,
     }
   };
 
@@ -1119,6 +1181,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     swr = 600;
     const allowOfficialFallback = !shouldDisableOfficialFallback(req);
     const allowProviderFallback = !shouldDisableProviderFallback(req);
+    const allowScraperFallback = !shouldDisableScraperFallback(req);
 
     // Single page mode (backward compat)
     if (page !== undefined) {
@@ -1132,13 +1195,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         res.setHeader('Cache-Control', `s-maxage=${cdnMaxAge}, stale-while-revalidate=${swr}`);
         return res.status(200).json({ ...cached.data, cached: true });
       }
-      const sched = await fetchOnePage(hub, dir, ts, pageNum);
+      const sched = await fetchOnePage(hub, dir, ts, pageNum, functionDeadline, {
+        disableScraperFallback: !allowScraperFallback,
+      });
       if (!sched) {
         return res.status(502).json({ error: 'Upstream service unavailable' });
       }
+      const scrapeTransport = sched._scrapeTransport || 'direct';
+      delete sched._scrapeTransport;
       cacheSet(cacheKey, sched, ttl);
       res.setHeader('Cache-Control', `s-maxage=${cdnMaxAge}, stale-while-revalidate=${swr}`);
-      return res.status(200).json({ ...sched, cached: false });
+      return res.status(200).json({ ...sched, cached: false, meta: { ...(sched.meta || {}), source: 'scraping', scrapeTransport } });
     }
 
     // Aggregation mode
@@ -1146,7 +1213,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     aggKey = currentAggKey;
 
     const cached = cacheGet(currentAggKey);
-    const shouldBypassEmptyPartialCache = cached?.data?.partial === true && Number(cached?.data?.total || 0) === 0 && allowProviderFallback && !!process.env.AERODATABOX_API_KEY;
+    const hasImmediateScheduleRecovery =
+      (allowScraperFallback && hasConfiguredFr24ScraperTransport()) ||
+      (allowProviderFallback && !!process.env.AERODATABOX_API_KEY);
+    const shouldBypassEmptyPartialCache = cached?.data?.partial === true && Number(cached?.data?.total || 0) === 0 && hasImmediateScheduleRecovery;
     if (cached && !shouldBypassEmptyPartialCache) {
       setAggregateCacheHeader(res, cached.data, cdnMaxAge, swr);
       return res.status(200).json({ ...cached.data, cached: true });
@@ -1158,6 +1228,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         allowTargetedOfficialRescue: false,
         disableOfficialSource: !allowOfficialFallback,
         disableProviderFallback: true,
+        disableScraperFallback: true,
       });
       res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
       return res.status(200).json({ ...stale.data, cached: true, stale: true });
@@ -1170,6 +1241,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         allowTargetedOfficialRescue: false,
         disableOfficialSource: !allowOfficialFallback,
         disableProviderFallback: true,
+        disableScraperFallback: true,
       });
       res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
       return res.status(200).json(buildDegradedResponse(fallbackComplete, exactLastComplete ? 'exact' : 'hub_dir'));
@@ -1178,14 +1250,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     let partialPersistentFallback: Awaited<ReturnType<typeof getPersistentFallback>> | null = null;
     const persistentFallback = await getPersistentFallback(currentAggKey);
     if (persistentFallback) {
-      const canAttemptProviderNow = persistentFallback.fallbackScope === 'persistent_partial' && allowProviderFallback && !!process.env.AERODATABOX_API_KEY;
-      if (canAttemptProviderNow) {
+      const canAttemptRecoveryNow = persistentFallback.fallbackScope === 'persistent_partial' && hasImmediateScheduleRecovery;
+      if (canAttemptRecoveryNow) {
         partialPersistentFallback = persistentFallback;
       } else {
         triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, {
           allowTargetedOfficialRescue: allowOfficialFallback && persistentFallback.fallbackScope === 'persistent_partial',
           disableOfficialSource: !allowOfficialFallback,
           disableProviderFallback: true,
+          disableScraperFallback: true,
         });
         res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
         return res.status(200).json(buildDegradedResponse(persistentFallback, persistentFallback.fallbackScope));
@@ -1204,6 +1277,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       allowTargetedOfficialRescue: allowOfficialFallback,
       disableOfficialSource: !allowOfficialFallback,
       disableProviderFallback: !allowProviderFallback,
+      disableScraperFallback: !allowScraperFallback,
     }).then(async result => {
       cacheSet(currentAggKey, result, result.partial ? 60000 : ttl);
       saveComplete(currentAggKey, result);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "packageManager": "bun@1.3.11",
   "scripts": {
     "dev": "bun scripts/run-astro-dev.mjs",

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -52,6 +52,13 @@ describe('schedule API', () => {
     delete process.env.FR24_API_TOKEN;
     delete process.env.AERODATABOX_API_KEY;
     delete process.env.AERODATABOX_BASE_URL;
+    delete process.env.SCRAPINGBEE_API_KEY;
+    delete process.env.SCHEDULE_SCRAPER_MODE;
+    delete process.env.SCHEDULE_SCRAPER_RENDER_JS;
+    delete process.env.SCHEDULE_SCRAPER_PREMIUM_PROXY;
+    delete process.env.SCHEDULE_SCRAPER_COUNTRY;
+    delete process.env.SCHEDULE_SCRAPER_URL;
+    delete process.env.SCHEDULE_SCRAPER_TOKEN;
     delete process.env.SCHEDULE_SOURCE_PRIORITY;
     delete process.env.SCHEDULE_OFFICIAL_FALLBACK_ENABLED;
     resetFallbackBreaker();
@@ -718,6 +725,126 @@ describe('schedule API', () => {
     expect(flight.aircraft.registration).toBe('N37267');
     expect(flight.time.scheduled.departure).toBe(depTime);
     expect(flight.time.scheduled.arrival).toBe(arrTime);
+  });
+
+  it('uses configured FR24 scraper transport before provider fallbacks when direct scraping is blocked', async () => {
+    process.env.SCRAPINGBEE_API_KEY = 'bee-test-key';
+    process.env.AERODATABOX_API_KEY = 'adb-test-key';
+    process.env.FR24_API_TOKEN = 'test-token-12345678';
+
+    const ts = getStartOfDayForHub('SFO') + 86400;
+    const depTime = ts + 7 * 3600;
+    const arrTime = ts + 11 * 3600;
+    let scrapingBeeCalls = 0;
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes('app.scrapingbee.com/api/v1')) {
+        scrapingBeeCalls++;
+        expect(urlStr).toContain('api_key=bee-test-key');
+        expect(urlStr).toContain('premium_proxy=true');
+        expect(urlStr).toContain('render_js=true');
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({
+            result: {
+              response: {
+                airport: {
+                  pluginData: {
+                    schedule: {
+                      departures: {
+                        page: { current: 1, total: 1 },
+                        data: [{
+                          flight: {
+                            airline: { code: { iata: 'UA' } },
+                            identification: { number: { default: 'UA900' }, callsign: 'UAL900' },
+                            time: { scheduled: { departure: depTime, arrival: arrTime } },
+                            airport: {
+                              origin: { code: { iata: 'SFO' }, info: { gate: 'F12', terminal: '3' } },
+                              destination: { code: { iata: 'NRT' }, info: { gate: '', terminal: '' } }
+                            },
+                            aircraft: { registration: 'N26902' }
+                          }
+                        }]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }),
+        };
+      }
+      if (urlStr.includes('prod.api.market/api/v1/aedbx/aerodatabox')) {
+        throw new Error('AeroDataBox should not be called after scraper transport success');
+      }
+      if (urlStr.includes('fr24api.flightradar24.com')) {
+        throw new Error('Official API should not be called after scraper transport success');
+      }
+      return {
+        ok: false,
+        status: 403,
+        text: async () => 'Cloudflare challenge',
+        headers: { get: (name) => String(name).toLowerCase() === 'cf-mitigated' ? 'challenge' : null },
+      };
+    });
+
+    const req = {
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'SFO', dir: 'departures', timestamp: String(ts) }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.total).toBe(1);
+    expect(res.body.partial).toBe(false);
+    expect(res.body.meta.source).toBe('scraping');
+    expect(res.body.meta.scrapeTransport).toBe('scrapingbee');
+    expect(res.body.meta.scraperRecoveredPages).toBe(1);
+    expect(res.body.meta.fallbackFrom).toBeUndefined();
+    expect(scrapingBeeCalls).toBe(1);
+    expect(fetchSpy.mock.calls.some(call => String(call[0]).includes('prod.api.market/api/v1/aedbx/aerodatabox'))).toBe(false);
+    expect(fetchSpy.mock.calls.some(call => String(call[0]).includes('fr24api.flightradar24.com'))).toBe(false);
+  });
+
+  it('honors scraperFallback=0 when direct FR24 scraping is blocked', async () => {
+    process.env.SCRAPINGBEE_API_KEY = 'bee-test-key';
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes('app.scrapingbee.com/api/v1')) {
+        throw new Error('Scraper transport should not be called when scraperFallback=0');
+      }
+      return {
+        ok: false,
+        status: 403,
+        text: async () => 'Cloudflare challenge',
+        headers: { get: (name) => String(name).toLowerCase() === 'cf-mitigated' ? 'challenge' : null },
+      };
+    });
+
+    const ts = getStartOfDayForHub('NRT') + 86400;
+    const req = {
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'NRT', dir: 'arrivals', timestamp: String(ts), scraperFallback: '0' }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.partial).toBe(true);
+    expect(res.body.total).toBe(0);
+    expect(res.body.meta.source).toBe('scraping');
+    expect(res.body.meta.partialReason).toBe('first_page_failed');
+    for (const call of fetchSpy.mock.calls) {
+      expect(String(call[0])).not.toContain('app.scrapingbee.com/api/v1');
+    }
   });
 
   it('honors providerFallback=0 when scraping fails', async () => {

--- a/tests/warm-schedules.test.js
+++ b/tests/warm-schedules.test.js
@@ -64,7 +64,7 @@ describe('warm-schedules buildWarmPlan', () => {
     expect(plan.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('disables paid/provider fallbacks for background schedule warming', () => {
+  it('disables paid/provider/scraper fallbacks for background schedule warming', () => {
     const url = buildScheduleWarmUrl('ORD', 'departures', 1778907600);
     expect(url).toContain('/api/schedule?');
     expect(url).toContain('hub=ORD');
@@ -72,5 +72,6 @@ describe('warm-schedules buildWarmPlan', () => {
     expect(url).toContain('timestamp=1778907600');
     expect(url).toContain('officialFallback=0');
     expect(url).toContain('providerFallback=0');
+    expect(url).toContain('scraperFallback=0');
   });
 });


### PR DESCRIPTION
## Summary
- Add a real FR24 scraper transport path for schedule recovery: direct FR24 schedule JSON scrape first, configured scraping transport second, provider/official APIs only after that.
- Support ScrapingBee via `SCRAPINGBEE_API_KEY` and a generic private scraper worker via `SCHEDULE_SCRAPER_URL`.
- Keep cron warmers from draining paid scrape/provider/official credits with `scraperFallback=0`, `providerFallback=0`, and `officialFallback=0`.
- Bypass cached empty partial schedule responses when a scraper transport is configured so users get an immediate recovery attempt.

## Production env required
This code only activates the production scraper when one of these is configured in Vercel Production:
- `SCRAPINGBEE_API_KEY` (defaults to `SCHEDULE_SCRAPER_MODE=scrapingbee`, `SCHEDULE_SCRAPER_RENDER_JS=true`, `SCHEDULE_SCRAPER_PREMIUM_PROXY=true`, `SCHEDULE_SCRAPER_COUNTRY=us`)
- or `SCHEDULE_SCRAPER_URL` for a private POST `{ url, method, headers, timeoutMs }` scraper worker, plus optional `SCHEDULE_SCRAPER_TOKEN`

Without that env, production continues to use the current direct scrape + AeroDataBox/official fallback behavior.

## Tests
- `bun run test tests/schedule.test.js tests/warm-schedules.test.js`
- `bun run test`
- `bun run build`