### PR TITLE
chore(ci): add type-check gate + fix prewarm-cache.ts top-level await [audit P2]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,5 +17,6 @@ jobs:
         with:
           bun-version: '1.3.11'
       - run: bun install --frozen-lockfile
+      - run: bun run typecheck
       - run: bun run test
       - run: bun run build

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "seed:schedules": "bun scripts/seed-schedules.mjs",
     "test": "bunx vitest run",
     "test:watch": "bunx vitest",
+    "typecheck": "tsc --noEmit",
     "ui-audit": "bun scripts/ui-audit.mjs"
   },
   "dependencies": {

--- a/scripts/prewarm-cache.ts
+++ b/scripts/prewarm-cache.ts
@@ -3,6 +3,10 @@
 // Run every 4-6 hours via cron to keep schedule endpoints hot
 // This ensures real users always hit CDN cache, never cold serverless functions
 
+// Marks this file as an ES module so TypeScript permits the top-level `await` below (fixes
+// TS1375). Harmless at runtime under `bun scripts/prewarm-cache.ts`.
+export {};
+
 const BASE = "https://theblueboard.co/api";
 const HUBS = ["ORD", "DEN", "IAH", "EWR", "SFO", "LAX", "IAD", "NRT", "GUM"];
 const DIRS = ["departures", "arrivals"];


### PR DESCRIPTION
## Summary (Audit P2 — build/CI hardening)

CI ran install/test/build but **never type-checked**, so the `TS1375` error in `scripts/prewarm-cache.ts` (top-level `await` in a non-module file) shipped to `main` unnoticed — and any future type regression in `api/*.ts` would too.

## Changes
- **`scripts/prewarm-cache.ts`**: add `export {};` so it's an ES module (permits the top-level `await`). Harmless at runtime under bun.
- **`package.json`**: add `"typecheck": "tsc --noEmit"`.
- **`.github/workflows/test.yml`**: run `bun run typecheck` before tests.

## Verification
- ✅ `bun run typecheck` → exit 0 (gate is green)
- ✅ `bun run build` clean

**Follow-ups:** `astro check` for `.astro` files (heavier separate tool); converting the 44s real-timer `schedule.test.js` to fake timers for CI speed.

🤖 Part of the full-sweep audit of theblueboard.co (non-conflicting wave).
