### PR TITLE
fix(schedule): re-enable same-day rescues before 6 AM (client/server day mismatch) [audit P1]

### DIFF
--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -10,6 +10,7 @@ import {
 import { getStartOfDayForHub } from './irops.js';
 import { waitUntil } from '@vercel/functions';
 import { icaoToIata, isInternationalRoute } from '../src/lib/airport-metadata.js';
+import { getStartOfHubDay } from '../src/lib/hubTz.js';
 
 const isRateLimited = createRateLimiter('schedule', 30);
 
@@ -180,8 +181,14 @@ function shouldAttemptTargetedOfficialRescue(hub: string, ts: number, options?: 
   const hubUpper = hub.toUpperCase();
   if (!TARGETED_OFFICIAL_RESCUE_HUBS.has(hubUpper)) return false;
 
+  // Accept BOTH the IROPS display value (getStartOfDayForHub rolls back to yesterday before 6 AM
+  // hub-local) AND the canonical hub-local start-of-today the dashboard actually sends
+  // (getStartOfHubDay(hub, 0)). Before 6 AM the two differ, which previously disabled this
+  // same-day official rescue for the genuinely-current board — and because the 9 hubs span 6
+  // timezones, some hub is always in that dead-zone. Widening only: never suppresses a rescue.
+  // (Audit P1: client/server start-of-day divergence.)
   const startOfToday = getStartOfDayForHub(hubUpper);
-  return ts === startOfToday;
+  return ts === startOfToday || ts === getStartOfHubDay(hubUpper, 0);
 }
 
 function cacheSet(key: string, data: any, ttlMs: number): void {
@@ -532,7 +539,9 @@ function isLiveFeedFallbackEnabled(): boolean {
 function shouldAttemptLiveFeedFallback(hub: string, ts: number): boolean {
   if (!isLiveFeedFallbackEnabled()) return false;
   const hubUpper = hub.toUpperCase();
-  return ts === getStartOfDayForHub(hubUpper);
+  // Same start-of-day fix as the official rescue gate: also accept the dashboard's canonical
+  // hub-local today, so the no-credit live-feed rescue isn't disabled before 6 AM hub-local.
+  return ts === getStartOfDayForHub(hubUpper) || ts === getStartOfHubDay(hubUpper, 0);
 }
 
 function toFiniteNumber(value: any): number | null {


### PR DESCRIPTION
## Summary (Audit P1 — HIGH, category: data-correctness)

The two same-day FR24 rescue gates compared the client-sent `ts` against `getStartOfDayForHub()` (`api/irops.ts`), which **rolls back to yesterday before 6 AM hub-local** (so the IROPS widget shows yesterday's completed ops overnight). But the dashboard builds its request with `getStartOfHubDay(hub, 0)` (`src/lib/hubTz.js`) — **no rollback**.

**Impact:** from `00:00–05:59` hub-local, the client's real-"today" `ts` never equals the gate's rolled-back value, so **both** rescues are silently disabled for the board the user sees as "today":
- `shouldAttemptTargetedOfficialRescue` (`schedule.ts:183`)
- `shouldAttemptLiveFeedFallback` (`schedule.ts:535`)

The 9 hubs span 6 timezones, so *some* hub is always inside its `00:00–05:59` dead-zone — the effect is effectively continuous, and it fires precisely when the early-morning scrape most often returns empty/blocked.

## Fix

Have both gates **also accept** the canonical hub-local start-of-today that the dashboard actually sends (`getStartOfHubDay(hub, 0)`). **Widening only** — anything that matched before still matches, so no rescue is ever suppressed; we only stop *wrongly rejecting* the genuinely-current board. The 6 AM display shift stays in the IROPS layer where it belongs.

## Verification
- ✅ `tests/schedule.test.js` (30) + `tests/hubTz.test.js` (34) + `tests/irops.test.js` (53) — all pass
- ✅ build clean, `tsc --noEmit` no new errors

**Follow-up** (for the test-hardening PR): add a pre-6 AM regression test asserting both gates return `true` for `getStartOfHubDay(hub,0)`.

🤖 Part of the full-sweep audit of theblueboard.co (P1 wave).
