### PR TITLE
fix(schedule): escalate empty-200 scrapes to the official API — fixes degraded/stale boards

### DIFF
--- a/api/_rate-limit.ts
+++ b/api/_rate-limit.ts
@@ -55,3 +55,14 @@ export function createRateLimiter(name: string, maxPerMinute: number = 60): (req
     return false;
   };
 }
+
+/**
+ * Test helper: clear all in-memory rate-limit state. Without this, every test request shares the
+ * same `unknown` IP bucket and the per-60s window accumulates across a suite run, intermittently
+ * tipping later tests into a spurious 429. Production never calls this.
+ */
+export function __resetRateLimitersForTests(): void {
+  // Clear each named store's per-IP buckets, but keep the store entries themselves — the limiter
+  // closure captured by createRateLimiter does `stores.get(name)!` and assumes the entry exists.
+  for (const [, store] of stores) store.clear();
+}

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -1145,6 +1145,17 @@ export function resetFallbackBreaker(): void {
   resetMirroredQuotaBlock();
 }
 
+/**
+ * Test helper: clear the in-memory schedule caches so a board cached by one test does not leak
+ * into another that happens to use the same hub/dir/day cache key. Production never calls this.
+ */
+export function __resetScheduleCachesForTests(): void {
+  cache.clear();
+  lastCompleteCache.clear();
+  lastCompleteByHubDir.clear();
+  pendingAggs.clear();
+}
+
 async function tryOfficialFallback(
   logHub: string, dir: string, ts: number, effectiveDeadline: number
 ): Promise<any | null> {
@@ -1446,6 +1457,25 @@ async function fetchAllPages(
       scraperRecoveredPages,
     }
   };
+
+  // An empty-but-200 scrape for a same-day TARGETED United hub is never legitimate: United always
+  // has a full day of flights, so a clean HTTP 200 with 0 rows (no 403/429/cf-mitigated) almost
+  // always means FR24/Cloudflare returned a soft-blocked empty schedule page to our datacenter IP.
+  // The official-rescue gate just below requires `partial`, but a clean empty page leaves
+  // partial=false, so official was never attempted and the board fell through to a stale live-feed
+  // snapshot. Mark it partial so it enters the rescue and fetches the FULL day from the paid FR24
+  // official API. Scoped to allowTargetedOfficialRescue (the 9 hubs, FR24 token present, current
+  // day, and USER requests only — the warm cron passes officialFallback=0 so allowTargetedOfficial-
+  // Rescue is false there), keeping background credit spend untouched and the breaker/402 cap in
+  // force. (Audit: empty-200 scrape treated as authoritative-empty, bypassing official rescue.)
+  if (scrapeResult.total === 0 && !scrapeResult.partial && allowTargetedOfficialRescue) {
+    scrapeResult.partial = true;
+    scrapeResult.meta = {
+      ...(scrapeResult.meta as any),
+      partialReason: 'empty_200_suspected_block',
+      completeness: 0,
+    };
+  }
 
   let attemptedOfficialRescue = false;
   if (

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -12,8 +12,9 @@ const vercelFunctionMocks = vi.hoisted(() => ({
 vi.mock(process.cwd() + '/api/_schedule-snapshots.ts', () => scheduleSnapshotMocks);
 vi.mock('@vercel/functions', () => vercelFunctionMocks);
 
-import handler, { shouldAttemptOfficialFallback, recordFallback, resetFallbackBreaker } from '../api/schedule.js';
+import handler, { shouldAttemptOfficialFallback, recordFallback, resetFallbackBreaker, __resetScheduleCachesForTests } from '../api/schedule.js';
 import { getStartOfDayForHub } from '../api/irops.js';
+import { __resetRateLimitersForTests } from '../api/_rate-limit.js';
 
 function formatForFR24Test(date) {
   return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
@@ -41,6 +42,8 @@ function createRes() {
 describe('schedule API', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    __resetRateLimitersForTests();
+    __resetScheduleCachesForTests();
     scheduleSnapshotMocks.loadScheduleSnapshot.mockReset();
     scheduleSnapshotMocks.saveScheduleSnapshot.mockReset();
     scheduleSnapshotMocks.loadScheduleSnapshot.mockResolvedValue(null);
@@ -458,6 +461,59 @@ describe('schedule API', () => {
     expect(res.body.meta.fallbackFrom).toBe('scraping');
     expect(officialUrl).toContain(`flight_datetime_from=${encodeURIComponent(formatForFR24Test(new Date(ts * 1000)))}`);
     expect(officialUrl).toContain(`flight_datetime_to=${encodeURIComponent(formatForFR24Test(new Date((ts + 86400 - 1) * 1000)))}`);
+  });
+
+  it('scrape-first: empty-200 scrape (suspected Cloudflare block) escalates to the official rescue', async () => {
+    // Regression for the live "0-flight board" bug: a direct FR24 scrape that returns a clean
+    // HTTP 200 with an empty schedule block (a soft datacenter-IP block, NOT a 403/429) used to be
+    // treated as an authoritative empty board (partial:false), so the official rescue was skipped
+    // and the user got a stale live-feed snapshot. For a same-day TARGETED hub with a token, the
+    // empty board must now be flagged partial and escalate to the official API for a full schedule.
+    process.env.FR24_API_TOKEN = 'test-token-12345678';
+
+    let officialCalled = false;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes('fr24api.flightradar24.com')) {
+        officialCalled = true;
+        return {
+          ok: true,
+          json: async () => ({
+            data: [{
+              flight_icao: 'UAL100',
+              flight_iata: 'UA100',
+              status: 'scheduled',
+              orig_iata: 'ORD',
+              dest_iata: 'LAX',
+              scheduled_departure: 1741653600,
+              scheduled_arrival: 1741660800,
+            }]
+          }),
+        };
+      }
+      // Direct FR24 scrape: clean HTTP 200, valid airport payload, but NO schedule block → 0 flights.
+      return {
+        ok: true,
+        json: async () => ({ result: { response: { airport: { pluginData: {} } } } }),
+        headers: { get: () => null },
+      };
+    });
+
+    const ts = getStartOfDayForHub('ORD'); // today; ORD is a TARGETED_OFFICIAL_RESCUE_HUB
+    const req = {
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'ORD', dir: 'departures', timestamp: String(ts) }
+    };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(officialCalled).toBe(true);
+    expect(res.body.meta.source).toBe('official-api');
+    expect(res.body.meta.fallbackFrom).toBe('scraping');
+    expect(res.body.total).toBeGreaterThan(0);
   });
 
   it('scrape-first: official fallback can still be disabled by env', async () => {


### PR DESCRIPTION
## The fix for degraded/stale schedule boards (your "make schedules work" issue)

**Symptom (live):** schedule boards show ~12h-stale `live-feed` data instead of full schedules.

**Root cause (4-agent cascade trace):** FR24's schedule scrape is Cloudflare-blocked from Vercel's datacenter IPs and returns a **clean HTTP 200 with an empty schedule block** (not a 403/429). The cascade classified that as an *authoritative empty board* (`partial:false`), so the official-API rescue gate (`schedule.ts ~1464`, which requires `total===0 && partial`) was **skipped** — the official API was never tried — and the board fell through to a stale live-feed snapshot that nothing overwrote (`saveComplete` refuses `total:0`). The circuit-breaker hypothesis was a **red herring** (`recordFallback` is never reached for an empty 200).

**Fix:** for a **same-day TARGETED hub**, flag an empty-200 scrape `partial` so it enters the existing official-rescue gate and fetches the **full day** from the paid FR24 official API.

**Credit-safe by construction:** scoped to `allowTargetedOfficialRescue` (the 9 hubs, FR24 token present, current day, **USER requests only** — the warm cron passes `officialFallback=0`, so this never fires in the credit-protected background warm), and still bounded by the circuit breaker + 402 quota block. Once official returns a full board (`total>0`) it's cached + snapshotted, so **one call serves many requests**.

## Bonus: two latent test-isolation leaks fixed
The new regression test exposed real cross-test state leaks (audit had flagged these):
- **`_rate-limit.ts`** `__resetRateLimitersForTests` — every test shared the `'unknown'` IP bucket; the 60/min window accumulated across the 44s run → spurious `429`s.
- **`schedule.ts`** `__resetScheduleCachesForTests` — a board cached by one test leaked into another with the same hub/dir/day key.
Both reset in `beforeEach`.

## Verification
- ✅ New regression test: empty-200 ORD-today + token → asserts `source: official-api`, `total>0`
- ✅ Schedule suite **31/31 stable across 3 runs** (was intermittently flaky)
- ✅ **Full suite: 582 pass**; `tsc` exit 0; build clean

🤖 The highest-leverage code fix to make schedules reliable without new vendor spend.
