### PR TITLE
chore(deps): upgrade typescript to 6.0.3 [audit]

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
         "@types/bun": "^1.3.11",
         "@vercel/node": "^5.6.12",
         "playwright": "^1.58.2",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vitest": "^3.0.0",
       },
     },
@@ -940,7 +940,7 @@
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 
@@ -1037,6 +1037,8 @@
     "@ts-morph/common/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "@vercel/nft/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@vercel/node/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@vercel/python-analysis/smol-toml": ["smol-toml@1.5.2", "", {}, "sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ=="],
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/bun": "^1.3.11",
     "@vercel/node": "^5.6.12",
     "playwright": "^1.58.2",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^3.0.0"
   }
 }

--- a/scripts/prewarm-cache.ts
+++ b/scripts/prewarm-cache.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+/// <reference types="bun" />
 // Prewarm Vercel CDN cache for schedule data
 // Run every 4-6 hours via cron to keep schedule endpoints hot
 // This ensures real users always hit CDN cache, never cold serverless functions


### PR DESCRIPTION
## Summary
Upgrades the `typescript` devDependency from `^5.9.3` to `^6.0.3` (latest major, 6.x).

This is a dev-only dependency (`devDependencies`), so there is no runtime impact. The risk is that TS 6 ships stricter checks that could break the `bun run typecheck` gate.

## Breaking change handled
TS 6.0 changed global-type auto-inclusion behavior. After the bump, `bun run typecheck` failed with a single error:

```
scripts/prewarm-cache.ts(40,11): error TS2868: Cannot find name 'Bun'.
```

In TS 5.x the global `Bun` namespace from `@types/bun` (which re-exports `bun-types`) was auto-resolved; TS 6 no longer surfaces it the same way for this file.

**Fix (minimal, behavior-preserving):** added a single `/// <reference types="bun" />` triple-slash directive to `scripts/prewarm-cache.ts` — the only file in the repo that uses the global `Bun` (`Bun.sleep`).

A repo-wide `compilerOptions.types: ["bun"]` in `tsconfig.json` was deliberately **avoided**: an explicit `types` array disables auto-inclusion of `@types/node`, which would have broken the `process.*` ambient globals used across 18+ files in `api/`. The targeted directive restores the `Bun` global only where it is needed and leaves all other ambient typing untouched.

## Files changed
- `package.json` — `typescript` `^5.9.3` → `^6.0.3` (only this dep touched)
- `bun.lock` — refreshed (`@vercel/node` keeps its own nested `typescript@5.9.3` transitive; not upgraded)
- `scripts/prewarm-cache.ts` — one-line `/// <reference types="bun" />`

## Verification — all green (exit 0)
| Gate | Command | Result |
|------|---------|--------|
| Typecheck | `bun run typecheck` | exit 0 |
| Tests | `bun run test` | 581 tests / 41 files passed, exit 0 |
| Build | `bun run build` | vite dashboard + astro (38 pages) + seo stamp, exit 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)