### PR TITLE
fix(irops): disable paid schedule fallbacks to stop credit burn [audit P0]

### DIFF
--- a/api/irops.ts
+++ b/api/irops.ts
@@ -22,7 +22,21 @@ const BASE_URL = process.env.VERCEL_PROJECT_PRODUCTION_URL
     : 'https://theblueboard.co';
 
 async function fetchHubFromScheduleAPI(hub: string, timestamp: number): Promise<any[]> {
-  const url = `${BASE_URL}/api/schedule?hub=${hub}&dir=departures&timestamp=${timestamp}`;
+  // IROPS only needs aggregate departure counts and tolerates empty per-hub results, so it must
+  // NOT trigger the paid FR24/AeroDataBox/ScrapingBee fallbacks. Disabling them also makes this
+  // request's query string byte-identical to the warm cron's buildScheduleWarmUrl(), so IROPS
+  // reuses cron-warmed CDN snapshots instead of paying to recompute on every miss.
+  // (We replicate the param string inline rather than importing buildScheduleWarmUrl to avoid a
+  // circular import: warm-schedules.ts already imports getStartOfDayForHub from this file.)
+  const params = new URLSearchParams({
+    hub,
+    dir: 'departures',
+    timestamp: String(timestamp),
+    officialFallback: '0',
+    providerFallback: '0',
+    scraperFallback: '0',
+  });
+  const url = `${BASE_URL}/api/schedule?${params}`;
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 55000);
   try {


### PR DESCRIPTION
## Summary (Audit P0 — CRITICAL, category: cost)

The IROPS disruption widget (`api/irops.ts`) fans out **9 `/api/schedule` calls** (one per UA hub) but built the request URL with **no fallback flags**, so `officialFallback` / `providerFallback` / `scraperFallback` all defaulted **ON** (`schedule.ts:1484-1486`).

**Impact:** one uncached `/api/irops` hit could trigger up to 9 cascades of `provider → official FR24 → ScrapingBee` — re-opening the exact paid-credit path the warm cron deliberately closes (`buildScheduleWarmUrl` sends `fallback=0`). The scraper leg has no per-window breaker, so an FR24 Cloudflare/rate-limit event during an IROPS miss could cascade all 9 hubs to paid scraper credits. This is a secondary "weather widget" capable of driving the same FR24 credit exhaustion behind the 2026-05-16 schedule firefight. The IROPS URL also differed from the warm cron's, so it could never reuse the cron-warmed CDN snapshot and always paid to recompute.

## Fix

Build the query string **byte-identical to `buildScheduleWarmUrl()`**:
`&officialFallback=0&providerFallback=0&scraperFallback=0`.

IROPS only needs aggregate departure counts and already tolerates empty per-hub results, so disabling the paid fallbacks is safe. This both **closes the credit path** and lets IROPS **reuse warm CDN snapshots** (identical cache key).

Replicated the param string inline rather than importing `buildScheduleWarmUrl` to **avoid a circular import** (`warm-schedules.ts` already imports `getStartOfDayForHub` from `irops.ts`).

## Verification
- ✅ `tests/irops.test.js` — 53/53 pass
- ✅ `bun run build` — clean
- ✅ `tsc --noEmit` — no new type errors

🤖 Part of a full-sweep audit of theblueboard.co (9 dimensions, 61 findings). This is 1 of 2 CRITICALs.
