### PR TITLE
fix(schedule): 120s CDN TTL for degraded-but-nonempty boards (cut re-scrape/credit burn) [audit P7]

### DIFF
--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -209,8 +209,13 @@ function cacheSet(key: string, data: any, ttlMs: number): void {
 
 function setAggregateCacheHeader(res: VercelResponse, data: any, cdnMaxAge: number, swr: number): void {
   const isPartial = data?.partial === true;
-  const maxAge = isPartial ? 30 : cdnMaxAge;
-  const stale = isPartial ? 60 : swr;
+  const total = Number(data?.total || 0);
+  // A degraded-but-NON-EMPTY board is still useful to show; re-validating it every 30s at the CDN
+  // just hammers FR24 and burns paid fallback credits during a block. Serve it for 120s and only
+  // fall back to the aggressive 30s window when the partial board is also EMPTY (total===0), where
+  // fast recovery matters more than cost. (Audit P7: partial-response-short-cdn-ttl-rescrape-loop.)
+  const maxAge = isPartial ? (total > 0 ? 120 : 30) : cdnMaxAge;
+  const stale = isPartial ? (total > 0 ? 120 : 60) : swr;
   res.setHeader('Cache-Control', `s-maxage=${maxAge}, stale-while-revalidate=${stale}`);
 }
 

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -1319,7 +1319,9 @@ describe('schedule API', () => {
         })
       })
     }));
-    expect(res.headers['Cache-Control']).toContain('s-maxage=30');
+    // Partial-but-NON-EMPTY boards now get a 120s CDN TTL (not 30s) so a degraded board isn't
+    // re-scraped every 30s during an FR24 block. 30s is reserved for partial AND empty. (Audit P7.)
+    expect(res.headers['Cache-Control']).toContain('s-maxage=120');
   });
 
   it('scrape-first: rate-limited mid-loop pauses and continues fetching', { timeout: 15000 }, async () => {


### PR DESCRIPTION
## Summary (Audit P7 — MEDIUM, cost)

Partial (degraded) schedule responses got a flat **30s** CDN `s-maxage` regardless of whether they had flights. During an FR24 block — exactly when paid fallbacks fire — a degraded-but-**populated** board was re-validated every 30s, turning one block into a high-frequency re-scrape + paid-fallback loop (the FR24 `402` credit exhaustion we just saw live).

`setAggregateCacheHeader` now serves a partial board **with flights (total>0)** for **120s** (and 120s SWR), keeping the aggressive 30s only for partial **AND empty** boards (where fast recovery beats cost). Complete boards unchanged. Updated the one test that asserted the old flat 30s for a nonempty-partial case.

**Scope:** the highest-leverage, fully-testable cost tweak. Other PR7 items (serve partial-stale within grace, scrape-tail early-stop, live-feed estimate UI labeling, AeroDataBox inclusive-seconds + breaker) are follow-ups — the AeroDataBox datetime-format change is unverifiable without a provider key, so it was left out.

## Verification
- ✅ 581 tests pass; build clean; typecheck exit 0

🤖 Part of the full-sweep audit of theblueboard.co.