### PR TITLE
chore(infra): pin Node 24, bump Bun to 1.3.14, align CI [audit]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.11'
+          bun-version: '1.3.14'
       - run: bun install --frozen-lockfile
       - run: bun run typecheck
       - run: bun run test

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
   "private": true,
   "type": "module",
   "version": "1.5.14",
-  "packageManager": "bun@1.3.11",
+  "packageManager": "bun@1.3.14",
+  "engines": {
+    "node": "24.x"
+  },
   "scripts": {
     "dev": "bun scripts/run-astro-dev.mjs",
     "build": "vite build --config vite.dashboard.config.js && astro build && bun scripts/stamp-seo-build-date.mjs",


### PR DESCRIPTION
## Summary (Audit: node-version-unpinned + Bun toolchain update)

Toolchain/runtime reproducibility, plus the Bun bump you flagged:

- **`package.json`**: add `engines.node: "24.x"` (the project runs Node 24 — makes the deployed runtime explicit/reviewable, fixing the `nodejs21`-vs-`node24` drift the audit flagged) and bump pinned **Bun 1.3.11 → 1.3.14**.
- **`.github/workflows/test.yml`**: align CI to **node 24** (was 20 — didn't match prod) and **bun 1.3.14** (was 1.3.11).

**Why the Bun bump matters beyond freshness:** the dependency-upgrade PRs regenerated `bun.lock` with Bun **1.3.14** locally, while CI ran `bun install --frozen-lockfile` on **1.3.11** — a lockfile-format mismatch could fail CI. Aligning both removes that.

## Verification
- ✅ `bun install --frozen-lockfile` exit 0 under 1.3.14
- ✅ `bun run typecheck` exit 0; `bun run build` clean

## Follow-up (separate api-hardening pass — audit PR9 remainder)
fleet/metar error content-type consistency + stale fallback; faa per-instance backoff doc/removal; sync-starlink `globalThis` cron persistence; refresh-tsa self-fetch hardening; check/predict upstream-status normalization to 502.

🤖 Part of the full-sweep audit of theblueboard.co.
