### PR TITLE
Fix schedule rescue for every hub

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ AERODATABOX_API_KEY=
 # Cron warmers pass scraperFallback=0 so paid scraper credits are not drained in the background.
 SCRAPINGBEE_API_KEY=
 # SCHEDULE_SCRAPER_MODE=scrapingbee
-# SCHEDULE_SCRAPER_RENDER_JS=true
+# SCHEDULE_SCRAPER_RENDER_JS=false
 # SCHEDULE_SCRAPER_PREMIUM_PROXY=true
 # SCHEDULE_SCRAPER_COUNTRY=us
 # Or point at a private scraper worker that accepts POST { url, method, headers, timeoutMs }.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.13] - 2026-05-16
+
+### Fixed
+- Same-day official schedule rescue now covers NRT and GUM too, so every United hub can recover visible rows when direct FR24 schedule scraping fails and paid FR24 credits are available.
+- ScrapingBee schedule recovery now defaults to `render_js=false`, reducing scraper credit burn for the FR24 JSON endpoint once the ScrapingBee quota is available.
+
 ## [1.5.12] - 2026-05-16
 
 ### Added

--- a/api/_fr24-scraper-transport.ts
+++ b/api/_fr24-scraper-transport.ts
@@ -98,7 +98,7 @@ async function fetchViaScrapingBee(targetUrl: string, deadlineMs?: number): Prom
   const url = new URL('https://app.scrapingbee.com/api/v1');
   url.searchParams.set('api_key', apiKey);
   url.searchParams.set('url', targetUrl);
-  url.searchParams.set('render_js', String(process.env.SCHEDULE_SCRAPER_RENDER_JS || 'true'));
+  url.searchParams.set('render_js', String(process.env.SCHEDULE_SCRAPER_RENDER_JS || 'false'));
   url.searchParams.set('premium_proxy', String(process.env.SCHEDULE_SCRAPER_PREMIUM_PROXY || 'true'));
   url.searchParams.set('country_code', process.env.SCHEDULE_SCRAPER_COUNTRY || 'us');
 

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -32,7 +32,7 @@ const MAX_COMPLETE_CACHE_SIZE = 128;
 const COMPLETE_CACHE_MAX_AGE = 21600000; // 6 hours
 const BATCH_DELAY = 500; // 500ms pause between parallel batches
 const STALE_GRACE = 120000; // serve stale data for up to 2min past expiry
-const TARGETED_OFFICIAL_RESCUE_HUBS = new Set(['ORD', 'DEN', 'IAH', 'EWR', 'SFO', 'IAD', 'LAX']);
+const TARGETED_OFFICIAL_RESCUE_HUBS = new Set(['ORD', 'DEN', 'IAH', 'EWR', 'SFO', 'IAD', 'LAX', 'NRT', 'GUM']);
 
 // Busy hubs get more time to fetch all pages (capped at 55s for Vercel's 60s maxDuration)
 const HUB_TIMEOUT_MS: Record<string, number> = { ORD: 55000, EWR: 55000, IAH: 55000, SFO: 55000, LAX: 55000, DEN: 55000, IAD: 55000, NRT: 55000, GUM: 55000 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "packageManager": "bun@1.3.11",
   "scripts": {
     "dev": "bun scripts/run-astro-dev.mjs",

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -416,7 +416,7 @@ describe('schedule API', () => {
     }
   });
 
-  it('scrape-first: today uses official fallback by default when scraping fails', async () => {
+  it('scrape-first: today uses official fallback by default for any hub when scraping fails', async () => {
     process.env.FR24_API_TOKEN = 'test-token-12345678';
 
     let officialUrl = '';
@@ -431,8 +431,8 @@ describe('schedule API', () => {
               flight_icao: 'UAL201',
               flight_iata: 'UA201',
               status: 'scheduled',
-              orig_iata: 'LAX',
-              dest_iata: 'ORD',
+              orig_iata: 'GUM',
+              dest_iata: 'NRT',
               scheduled_departure: 1741653600,
               scheduled_arrival: 1741660800,
             }]
@@ -442,11 +442,11 @@ describe('schedule API', () => {
       return { ok: false, status: 403, text: async () => 'Forbidden', headers: { get: () => null } };
     });
 
-    const ts = getStartOfDayForHub('LAX');
+    const ts = getStartOfDayForHub('GUM');
     const req = {
       method: 'GET',
       headers: { origin: 'http://localhost:3000' },
-      query: { hub: 'LAX', dir: 'departures', timestamp: String(ts) }
+      query: { hub: 'GUM', dir: 'departures', timestamp: String(ts) }
     };
     const res = createRes();
 
@@ -743,7 +743,7 @@ describe('schedule API', () => {
         scrapingBeeCalls++;
         expect(urlStr).toContain('api_key=bee-test-key');
         expect(urlStr).toContain('premium_proxy=true');
-        expect(urlStr).toContain('render_js=true');
+        expect(urlStr).toContain('render_js=false');
         return {
           ok: true,
           status: 200,


### PR DESCRIPTION
## Summary
- Extend same-day FR24 official schedule rescue to all United hubs, including NRT and GUM.
- Keep cron protected because warmers still pass `officialFallback=0`.
- Change ScrapingBee schedule transport default to `render_js=false` so it burns fewer scraper credits once the ScrapingBee quota is available.

## Why
The production scraper credential is installed, but ScrapingBee currently returns `Monthly API calls limit reached: 1000`. This patch uses the topped-up FR24 credits as an immediate user-facing safety net for all hubs while scraper quota is fixed.

## Tests
- `bun run test tests/schedule.test.js`
- `bun run build`