### PR TITLE
fix(schedule): never persist an empty board as "complete" truth [audit P0]

### DIFF
--- a/api/_schedule-snapshots.ts
+++ b/api/_schedule-snapshots.ts
@@ -124,6 +124,13 @@ export async function saveScheduleSnapshot({ cacheKey, hub, dir, ts, data }: Sav
   if (!data) return;
 
   const isCompleteSnapshot = !data.partial;
+  // Never persist an empty board (total===0) as a "complete" snapshot. Otherwise a transient
+  // empty 200 is stored in Supabase for the full 72h TTL, served as the degraded "good"
+  // fallback, and reloaded into the in-memory complete cache on every cold start — a
+  // self-sustaining 0-flight board that survives instance recycling. Partial snapshots already
+  // require total>0 via shouldPersistPartialSnapshot; this closes the same gap on the complete
+  // path. (Audit P0: empty-complete-poisons-fallback)
+  if (isCompleteSnapshot && Number(data?.total || 0) === 0) return;
   if (!isCompleteSnapshot && !shouldPersistPartialSnapshot(data)) return;
 
   const supabase = await getSupabaseAdmin();

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -101,6 +101,14 @@ function cacheGetStale(key: string) {
 
 function saveComplete(key: string, data: any, savedAtMs = Date.now()): void {
   if (data.partial) return;
+  // Never record an empty board (total===0) as authoritative "complete" truth. A transient
+  // empty 200 (FR24 throttle interstitial, clean-empty scrape, or the official-priority empty
+  // path) would otherwise be pinned for COMPLETE_CACHE_MAX_AGE, re-served as the "good" degraded
+  // fallback, and reloaded into memory on every cold start via getPersistentFallback — a
+  // self-sustaining 0-flight board. United hubs are never legitimately empty same-day, so
+  // recomputing an empty board is far cheaper than serving a poisoned one.
+  // (Audit P0: empty-complete-poisons-fallback)
+  if (Number(data?.total || 0) === 0) return;
   if (lastCompleteCache.size >= MAX_COMPLETE_CACHE_SIZE) {
     lastCompleteCache.delete(lastCompleteCache.keys().next().value!);
   }


### PR DESCRIPTION
## Summary (Audit P0 — CRITICAL, category: data-correctness)

A transient empty-but-`200` schedule result (an FR24 rate-limit interstitial, a clean-empty scrape, or the official-priority empty path) was being recorded as **authoritative "complete" truth**, because both cache layers gated only on `partial` and never on `total`:

- **`saveComplete()`** (`api/schedule.ts:102`) stored `total:0 / partial:false` into the in-memory `lastCompleteCache` for `COMPLETE_CACHE_MAX_AGE` (~6h).
- **`saveScheduleSnapshot()`** (`api/_schedule-snapshots.ts:123`) persisted it to Supabase for the full `SNAPSHOT_TTL_MS` (**72h**), and `getPersistentFallback()` (`schedule.ts:144`) reloads that snapshot back into the in-memory complete cache on **every cold start**.

**Impact:** one empty `200` becomes a **self-sustaining 0-flight board** — re-served as the "good" degraded fallback and resurrected after every serverless instance recycle until a genuinely-complete fetch overwrites it. This is a textbook cause of the reported persistent 0-flight board, and it *survives the very recovery layers meant to fix it*.

## Fix

Refuse to record `total === 0` as **complete** in both layers (a one-line guard each). United hubs are never legitimately empty same-day, so recomputing an empty board is far cheaper than pinning a poisoned one. Partial snapshots already require `total > 0` via `shouldPersistPartialSnapshot`; this closes the same gap on the complete path.

**Response semantics are unchanged** — the empty result is still returned for the current request; it just isn't cached or persisted as truth.

## Verification
- ✅ `tests/schedule.test.js` (30) + `tests/schedule-snapshots.test.js` (19) + `tests/warm-schedules.test.js` (7) — all pass
- ✅ existing "returns valid empty result when official API returns 0 flights" test still green (guard affects caching, not the response)
- ✅ `bun run build` clean, `tsc --noEmit` no new errors

🤖 Part of a full-sweep audit of theblueboard.co. This is 2 of 2 CRITICALs (pairs with #165).
