### PR TITLE
chore(deps): upgrade @anthropic-ai/sdk to 0.100.1 [audit]

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "the-blue-board",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.78.0",
+        "@anthropic-ai/sdk": "^0.100.1",
         "@supabase/supabase-js": "^2.49.1",
         "@vercel/functions": "^3.4.3",
         "@vercel/speed-insights": "^2.0.0",
@@ -24,7 +24,7 @@
     },
   },
   "packages": {
-    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.78.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w=="],
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.100.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg=="],
 
     "@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ui-audit": "bun scripts/ui-audit.mjs"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.78.0",
+    "@anthropic-ai/sdk": "^0.100.1",
     "@supabase/supabase-js": "^2.49.1",
     "@vercel/functions": "^3.4.3",
     "@vercel/speed-insights": "^2.0.0",


### PR DESCRIPTION
## Version bump
Upgrades `@anthropic-ai/sdk` from `^0.78.0` to `^0.100.1` (latest). It lives in `dependencies`. No other dependency was touched.

## Breaking changes handled
None required. The only consumer is `api/delay-explain.ts` (`messages.create`), and its call shape is fully compatible with 0.100.1:
- Constructor `new Anthropic({ apiKey })` unchanged.
- `client.messages.create(body, { signal })` signature unchanged — `RequestOptions` still exposes `signal` (used for the 12s AbortController timeout).
- Params `model` / `max_tokens` / `system` / `messages` unchanged on `MessageCreateParamsNonStreaming`.
- Model id `claude-haiku-4-5` is still a valid `Model` in 0.100.1.
- Response access `message.content[0].type === 'text'` / `.text` unchanged.

Note: 0.100.1 declares an **optional** `zod` peer dependency (`optionalPeers: ["zod"]`), so no install or code change is needed.

## Verification (all green)
- `bun run typecheck` → exit 0
- `bun run test` → 581 passed (41 files), including `tests/delay-explain.test.js` (14) and `tests/delay-explain-context.test.js` (4)
- `bun run build` → exit 0 (vite dashboard build + astro build + seo stamp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)