### PR TITLE
fix(delivery): stop pinning stale dashboard.js/css so deploys reach users [audit critic #1]

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v8';
+const CACHE_VERSION = 'v9'; // bumped to purge the v8 precache that pinned the old dashboard.js / style.css
 const PAGE_CACHE = `blueboard-pages-${CACHE_VERSION}`;
 const DATA_CACHE = `blueboard-data-${CACHE_VERSION}`;
 const STATIC_CACHE = `blueboard-static-${CACHE_VERSION}`;
@@ -8,7 +8,10 @@ const PAGE_MAX = 20;
 const DATA_MAX = 80;
 const STATIC_MAX = 120;
 
-const APP_SHELL = ['/', '/index.html', '/css/style.css?v=1', '/js/dashboard.js'];
+// Only the navigation shell is precached. The app's own code (dashboard.js / style.css) is served
+// network-first in the fetch handler so a new deploy reaches returning users immediately, instead
+// of being pinned here until CACHE_VERSION is manually bumped. (Audit critic #1.)
+const APP_SHELL = ['/', '/index.html'];
 
 async function trimCache(cacheName, maxEntries) {
   const cache = await caches.open(cacheName);
@@ -109,6 +112,33 @@ self.addEventListener('fetch', (event) => {
           status: 503,
           headers: { 'content-type': 'application/json' }
         });
+      }
+    })());
+    return;
+  }
+
+  // The app's own code (dashboard bundle + stylesheet) is NOT content-hashed, so serve it
+  // network-first: always fetch the latest when online so shipped fixes reach returning users,
+  // falling back to cache only when offline. Other static assets (fonts, images) stay
+  // stale-while-revalidate below. (Audit critic #1: immutable + non-hashed + SW precache pinning
+  // meant deploys never reached users.)
+  const isAppCode = url.pathname === '/js/dashboard.js' || url.pathname === '/css/style.css';
+  if (isAppCode) {
+    event.respondWith((async () => {
+      try {
+        const networkResponse = await fetch(new Request(request, { cache: 'no-cache' }));
+        if (isCacheable(networkResponse)) {
+          event.waitUntil((async () => {
+            const cache = await caches.open(STATIC_CACHE);
+            await cache.put(request, networkResponse.clone());
+            await trimCache(STATIC_CACHE, STATIC_MAX);
+          })());
+        }
+        return networkResponse;
+      } catch (_err) {
+        const cached = await caches.match(request);
+        if (cached) return cached;
+        return new Response('Offline', { status: 503, headers: { 'content-type': 'text/plain' } });
       }
     })());
     return;

--- a/vercel.json
+++ b/vercel.json
@@ -102,13 +102,13 @@
     {
       "source": "/css/(.*)",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }
       ]
     },
     {
       "source": "/js/(.*)",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }
       ]
     }
   ]


### PR DESCRIPTION
## Summary (Audit critic #1 — HIGH, delivery)

The dashboard bundle (`public/js/dashboard.js`) and stylesheet (`style.css`) are **not content-hashed** (the vite lib build uses a fixed `fileName`), yet they were served `Cache-Control: public, max-age=31536000, immutable` **and** precached in the service-worker `APP_SHELL` (only refreshed on a manual `CACHE_VERSION` bump).

**Impact:** a new deploy of `dashboard.js`/`style.css` could not reach a returning visitor until **both** the 1-year immutable HTTP cache expired **and** `CACHE_VERSION` changed. Shipped fixes silently never landed for existing users — a primary reason the firefighting "didn't stick."

## Fix (two coordinated parts, no content-hashing plumbing needed)

- **`vercel.json`**: serve `/js` and `/css` as `public, max-age=0, must-revalidate` → browsers/CDN revalidate via ETag (304 when unchanged, fresh bytes on deploy). Immutable should only be used with hashed URLs.
- **`public/sw.js`**: serve the app's own `dashboard.js`/`style.css` **network-first** (latest when online, cache only offline); **remove them from the precached `APP_SHELL`** so they're no longer pinned; **bump `CACHE_VERSION` v8→v9** to purge the stale v8 precache once. Fonts/images keep stale-while-revalidate.

## Verification
- ✅ `vercel.json` valid JSON; `public/sw.js` parses (`node --check`)
- ✅ `tests/csp.test.js` (9) pass; no test asserted the old `immutable` value
- ✅ `bun run build` clean

**Follow-up:** true content-hashing (`dashboard.[hash].js`) would let us restore long-lived `immutable` caching — best done by extending `scripts/stamp-seo-build-date.mjs` to rewrite the asset refs in `dist/index.html` + `dist/sw.js`.

🤖 Part of the full-sweep audit of theblueboard.co (non-conflicting wave).
