### PR TITLE
fix(otp): exclude degraded synthetic rows from hub-health on-time math [audit P1]

### DIFF
--- a/api/irops.ts
+++ b/api/irops.ts
@@ -77,6 +77,13 @@ export function computeMetrics(flightsByHub: Record<string, any[]>) {
       const schedT = fl.time?.scheduled?.departure;
       if (!schedT) continue;
 
+      // Exclude degraded synthetic rows (live-feed rescue / schedule-derived-from-actual): their
+      // scheduled time equals the actual, so they always score on-time and inflate hub OTP exactly
+      // when the FR24 feed is degraded — mirrors the dashboard's per-board exclusion.
+      // (Audit P1: degraded-rows-inflate-hub-otp.)
+      if (fl._source?.liveFeedFallback) continue;
+      if (fl._source?.scheduleTimeDerivedFromActual?.departure || fl._source?.scheduleTimeDerivedFromActual?.arrival) continue;
+
       hubMetrics[hub].operated++;
       if (realDep <= schedT + 1800) {
         hubMetrics[hub].onTime++;

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -4440,6 +4440,13 @@ function updateHubHealth() {
       const status = classifySchedStatus(fl);
       const hasOp = status.key === 'departed' || status.key === 'enroute' || status.key === 'landed';
       if (!hasOp) return;
+      // Exclude degraded synthetic rows, exactly as the per-board OTP card does (updateSchedStats):
+      // live-feed rescue rows carry last-seen/ETA times (not a true schedule baseline), and rows
+      // whose schedule time was derived from the actual time always score on-time (delay 0) —
+      // inflating hub OTP toward 100% precisely when the FR24 feed is degraded.
+      // (Audit P1: degraded-rows-inflate-hub-otp.)
+      if (fl._source?.liveFeedFallback) return;
+      if (fl._source?.scheduleTimeDerivedFromActual?.departure || fl._source?.scheduleTimeDerivedFromActual?.arrival) return;
       const schedT = fl.time?.scheduled?.departure || fl.time?.scheduled?.arrival;
       const realT = fl.time?.real?.departure || fl.time?.real?.arrival;
       if (!realT || !schedT) return; // skip flights without real timestamps


### PR DESCRIPTION
## Summary (Audit P1 — HIGH, data-correctness)

The per-board OTP card (`updateSchedStats`, `main.js:4068-4083`) **correctly** excludes degraded rows, but the two **aggregate** on-time calculators did not — so they counted synthetic rows where `scheduled === actual` (delay 0 → always "on time").

**Impact:** the headline **hub-health OTP** was inflated toward 100% precisely during the FR24-degraded scenario where the live-feed fallback fires, and the per-board card and the hub-health strip visibly **disagreed on one screen**. The numbers users trust most were wrong exactly when ops were worst.

## Fix

Mirror the per-board card's exclusions in both aggregators:
- **`src/dashboard/main.js` `updateHubHealth`**: skip `fl._source.liveFeedFallback` rows (last-seen/ETA times, not a schedule baseline) and `fl._source.scheduleTimeDerivedFromActual` rows before counting `operated`/`onTime`.
- **`api/irops.ts` `computeMetrics`**: same exclusion before `hubMetrics[hub].operated++`.

The flags are already set by `normalizeSummaryFlight`/`normalizeLiveFeedFlight`, so this only removes synthetic zero-delay rows; real operated flights are unaffected.

## Verification
- ✅ `tests/irops.test.js` (53) + `tests/delay-risk.test.js` (10) pass
- ✅ build clean, no new type errors

🤖 Part of the full-sweep audit of theblueboard.co (non-conflicting wave).
