### PR TITLE
fix(schedule): make the FR24 402 quota block global across instances [audit P1 — credit-drain cure]

### DIFF
--- a/api/_cost-state.ts
+++ b/api/_cost-state.ts
@@ -1,0 +1,93 @@
+// Global cost-guard state shared across serverless instances via Supabase.
+//
+// Currently tracks the FR24 official-API quota block (402 "credit limit reached"). Once ANY lambda
+// hits the credit ceiling, every other lambda should also stop calling the paid official API until
+// the block expires. Without a shared store, each cold instance independently re-discovers the 402,
+// so real spend scales with instance fan-out (N x the intended per-instance 30-min block).
+// (Audit P1/HIGH: per-lambda cost guards do not bound global spend under Vercel fan-out.)
+//
+// Design: the schedule hot path makes SYNC guard checks, so we mirror the global block into an
+// in-memory value rather than awaiting Supabase per request. The async handler calls
+// hydrateQuotaBlock() (internally rate-limited to one read per HYDRATE_TTL_MS) before its
+// official-fallback decisions, and persistQuotaBlock() write-through fires when a 402 is hit.
+// Every Supabase interaction is fully guarded: any failure (unavailable, migration not applied, or
+// a test that mocks away the client) degrades to in-memory-only — behaviour is never worse than the
+// prior per-instance guard.
+
+import { getSupabaseAdmin } from './_schedule-snapshots.js';
+
+const COST_KEY = 'official_quota_block';
+const HYDRATE_TTL_MS = 10_000;
+
+let mirroredBlockedUntil = 0; // global block (epoch ms) as last read from / written to Supabase
+let lastHydratedAt = 0;
+
+/** The latest global quota block (epoch ms) known to this instance. Sync; safe in the hot path. */
+export function getMirroredQuotaBlockedUntil(): number {
+  return mirroredBlockedUntil;
+}
+
+/** Clear the in-memory mirror. Used by schedule.ts's resetFallbackBreaker() so module state does
+ *  not leak across tests (production never calls it). */
+export function resetMirroredQuotaBlock(): void {
+  mirroredBlockedUntil = 0;
+  lastHydratedAt = 0;
+}
+
+/**
+ * Pull the latest global quota block from Supabase into the in-memory mirror, at most once per
+ * HYDRATE_TTL_MS. Returns the (possibly updated) mirrored value. Never throws; on any failure it
+ * returns the current in-memory value so callers degrade to per-instance behaviour.
+ */
+export async function hydrateQuotaBlock(): Promise<number> {
+  const now = Date.now();
+  if (now - lastHydratedAt < HYDRATE_TTL_MS) return mirroredBlockedUntil;
+  lastHydratedAt = now;
+
+  try {
+    const supabase = typeof getSupabaseAdmin === 'function' ? await getSupabaseAdmin() : null;
+    if (!supabase) return mirroredBlockedUntil;
+
+    const { data, error } = await supabase
+      .from('schedule_cost_state')
+      .select('blocked_until')
+      .eq('key', COST_KEY)
+      .limit(1);
+    if (error) {
+      console.error('cost-state read failed:', error.message);
+      return mirroredBlockedUntil;
+    }
+    const row = (data as Array<{ blocked_until: string | null }> | null)?.[0];
+    const until = row?.blocked_until ? Date.parse(row.blocked_until) : 0;
+    if (Number.isFinite(until)) mirroredBlockedUntil = Math.max(mirroredBlockedUntil, until);
+    return mirroredBlockedUntil;
+  } catch (error: any) {
+    console.error('cost-state read threw:', error?.message || error);
+    return mirroredBlockedUntil;
+  }
+}
+
+/**
+ * Write-through a new quota block so other instances honour it on their next hydrate. Fire-and-
+ * forget from the caller's perspective; never throws.
+ */
+export async function persistQuotaBlock(blockedUntilMs: number, reason: string): Promise<void> {
+  mirroredBlockedUntil = Math.max(mirroredBlockedUntil, blockedUntilMs);
+
+  try {
+    const supabase = typeof getSupabaseAdmin === 'function' ? await getSupabaseAdmin() : null;
+    if (!supabase) return;
+
+    const { error } = await supabase
+      .from('schedule_cost_state')
+      .upsert({
+        key: COST_KEY,
+        blocked_until: new Date(blockedUntilMs).toISOString(),
+        reason: String(reason || '').slice(0, 500),
+        updated_at: new Date().toISOString(),
+      }, { onConflict: 'key' });
+    if (error) console.error('cost-state write failed:', error.message);
+  } catch (error: any) {
+    console.error('cost-state write threw:', error?.message || error);
+  }
+}

--- a/api/_schedule-snapshots.ts
+++ b/api/_schedule-snapshots.ts
@@ -70,7 +70,7 @@ function getSupabaseConfig(): { url: string; key: string } | null {
   return { url, key };
 }
 
-async function getSupabaseAdmin(): Promise<any | null> {
+export async function getSupabaseAdmin(): Promise<any | null> {
   const config = getSupabaseConfig();
   if (!config) return null;
   if (!supabaseClientPromise) {

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -1,6 +1,7 @@
 import type { VercelRequest, VercelResponse } from './types.js';
 import { createRateLimiter } from './_rate-limit.js';
 import { loadScheduleSnapshot, saveScheduleSnapshot } from './_schedule-snapshots.js';
+import { hydrateQuotaBlock, getMirroredQuotaBlockedUntil, persistQuotaBlock, resetMirroredQuotaBlock } from './_cost-state.js';
 import { fetchViaAeroDataBox } from './_schedule-aerodatabox.js';
 import {
   FR24_SCHEDULE_HEADERS,
@@ -531,12 +532,16 @@ function parseRetryAfterMs(headerValue: string | null): number {
 }
 
 function isOfficialQuotaBlocked(): boolean {
-  return Date.now() < officialQuotaBlockedUntil;
+  // Honour BOTH this instance's block and the global block mirrored from Supabase, so a 402 hit by
+  // any other lambda also stops this one from calling the paid official API. (Audit: global guard.)
+  return Date.now() < Math.max(officialQuotaBlockedUntil, getMirroredQuotaBlockedUntil());
 }
 
 function blockOfficialQuota(reason: string): void {
   officialQuotaBlockedUntil = Date.now() + OFFICIAL_QUOTA_BLOCK_MS;
   console.warn(`Official FR24 API quota blocked for 30m: ${reason}`);
+  // Propagate the block to all other instances (fire-and-forget; never throws).
+  void persistQuotaBlock(officialQuotaBlockedUntil, reason);
 }
 
 function isLiveFeedFallbackEnabled(): boolean {
@@ -1132,6 +1137,7 @@ export function resetFallbackBreaker(): void {
   officialQuotaBlockedUntil = 0;
   liveFeedCache = null;
   liveFeedInFlight = null;
+  resetMirroredQuotaBlock();
 }
 
 async function tryOfficialFallback(
@@ -1477,6 +1483,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   try {
     const functionDeadline = Date.now() + 57000;
+
+    // Pull the latest cross-instance FR24 quota block (rate-limited to ~one read per 10s) so a 402
+    // "credit limit reached" hit by ANY other lambda is honoured here before we decide to call the
+    // paid official API. (Audit P1: per-lambda cost guards do not bound global spend.)
+    await hydrateQuotaBlock();
 
     const { hub, dir = 'departures', timestamp, page } = req.query as Record<string, string>;
     if (!hub || !timestamp) {

--- a/sql/007_schedule_cost_state.sql
+++ b/sql/007_schedule_cost_state.sql
@@ -1,0 +1,19 @@
+-- Global cost-guard state shared across serverless instances.
+--
+-- Today it holds the FR24 official-API quota block ("402 — credit limit reached") so that once ANY
+-- lambda hits the credit ceiling, ALL lambdas stop calling the paid official API until the block
+-- expires. Without a shared store, every cold instance independently re-discovers the 402, so real
+-- spend scales with instance fan-out (N × the intended per-instance cap). See api/_cost-state.ts.
+--
+-- Written only by the service-role key (server-side); the anon client has no access.
+
+CREATE TABLE schedule_cost_state (
+  key TEXT PRIMARY KEY,
+  blocked_until TIMESTAMPTZ,
+  reason TEXT,
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Cost state is server-internal. Enable RLS with no policies so only the service-role key (which
+-- bypasses RLS) can read/write; the anon key is denied entirely.
+ALTER TABLE schedule_cost_state ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary (Audit P1 — HIGH, cost) — the systemic credit-drain fix

The official-API cost guards lived in **per-lambda module memory**, so on Vercel's fan-out they bounded nothing globally: each cold instance independently re-discovered the `402 "credit limit reached"`, and the 30-minute block one instance set **never propagated** to the others — real spend scaled with instance count (N × the intended cap). This is a core driver of the credit-drain firefight.

This makes the **402 quota block global** via the existing Supabase service-role layer, **without** turning the sync hot-path guard checks async (which would ripple through the whole fetch orchestration):

- **`api/_cost-state.ts`** (new): mirrors the global block into an in-memory value. `hydrateQuotaBlock()` reads it (rate-limited to ~one Supabase read per 10s); `persistQuotaBlock()` write-throughs when a 402 is hit. **Every** Supabase call is fully guarded — if Supabase is unavailable, the migration isn't applied, or a test mocks the client away, it degrades to the prior **per-instance** behaviour (never worse).
- **`api/schedule.ts`**: handler `await`s `hydrateQuotaBlock()` before fallback decisions; `isOfficialQuotaBlocked()` honours `max(local, mirrored)`; `blockOfficialQuota()` write-throughs; `resetFallbackBreaker()` also clears the mirror (test hygiene).
- **`api/_schedule-snapshots.ts`**: export `getSupabaseAdmin()` for reuse.
- **`sql/007_schedule_cost_state.sql`**: new table (RLS on, service-role only).

## ⚠️ Action required
Apply **`sql/007_schedule_cost_state.sql`** to the Supabase project. Until then this PR is a **safe no-op** (per-instance behaviour, exactly as today).

## Scope
Globalizes the **402 quota block** (the direct money-protector). Globalizing the 5-per-15-min circuit breaker (`fallbackLog`) is a noted **follow-up** (it needs a shared sliding window; the quota block is the higher-leverage half).

## Verification
- ✅ **581 tests pass** (41 files); the schedule 402-path suite green
- ✅ `bun run typecheck` exit 0; `bun run build` clean
- ✅ Graceful-degradation verified: with the snapshot module mocked (no `getSupabaseAdmin`), hydrate/persist no-op via a `typeof` guard

🤖 Part of the full-sweep audit of theblueboard.co (the systemic root-cause fix).
