### PR TITLE
fix(starlink): correct served data + durable cross-instance cache

### DIFF
--- a/api/_starlink-normalize.ts
+++ b/api/_starlink-normalize.ts
@@ -1,0 +1,191 @@
+// Shared normalizer for the unitedstarlinktracker.com upstream payload.
+//
+// Both api/cron/sync-starlink.ts and api/starlink-data.ts used to carry their own copy of this
+// transform, which let them drift. They now share this one function so "what good data looks like"
+// is defined in exactly one place.
+//
+// Data-quality fixes encoded here (verified against the live upstream 2026-05-31):
+//   1. totalCount: upstream.totalCount is the ENTIRE tracked fleet (1781), NOT the Starlink count
+//      (371). We expose the real Starlink count instead.
+//   2. operator: upstream ships both "Skywest dba UAX" and "SkyWest dba UAX" (and friends), which
+//      split the operator filter into duplicate rows. normalizeOperator() canonicalises carrier
+//      casing.
+//   3. type: upstream mixes "Bombardier CRJ-550" with "CRJ-550" and United customer codes
+//      (737-824, 737-924(ER), A321-271NX) with marketing names. normalizeType() collapses them to
+//      one label per airframe, aligned with the mainline fleet vocabulary.
+//   4. flight times: upstream departure_time/arrival_time are UNIX SECONDS (integers), not the
+//      ISO strings the consumer expects. We emit ISO strings AND a numeric *_ts (seconds) so the
+//      client can pick the next UPCOMING flight and format the time.
+//   5. enrichment: we now carry DateFound (powers the "NEW" badge / weekly-adds) and WiFi.
+
+export interface StarlinkAircraft {
+  tail: string;
+  fleet: string;        // "Mainline" | "Express"
+  type: string;         // normalised airframe label
+  operator: string;     // normalised carrier label
+  dateFound: string;    // upstream DateFound (YYYY-MM-DD) or ''
+  wifi: string;         // "Starlink" or ''
+}
+
+export interface StarlinkFlight {
+  flight_number: string;
+  origin: string;
+  destination: string;
+  departure_time: string; // ISO 8601 (derived from the upstream epoch) or ''
+  departure_ts: number;   // UNIX seconds, for "next upcoming" selection + formatting (0 if unknown)
+  arrival_time: string;   // ISO 8601 or ''
+  airline: string;        // e.g. "UA" or ''
+}
+
+export interface StarlinkFleetStats {
+  mainline: number;       // mainline aircraft with Starlink
+  express: number;        // express aircraft with Starlink
+  total: number;          // mainline + express (real Starlink count)
+  mainlineTotal: number;  // total mainline aircraft tracked
+  expressTotal: number;   // total express aircraft tracked
+  fleetTotal: number;     // mainlineTotal + expressTotal (rollout denominator)
+  mainlinePct: number;    // % of mainline fleet equipped (0-100)
+  expressPct: number;     // % of express fleet equipped (0-100)
+}
+
+export interface StarlinkPayload {
+  aircraft: StarlinkAircraft[];
+  totalCount: number;     // == aircraft.length (the FIX — see note 1)
+  fleetStats: StarlinkFleetStats | null;
+  flightsByTail: Record<string, StarlinkFlight[]>;
+  lastUpdated: string;
+  syncedAt: string;
+}
+
+// Canonical carrier spellings. Any case-insensitive occurrence of the token is rewritten so future
+// upstream casing drift ("Gojet", "SKYWEST", …) still collapses to one operator-filter entry.
+const CARRIER_CANON: Array<[RegExp, string]> = [
+  [/\bskywest\b/gi, 'SkyWest'],
+  [/\bgojet\b/gi, 'GoJet'],
+  [/\brepublic\b/gi, 'Republic'],
+  [/\bmesa\b/gi, 'Mesa'],
+  [/\bcommutair\b/gi, 'CommutAir'],
+  [/\bair wisconsin\b/gi, 'Air Wisconsin'],
+  [/\bunited\b/gi, 'United'],
+];
+
+export function normalizeOperator(raw: unknown): string {
+  let s = String(raw ?? '').trim().replace(/\s+/g, ' ');
+  if (!s) return 'United Airlines';
+  for (const [re, canon] of CARRIER_CANON) s = s.replace(re, canon);
+  return s;
+}
+
+// United customer codes / marketing-name variants → one label per airframe. Keys are lowercase and
+// already manufacturer-prefix-stripped. Unmatched types fall through to the prefix-stripped value,
+// so a new airframe still renders as a clean name rather than a duplicate.
+const TYPE_CANON: Record<string, string> = {
+  '737-724': '737-700', '737-700': '737-700',
+  '737-824': '737-800', '737-800': '737-800',
+  '737-924(er)': '737-900ER', '737-932(er)': '737-900ER', '737-900er': '737-900ER', '737-900': '737-900',
+  '737-8 max': '737 MAX 8', '737 max 8': '737 MAX 8', '737-9 max': '737 MAX 9', '737 max 9': '737 MAX 9',
+  'a319-131': 'A319', 'a320-232': 'A320', 'a321-211': 'A321', 'a321-271nx': 'A321neo', 'a321neo': 'A321neo',
+  'crj-550': 'CRJ-550', 'crj-700': 'CRJ-700', 'crj-900': 'CRJ-900',
+  'erj-175': 'ERJ-175', 'e175': 'ERJ-175', 'e175sc': 'E175SC',
+};
+
+export function normalizeType(raw: unknown): string {
+  let s = String(raw ?? '').trim();
+  if (!s) return 'Unknown';
+  s = s.replace(/^(Boeing|Airbus|Bombardier|Embraer|McDonnell Douglas)\s+/i, '');
+  const key = s.toLowerCase();
+  return TYPE_CANON[key] ?? s;
+}
+
+function capitalizeFleet(raw: unknown): string {
+  const s = String(raw ?? 'express').trim() || 'express';
+  return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+}
+
+function normalizeWifi(raw: unknown): string {
+  return /star\s*l|strlnk|starlink/i.test(String(raw ?? '')) ? 'Starlink' : '';
+}
+
+// Accept either an upstream epoch (seconds, occasionally ms) or an ISO string, and return both an
+// ISO string and the numeric seconds. Returns ''/0 for anything unparseable.
+function toTime(value: unknown): { iso: string; sec: number } {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    const sec = value > 1e12 ? Math.round(value / 1000) : Math.round(value);
+    return { iso: new Date(sec * 1000).toISOString(), sec };
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const ms = Date.parse(value);
+    if (Number.isFinite(ms)) return { iso: new Date(ms).toISOString(), sec: Math.round(ms / 1000) };
+  }
+  return { iso: '', sec: 0 };
+}
+
+function pct(part: number, whole: number): number {
+  if (!whole || whole <= 0) return 0;
+  return Math.round((part / whole) * 100);
+}
+
+export function normalizeStarlinkPayload(upstream: any, syncedAt: string = new Date().toISOString()): StarlinkPayload {
+  const planes: any[] = Array.isArray(upstream?.starlinkPlanes) ? upstream.starlinkPlanes : [];
+
+  const aircraft: StarlinkAircraft[] = planes.map((p) => ({
+    tail: String(p?.TailNumber ?? '').trim(),
+    fleet: capitalizeFleet(p?.fleet),
+    type: normalizeType(p?.Aircraft),
+    operator: normalizeOperator(p?.OperatedBy),
+    dateFound: String(p?.DateFound ?? '').trim(),
+    wifi: normalizeWifi(p?.WiFi),
+  }));
+
+  const fs = upstream?.fleetStats;
+  const mainline = Number(fs?.mainline?.starlink ?? 0) || 0;
+  const express = Number(fs?.express?.starlink ?? 0) || 0;
+  const mainlineTotal = Number(fs?.mainline?.total ?? 0) || 0;
+  const expressTotal = Number(fs?.express?.total ?? 0) || 0;
+  // total = real Starlink count. Prefer upstream.combined when present, else mainline+express, else
+  // the array length. Never upstream.totalCount (that is the whole tracked fleet).
+  const total = Number(fs?.combined?.starlink ?? (mainline + express || aircraft.length)) || aircraft.length;
+  const fleetStats: StarlinkFleetStats | null = fs ? {
+    mainline,
+    express,
+    total,
+    mainlineTotal,
+    expressTotal,
+    fleetTotal: mainlineTotal + expressTotal,
+    mainlinePct: pct(mainline, mainlineTotal),
+    expressPct: pct(express, expressTotal),
+  } : null;
+
+  const flightsByTail: Record<string, StarlinkFlight[]> = {};
+  const upstreamFlights = upstream?.flightsByTail && typeof upstream.flightsByTail === 'object'
+    ? upstream.flightsByTail as Record<string, any[]>
+    : {};
+  for (const [tail, flights] of Object.entries(upstreamFlights)) {
+    if (!Array.isArray(flights)) continue;
+    const mapped = flights.map((f: any) => {
+      const dep = toTime(f?.departure_time);
+      const arr = toTime(f?.arrival_time);
+      return {
+        flight_number: String(f?.flight_number ?? ''),
+        origin: String(f?.departure_airport ?? f?.origin ?? ''),
+        destination: String(f?.arrival_airport ?? f?.destination ?? ''),
+        departure_time: dep.iso,
+        departure_ts: dep.sec,
+        arrival_time: arr.iso,
+        airline: String(f?.airline ?? ''),
+      } as StarlinkFlight;
+    });
+    // Keep chronological order so the client's "next upcoming" scan is a simple forward find.
+    mapped.sort((a, b) => a.departure_ts - b.departure_ts);
+    flightsByTail[tail] = mapped;
+  }
+
+  return {
+    aircraft,
+    totalCount: aircraft.length,
+    fleetStats,
+    flightsByTail,
+    lastUpdated: typeof upstream?.lastUpdated === 'string' && upstream.lastUpdated ? upstream.lastUpdated : syncedAt,
+    syncedAt,
+  };
+}

--- a/api/_starlink-snapshot.ts
+++ b/api/_starlink-snapshot.ts
@@ -1,0 +1,83 @@
+// Durable Starlink snapshot shared across serverless instances via Supabase.
+//
+// Why: api/cron/sync-starlink.ts used to stash its result on globalThis.__starlinkCache, but on
+// Vercel the cron runs in a different lambda than api/starlink-data.ts, so that global was never
+// visible to the serving endpoint — the cron was a no-op that just burned a 727KB upstream fetch
+// every 4h, and every cold serving instance independently re-fetched upstream. This is the same
+// per-instance-state bug PR #177 fixed for the FR24 cost guard; we fix it the same way (Supabase).
+//
+// Design mirrors api/_schedule-snapshots.ts: reuse the one service-role client, and make every
+// Supabase interaction fully guarded — any failure (unconfigured, migration not applied, mocked
+// away in tests) degrades to "no snapshot", never worse than the prior behaviour.
+
+import { getSupabaseAdmin } from './_schedule-snapshots.js';
+import type { StarlinkPayload } from './_starlink-normalize.js';
+
+const SNAPSHOT_TABLE = 'starlink_snapshot';
+const SNAPSHOT_KEY = 'current';
+const SNAPSHOT_TTL_MS = 12 * 60 * 60 * 1000; // 12h — the cron runs every 4h, so this is generous slack
+
+export interface PersistedStarlinkSnapshot {
+  data: StarlinkPayload;
+  refreshedAt: number; // epoch ms
+}
+
+export async function loadStarlinkSnapshot(): Promise<PersistedStarlinkSnapshot | null> {
+  const supabase = await getSupabaseAdmin();
+  if (!supabase) return null;
+
+  try {
+    const { data, error } = await supabase
+      .from(SNAPSHOT_TABLE)
+      .select('payload, refreshed_at')
+      .eq('key', SNAPSHOT_KEY)
+      .limit(1);
+
+    if (error) {
+      console.error('Starlink snapshot read failed:', error.message);
+      return null;
+    }
+
+    const row = (data as Array<{ payload: StarlinkPayload | null; refreshed_at: string }> | null)?.[0];
+    if (!row?.payload || !Array.isArray(row.payload.aircraft) || row.payload.aircraft.length === 0) {
+      return null;
+    }
+
+    const refreshedAt = Date.parse(row.refreshed_at);
+    return {
+      data: row.payload,
+      refreshedAt: Number.isFinite(refreshedAt) ? refreshedAt : Date.now(),
+    };
+  } catch (error: any) {
+    console.error('Starlink snapshot read threw:', error?.message || error);
+    return null;
+  }
+}
+
+export async function saveStarlinkSnapshot(payload: StarlinkPayload): Promise<void> {
+  // Never persist an empty board — a transient empty 200 must not become the durable fallback.
+  if (!payload || !Array.isArray(payload.aircraft) || payload.aircraft.length === 0) return;
+
+  const supabase = await getSupabaseAdmin();
+  if (!supabase) return;
+
+  const nowIso = new Date().toISOString();
+  const expiresAtIso = new Date(Date.now() + SNAPSHOT_TTL_MS).toISOString();
+
+  try {
+    const { error } = await supabase
+      .from(SNAPSHOT_TABLE)
+      .upsert({
+        key: SNAPSHOT_KEY,
+        payload,
+        total: payload.aircraft.length,
+        refreshed_at: nowIso,
+        expires_at: expiresAtIso,
+        updated_at: nowIso,
+      }, { onConflict: 'key' });
+
+    if (error) console.error('Starlink snapshot write failed:', error.message);
+  } catch (error: any) {
+    console.error('Starlink snapshot write threw:', error?.message || error);
+  }
+}

--- a/api/cron/sync-starlink.ts
+++ b/api/cron/sync-starlink.ts
@@ -1,8 +1,13 @@
 // Vercel Cron Job: syncs Starlink aircraft data from unitedstarlinktracker.com
-// Writes enriched data (aircraft list, fleet stats, flights) to /tmp for edge caching
+// Persists the enriched payload to the durable Supabase snapshot (starlink_snapshot) so the
+// serving endpoint (api/starlink-data.ts) can read it from any lambda. It also sets
+// globalThis.__starlinkCache as a same-instance fast path, but Supabase is the real handoff —
+// globalThis does NOT survive across serverless instances (the bug this replaces).
 // Config in vercel.json: { "path": "/api/cron/sync-starlink", "schedule": "0 */4 * * *" }
 
 import type { VercelRequest, VercelResponse } from '../types.js';
+import { normalizeStarlinkPayload } from '../_starlink-normalize.js';
+import { saveStarlinkSnapshot } from '../_starlink-snapshot.js';
 
 const UPSTREAM_URL = 'https://unitedstarlinktracker.com/api/data';
 
@@ -26,60 +31,26 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return res.status(502).json({ error: `Upstream returned ${resp.status}` });
     }
 
-    const upstream = await resp.json() as {
-      totalCount: number;
-      starlinkPlanes: Array<{ TailNumber: string; Aircraft: string; fleet: string; OperatedBy: string }>;
-      lastUpdated: string;
-      fleetStats: { mainline: { total: number; starlink: number }; express: { total: number; starlink: number }; combined: { total: number; starlink: number } };
-      flightsByTail: Record<string, Array<{ flight_number: string; departure_airport: string; arrival_airport: string; departure_time: string }>>;
-    };
+    const upstream = await resp.json();
+    const enriched = normalizeStarlinkPayload(upstream);
 
-    // Transform to our format: keep backwards-compatible starlink.json shape + extras
-    // Upstream uses: TailNumber, Aircraft (=type), fleet ("express"/"mainline"), OperatedBy
-    const aircraft = (upstream.starlinkPlanes || []).map(p => ({
-      tail: p.TailNumber,
-      fleet: (p.fleet || 'express').charAt(0).toUpperCase() + (p.fleet || 'express').slice(1),
-      type: p.Aircraft || 'Unknown',
-      operator: p.OperatedBy || 'United Airlines',
-    }));
-
-    // Normalize fleet stats to simple counts
-    const fs = upstream.fleetStats;
-    const fleetStats = fs ? {
-      mainline: fs.mainline?.starlink ?? 0,
-      express: fs.express?.starlink ?? 0,
-      total: fs.combined?.starlink ?? aircraft.length,
-      mainlineTotal: fs.mainline?.total ?? 0,
-      expressTotal: fs.express?.total ?? 0,
-    } : null;
-
-    // Normalize flight fields (upstream uses departure_airport/arrival_airport)
-    const flightsByTail: Record<string, Array<{ flight_number: string; origin: string; destination: string; departure_time: string }>> = {};
-    for (const [tail, flights] of Object.entries(upstream.flightsByTail || {})) {
-      flightsByTail[tail] = flights.map((f: any) => ({
-        flight_number: f.flight_number,
-        origin: f.departure_airport || f.origin || '',
-        destination: f.arrival_airport || f.destination || '',
-        departure_time: f.departure_time || '',
-      }));
+    // Refuse to persist an empty board — a transient empty 200 must not poison the durable snapshot
+    // and get served as the "good" fallback for the next 12h.
+    if (enriched.aircraft.length === 0) {
+      return res.status(502).json({ error: 'Upstream returned 0 Starlink aircraft — snapshot not updated' });
     }
 
-    const enriched = {
-      aircraft,
-      totalCount: upstream.totalCount || aircraft.length,
-      fleetStats,
-      flightsByTail,
-      lastUpdated: upstream.lastUpdated || new Date().toISOString(),
-      syncedAt: new Date().toISOString(),
-    };
-
-    // Store in global for the /api/starlink-data endpoint to serve
+    // Same-instance fast path (cheap; harmless). The durable cross-instance handoff is Supabase.
     (globalThis as any).__starlinkCache = enriched;
+
+    // Persist durably. saveStarlinkSnapshot never throws and degrades to a no-op if Supabase is
+    // unconfigured, so the cron still reports success and the endpoint falls back to direct fetch.
+    await saveStarlinkSnapshot(enriched);
 
     return res.status(200).json({
       status: 'ok',
-      aircraft_count: aircraft.length,
-      fleet_stats: upstream.fleetStats,
+      aircraft_count: enriched.aircraft.length,
+      fleet_stats: enriched.fleetStats,
       synced_at: enriched.syncedAt,
     });
   } catch (err: any) {

--- a/api/starlink-data.ts
+++ b/api/starlink-data.ts
@@ -1,28 +1,50 @@
-// Serves enriched Starlink aircraft data
-// Primary: serves cached data from cron sync
-// Fallback: fetches directly from upstream if cache is empty
+// Serves enriched Starlink aircraft data.
+//
+// Serve order (each falls through to the next on miss/failure):
+//   1. globalThis.__starlinkCache  — same-instance cron result (fast path, rare)
+//   2. in-memory cache             — this lambda's last fetch, if still fresh
+//   3. Supabase snapshot           — durable, cross-instance, written by the cron every 4h
+//   4. direct upstream fetch       — rate-limited; refreshes the in-memory cache
+// On error, degrade rather than fail: stale in-memory -> stale Supabase snapshot -> committed
+// static file. The X-Starlink-Source header reports which path served the response.
 
 import type { VercelRequest, VercelResponse } from './types.js';
 import { createRateLimiter } from './_rate-limit.js';
+import { normalizeStarlinkPayload, normalizeOperator, normalizeType, type StarlinkPayload } from './_starlink-normalize.js';
+import { loadStarlinkSnapshot, type PersistedStarlinkSnapshot } from './_starlink-snapshot.js';
+import STATIC_STARLINK from '../public/data/starlink.json';
 
 const UPSTREAM_URL = 'https://unitedstarlinktracker.com/api/data';
-const CACHE_TTL = 4 * 60 * 60 * 1000; // 4 hours
-
-interface StarlinkCache {
-  aircraft: Array<{ tail: string; fleet: string; type: string; operator: string }>;
-  totalCount: number;
-  fleetStats: { mainline: number; express: number; total: number; mainlineTotal: number; expressTotal: number } | null;
-  flightsByTail: Record<string, Array<{ flight_number: string; origin: string; destination: string; departure_time: string }>>;
-  lastUpdated: string;
-  syncedAt: string;
-}
+const CACHE_TTL = 4 * 60 * 60 * 1000;       // 4h in-memory freshness
+const SNAPSHOT_FRESH_MS = 6 * 60 * 60 * 1000; // serve the durable snapshot directly if <6h old
 
 const isRateLimited = createRateLimiter('starlink-data', 30);
 
-let inMemoryCache: StarlinkCache | null = null;
+let inMemoryCache: StarlinkPayload | null = null;
 let lastFetch = 0;
 
-async function fetchUpstream(): Promise<StarlinkCache> {
+// Committed snapshot bundled at build time — the last-resort fallback when upstream is down and no
+// other cache exists. Shape on disk is just the aircraft array; wrap it into the full payload.
+function staticPayload(): StarlinkPayload {
+  const aircraft = (STATIC_STARLINK as Array<{ tail: string; fleet: string; type: string; operator: string }>).map((a) => ({
+    tail: a.tail,
+    fleet: a.fleet,
+    type: normalizeType(a.type),
+    operator: normalizeOperator(a.operator),
+    dateFound: '',
+    wifi: 'Starlink',
+  }));
+  return {
+    aircraft,
+    totalCount: aircraft.length,
+    fleetStats: null,
+    flightsByTail: {},
+    lastUpdated: '',
+    syncedAt: new Date().toISOString(),
+  };
+}
+
+async function fetchUpstream(): Promise<StarlinkPayload> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 15000);
 
@@ -33,45 +55,19 @@ async function fetchUpstream(): Promise<StarlinkCache> {
   clearTimeout(timeout);
 
   if (!resp.ok) throw new Error(`Upstream ${resp.status}`);
+  return normalizeStarlinkPayload(await resp.json());
+}
 
-  const upstream = await resp.json() as any;
-  // Upstream uses: TailNumber, Aircraft (=type), fleet ("express"/"mainline"), OperatedBy
-  const aircraft = (upstream.starlinkPlanes || []).map((p: any) => ({
-    tail: p.TailNumber,
-    fleet: (p.fleet || 'express').charAt(0).toUpperCase() + (p.fleet || 'express').slice(1),
-    type: p.Aircraft || 'Unknown',
-    operator: p.OperatedBy || 'United Airlines',
-  }));
+function serveFresh(res: VercelResponse, payload: StarlinkPayload, source: string) {
+  res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=600');
+  res.setHeader('X-Starlink-Source', source);
+  return res.status(200).json(payload);
+}
 
-  // Normalize fleet stats to simple counts
-  const fs = upstream.fleetStats;
-  const fleetStats = fs ? {
-    mainline: fs.mainline?.starlink ?? 0,
-    express: fs.express?.starlink ?? 0,
-    total: fs.combined?.starlink ?? aircraft.length,
-    mainlineTotal: fs.mainline?.total ?? 0,
-    expressTotal: fs.express?.total ?? 0,
-  } : null;
-
-  // Normalize flight fields (upstream uses departure_airport/arrival_airport)
-  const flightsByTail: Record<string, any[]> = {};
-  for (const [tail, flights] of Object.entries(upstream.flightsByTail || {} as Record<string, any[]>)) {
-    flightsByTail[tail] = (flights as any[]).map((f: any) => ({
-      flight_number: f.flight_number,
-      origin: f.departure_airport || f.origin || '',
-      destination: f.arrival_airport || f.destination || '',
-      departure_time: f.departure_time || '',
-    }));
-  }
-
-  return {
-    aircraft,
-    totalCount: upstream.totalCount || aircraft.length,
-    fleetStats,
-    flightsByTail,
-    lastUpdated: upstream.lastUpdated || new Date().toISOString(),
-    syncedAt: new Date().toISOString(),
-  };
+function serveDegraded(res: VercelResponse, payload: StarlinkPayload, source: string) {
+  res.setHeader('Cache-Control', 'public, s-maxage=300');
+  res.setHeader('X-Starlink-Source', source);
+  return res.status(200).json(payload);
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -79,37 +75,41 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
+  // Cached from earlier in the request lifecycle so the catch block can reuse it without a second read.
+  let snapshot: PersistedStarlinkSnapshot | null = null;
+
   try {
-    // Serve cached responses without rate limiting
-    const cronCache = (globalThis as any).__starlinkCache as StarlinkCache | undefined;
-    if (cronCache) {
-      res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=600');
-      return res.status(200).json(cronCache);
-    }
+    // 1. Same-instance cron result.
+    const cronCache = (globalThis as any).__starlinkCache as StarlinkPayload | undefined;
+    if (cronCache) return serveFresh(res, cronCache, 'cron');
 
+    // 2. Fresh in-memory cache.
     if (inMemoryCache && Date.now() - lastFetch < CACHE_TTL) {
-      res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=600');
-      return res.status(200).json(inMemoryCache);
+      return serveFresh(res, inMemoryCache, 'memory');
     }
 
-    // Rate limit only upstream fetches, not cache hits
+    // 3. Durable Supabase snapshot (written by the cron). Serve directly if fresh; this lets a cold
+    //    instance skip the 727KB upstream fetch entirely and keeps every instance consistent.
+    snapshot = await loadStarlinkSnapshot();
+    if (snapshot && Date.now() - snapshot.refreshedAt < SNAPSHOT_FRESH_MS) {
+      inMemoryCache = snapshot.data;
+      lastFetch = snapshot.refreshedAt;
+      return serveFresh(res, snapshot.data, 'supabase');
+    }
+
+    // 4. Fetch fresh from upstream. If rate-limited, degrade instead of erroring.
     if (isRateLimited(req)) {
-      return res.status(429).json({ error: 'Too many requests' });
+      return serveDegraded(res, snapshot?.data ?? staticPayload(), snapshot ? 'supabase-stale' : 'static');
     }
 
-    // Fetch fresh
     inMemoryCache = await fetchUpstream();
     lastFetch = Date.now();
-
-    res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=600');
-    return res.status(200).json(inMemoryCache);
+    return serveFresh(res, inMemoryCache, 'upstream');
   } catch (err: any) {
-    // If we have stale cache, serve it rather than failing
-    if (inMemoryCache) {
-      res.setHeader('Cache-Control', 'public, s-maxage=300');
-      return res.status(200).json(inMemoryCache);
-    }
-    console.error('Starlink data error:', err);
-    return res.status(502).json({ error: 'Failed to fetch Starlink data' });
+    // Degrade rather than 502: stale in-memory -> stale snapshot -> committed static file.
+    if (inMemoryCache) return serveDegraded(res, inMemoryCache, 'memory-stale');
+    if (snapshot?.data) return serveDegraded(res, snapshot.data, 'supabase-stale');
+    console.error('Starlink data error (serving static fallback):', err?.message || err);
+    return serveDegraded(res, staticPayload(), 'static');
   }
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -355,6 +355,8 @@ tbody td{padding:5px 8px;white-space:nowrap}
 .sa-flight-info{font-size:9px;color:var(--ua-green);margin-top:2px}
 .fleet-starlink-chip-val{font-size:16px;font-weight:700}
 .fleet-starlink-chip-label{color:var(--ua-muted);font-size:10px}
+.starlink-new-badge{display:inline-block;vertical-align:middle;font-family:var(--font-mono);font-size:9px;font-weight:600;text-transform:uppercase;letter-spacing:.5px;padding:1px 5px;border-radius:3px;background:var(--ua-amber-soft);color:var(--ua-amber)}
+.starlink-next-time{color:var(--ua-muted);font-family:var(--font-mono)}
 
 /* Special Aircraft Badge & Tracker */
 .special-badge{background:rgba(139,92,246,.2);color:#a78bfa;padding:2px 6px;border-radius:3px;font-size:9px;font-weight:700;font-family:var(--font-mono)}

--- a/sql/008_starlink_snapshot.sql
+++ b/sql/008_starlink_snapshot.sql
@@ -1,0 +1,22 @@
+-- Durable Starlink snapshot shared across serverless instances.
+--
+-- api/cron/sync-starlink.ts writes the enriched unitedstarlinktracker.com payload here every 4h;
+-- api/starlink-data.ts reads it so every cold serving instance returns the same fresh data without
+-- re-fetching 727KB from upstream. Replaces the old globalThis.__starlinkCache handoff, which never
+-- survived across lambdas (see api/_starlink-snapshot.ts). Same pattern as schedule_cost_state (007).
+--
+-- Single logical row (key = 'current'). Written only by the service-role key (server-side); the
+-- anon client has no access.
+
+CREATE TABLE IF NOT EXISTS starlink_snapshot (
+  key          TEXT PRIMARY KEY,
+  payload      JSONB NOT NULL,
+  total        INTEGER,
+  refreshed_at TIMESTAMPTZ DEFAULT NOW(),
+  expires_at   TIMESTAMPTZ,
+  updated_at   TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Snapshot is server-internal. Enable RLS with no policies so only the service-role key (which
+-- bypasses RLS) can read/write; the anon key is denied entirely.
+ALTER TABLE starlink_snapshot ENABLE ROW LEVEL SECURITY;

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -1826,12 +1826,21 @@ function initFleetTab() {
     if (statsEl) {
       const fs = STARLINK_FLEET_STATS;
       // Note: all values are pre-sanitized integers from our own API
+      const mainlinePct = (fs.mainlinePct != null) ? fs.mainlinePct : (fs.mainlineTotal ? Math.round(fs.mainline / fs.mainlineTotal * 100) : null);
+      const expressPct = (fs.expressPct != null) ? fs.expressPct : (fs.expressTotal ? Math.round(fs.express / fs.expressTotal * 100) : null);
+      const newThisWeek = STARLINK_DB.filter(s => isRecentlyFound(s.dateFound)).length;
       let chipsHtml = '';
       chipsHtml += '<div class="fleet-starlink-chip" style="background:rgba(34,197,94,.1);border:1px solid rgba(34,197,94,.2)"><span class="fleet-starlink-chip-val" style="color:var(--ua-green)">' + fs.total + '</span><span class="fleet-starlink-chip-label">Total</span></div>';
       chipsHtml += '<div class="fleet-starlink-chip" style="background:rgba(0,93,170,.1);border:1px solid rgba(0,93,170,.2)"><span class="fleet-starlink-chip-val" style="color:var(--ua-accent)">' + fs.mainline + '</span><span class="fleet-starlink-chip-label">Mainline</span></div>';
       chipsHtml += '<div class="fleet-starlink-chip" style="background:rgba(168,85,247,.1);border:1px solid rgba(168,85,247,.2)"><span class="fleet-starlink-chip-val" style="color:#a855f7">' + fs.express + '</span><span class="fleet-starlink-chip-label">Express</span></div>';
-      if (fs.mainlineTotal) {
-        chipsHtml += '<div class="fleet-starlink-chip" style="background:rgba(100,116,139,.08);border:1px solid rgba(100,116,139,.15)"><span class="fleet-starlink-chip-val" style="color:var(--ua-text)">' + Math.round(fs.mainline / fs.mainlineTotal * 100) + '%</span><span class="fleet-starlink-chip-label">Mainline Fleet</span></div>';
+      if (mainlinePct != null) {
+        chipsHtml += '<div class="fleet-starlink-chip" style="background:rgba(100,116,139,.08);border:1px solid rgba(100,116,139,.15)"><span class="fleet-starlink-chip-val" style="color:var(--ua-text)">' + mainlinePct + '%</span><span class="fleet-starlink-chip-label">Mainline Fleet</span></div>';
+      }
+      if (expressPct != null) {
+        chipsHtml += '<div class="fleet-starlink-chip" style="background:rgba(100,116,139,.08);border:1px solid rgba(100,116,139,.15)"><span class="fleet-starlink-chip-val" style="color:var(--ua-text)">' + expressPct + '%</span><span class="fleet-starlink-chip-label">Express Fleet</span></div>';
+      }
+      if (newThisWeek > 0) {
+        chipsHtml += '<div class="fleet-starlink-chip" style="background:var(--ua-amber-soft);border:1px solid rgba(196,163,90,.25)"><span class="fleet-starlink-chip-val" style="color:var(--ua-amber)">+' + newThisWeek + '</span><span class="fleet-starlink-chip-label">New (7d)</span></div>';
       }
       statsEl.innerHTML = chipsHtml;
     }
@@ -2416,6 +2425,24 @@ function renderAgeChart() {
 
 let starlinkSortKey = 'tail', starlinkSortAsc = true;
 
+// A plane counts as "newly equipped" if upstream first recorded its Starlink (DateFound) within the
+// last 7 days. Computed against the live clock so the badge ages out on its own.
+function isRecentlyFound(dateFound) {
+  if (!dateFound) return false;
+  const t = Date.parse(dateFound);
+  if (isNaN(t)) return false;
+  const now = Date.now();
+  return t <= now + 86400000 && (now - t) <= 7 * 86400000;
+}
+
+// Format an upstream departure timestamp (UNIX seconds) as a short local HH:MM hint.
+function formatFlightTime(ts) {
+  if (!ts) return '';
+  const d = new Date(ts * 1000);
+  if (isNaN(d.getTime())) return '';
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
 function initStarlinkFilters() {
   // Populate type and operator dropdowns from actual data
   const types = [...new Set(STARLINK_DB.map(s => s.type))].sort();
@@ -2465,18 +2492,24 @@ function renderStarlinkTable() {
   document.getElementById('starlink-count').textContent = STARLINK_DB.length;
 
   const hasFlights = Object.keys(STARLINK_FLIGHTS_BY_TAIL).length > 0;
+  const nowSec = Date.now() / 1000;
   document.getElementById('starlink-tbody').innerHTML = filtered.map(s => {
     let nextFlightHtml = '';
     if (hasFlights) {
       const flights = STARLINK_FLIGHTS_BY_TAIL[s.tail];
       if (flights && flights.length > 0) {
-        const next = flights[0];
-        nextFlightHtml = `<td style="font-size:9px">${escapeHtml(next.flight_number || '')} ${escapeHtml((next.origin || '') + '→' + (next.destination || ''))}</td>`;
+        // Next UPCOMING departure (flights are chronological; allow a 30-min grace for one that
+        // just left), falling back to the latest known flight if all are in the past.
+        const next = flights.find(f => (f.departure_ts || 0) >= nowSec - 1800) || flights[flights.length - 1];
+        const t = formatFlightTime(next.departure_ts);
+        const timeHtml = t ? ` <span class="starlink-next-time">${escapeHtml(t)}</span>` : '';
+        nextFlightHtml = `<td style="font-size:9px">${escapeHtml(next.flight_number || '')} ${escapeHtml((next.origin || '') + '→' + (next.destination || ''))}${timeHtml}</td>`;
       } else {
         nextFlightHtml = '<td style="font-size:9px;color:var(--ua-muted)">—</td>';
       }
     }
-    return `<tr><td style="font-weight:700;color:var(--ua-green)">${escapeHtml(s.tail)}</td><td>${escapeHtml(s.fleet)}</td><td>${escapeHtml(s.type)}</td><td style="font-size:10px">${escapeHtml(s.operator)}</td>${nextFlightHtml}</tr>`;
+    const newBadge = isRecentlyFound(s.dateFound) ? ` <span class="starlink-new-badge" title="Starlink equipment first seen ${escapeHtml(s.dateFound)}">NEW</span>` : '';
+    return `<tr><td style="font-weight:700;color:var(--ua-green)">${escapeHtml(s.tail)}${newBadge}</td><td>${escapeHtml(s.fleet)}</td><td>${escapeHtml(s.type)}</td><td style="font-size:10px">${escapeHtml(s.operator)}</td>${nextFlightHtml}</tr>`;
   }).join('');
 
   // Toggle next-flight column header visibility

--- a/tests/starlink-data.test.js
+++ b/tests/starlink-data.test.js
@@ -20,24 +20,26 @@ function makeReq(overrides = {}) {
   };
 }
 
+// Mirrors the live upstream: totalCount is the WHOLE tracked fleet (not the Starlink count),
+// fleetStats has no `combined`, departure_time is a UNIX-seconds integer, operator/type casing
+// is inconsistent.
 function mockUpstreamResponse() {
   return {
     starlinkPlanes: [
-      { TailNumber: 'N37559', fleet: 'mainline', Aircraft: 'B738', OperatedBy: 'United Airlines' },
-      { TailNumber: 'N77296', fleet: 'express', Aircraft: 'E175', OperatedBy: 'SkyWest Airlines' },
+      { TailNumber: 'N37559', fleet: 'mainline', Aircraft: 'Boeing 737-824', OperatedBy: 'United Airlines', DateFound: '2020-01-01', WiFi: 'Starlink' },
+      { TailNumber: 'N77296', fleet: 'express', Aircraft: 'Bombardier CRJ-550', OperatedBy: 'Skywest dba UAX', DateFound: '2020-01-01', WiFi: 'StrLnk' },
     ],
-    totalCount: 2,
+    totalCount: 1781,
     fleetStats: {
-      mainline: { starlink: 100, total: 800 },
-      express: { starlink: 50, total: 500 },
-      combined: { starlink: 150, total: 1300 },
+      mainline: { starlink: 51, total: 1122 },
+      express: { starlink: 320, total: 659 },
     },
     flightsByTail: {
       N37559: [
-        { flight_number: 'UA1234', departure_airport: 'ORD', arrival_airport: 'LAX', departure_time: '2026-04-04T10:00:00Z' },
+        { flight_number: 'UA1234', departure_airport: 'ORD', arrival_airport: 'LAX', departure_time: 1780270800, arrival_time: 1780280100, airline: 'UA' },
       ],
     },
-    lastUpdated: '2026-04-04T12:00:00Z',
+    lastUpdated: '2026-05-31T23:02:04.479Z',
   };
 }
 
@@ -58,28 +60,34 @@ describe('starlink-data API', () => {
     expect(res.statusCode).toBe(405);
   });
 
-  // --- Error paths (must run before any successful fetch populates inMemoryCache) ---
+  // --- Degraded paths (must run before any successful fetch populates inMemoryCache) ---
+  // With no in-memory or Supabase cache, the endpoint serves the committed static file rather
+  // than erroring, so the board never goes blank when upstream is down.
 
-  it('returns 502 when upstream fails and no cache exists', async () => {
+  it('serves the static fallback when upstream fails and no cache exists', async () => {
     vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('upstream down'));
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const res = createRes();
     await handler(makeReq(), res);
 
-    expect(res.statusCode).toBe(502);
-    expect(res.body.error).toMatch(/Failed to fetch/);
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['X-Starlink-Source']).toBe('static');
+    expect(Array.isArray(res.body.aircraft)).toBe(true);
+    expect(res.body.aircraft.length).toBeGreaterThan(0);
+    expect(res.body.totalCount).toBe(res.body.aircraft.length);
     spy.mockRestore();
   });
 
-  it('returns 502 when upstream returns non-ok status and no cache', async () => {
+  it('serves the static fallback when upstream returns a non-ok status and no cache', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 503 });
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const res = createRes();
     await handler(makeReq(), res);
 
-    expect(res.statusCode).toBe(502);
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['X-Starlink-Source']).toBe('static');
     spy.mockRestore();
   });
 
@@ -109,19 +117,28 @@ describe('starlink-data API', () => {
     await handler(makeReq(), res);
 
     expect(res.statusCode).toBe(200);
+    expect(res.headers['X-Starlink-Source']).toBe('upstream');
     expect(res.body.aircraft).toHaveLength(2);
     expect(res.body.aircraft[0].tail).toBe('N37559');
     expect(res.body.aircraft[0].fleet).toBe('Mainline');
     expect(res.body.aircraft[1].fleet).toBe('Express');
-    expect(res.body.fleetStats.mainline).toBe(100);
-    expect(res.body.fleetStats.express).toBe(50);
+    // Type + operator normalisation
+    expect(res.body.aircraft[0].type).toBe('737-800');   // from "Boeing 737-824"
+    expect(res.body.aircraft[1].type).toBe('CRJ-550');   // from "Bombardier CRJ-550"
+    expect(res.body.aircraft[1].operator).toBe('SkyWest dba UAX'); // from "Skywest dba UAX"
+    expect(res.body.fleetStats.mainline).toBe(51);
+    expect(res.body.fleetStats.express).toBe(320);
+    // The headline fix: serve the real Starlink count, NOT upstream.totalCount (1781 = whole fleet)
     expect(res.body.totalCount).toBe(2);
+    expect(res.body.totalCount).not.toBe(1781);
 
-    // Verify flight normalization
+    // Verify flight normalization: epoch → ISO string + numeric ts
     const flights = res.body.flightsByTail.N37559;
     expect(flights).toHaveLength(1);
     expect(flights[0].origin).toBe('ORD');
     expect(flights[0].destination).toBe('LAX');
+    expect(flights[0].departure_ts).toBe(1780270800);
+    expect(flights[0].departure_time).toBe(new Date(1780270800 * 1000).toISOString());
   });
 
   // --- After inMemoryCache is populated, error falls back to stale cache ---

--- a/tests/starlink-normalize.test.js
+++ b/tests/starlink-normalize.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeOperator,
+  normalizeType,
+  normalizeStarlinkPayload,
+} from '../api/_starlink-normalize.js';
+
+describe('normalizeOperator', () => {
+  it('canonicalises SkyWest casing so the operator filter does not split', () => {
+    expect(normalizeOperator('Skywest dba UAX')).toBe('SkyWest dba UAX');
+    expect(normalizeOperator('SkyWest dba UAX')).toBe('SkyWest dba UAX');
+    expect(normalizeOperator('SKYWEST dba UAX')).toBe('SkyWest dba UAX');
+    expect(normalizeOperator('SkyWest floater')).toBe('SkyWest floater');
+  });
+
+  it('leaves other carriers intact and defaults empty to United Airlines', () => {
+    expect(normalizeOperator('Republic dba UAX')).toBe('Republic dba UAX');
+    expect(normalizeOperator('GoJet dba UAX')).toBe('GoJet dba UAX');
+    expect(normalizeOperator('United Airlines')).toBe('United Airlines');
+    expect(normalizeOperator('')).toBe('United Airlines');
+    expect(normalizeOperator(null)).toBe('United Airlines');
+  });
+});
+
+describe('normalizeType', () => {
+  it('collapses manufacturer-prefixed and customer-code variants to one label', () => {
+    expect(normalizeType('Bombardier CRJ-550')).toBe('CRJ-550');
+    expect(normalizeType('CRJ-550')).toBe('CRJ-550');
+    expect(normalizeType('Boeing 737-824')).toBe('737-800');
+    expect(normalizeType('Boeing 737-800')).toBe('737-800');
+    expect(normalizeType('Boeing 737-924(ER)')).toBe('737-900ER');
+    expect(normalizeType('Boeing 737-932(ER)')).toBe('737-900ER');
+    expect(normalizeType('Boeing 737-900ER')).toBe('737-900ER');
+    expect(normalizeType('Airbus A321-271NX')).toBe('A321neo');
+  });
+
+  it('preserves distinct regional configs and unknown types gracefully', () => {
+    expect(normalizeType('ERJ-175')).toBe('ERJ-175');
+    expect(normalizeType('E175SC')).toBe('E175SC');
+    expect(normalizeType('Boeing 787-9')).toBe('787-9'); // unmapped → prefix-stripped
+    expect(normalizeType('')).toBe('Unknown');
+  });
+});
+
+describe('normalizeStarlinkPayload', () => {
+  // Mirrors the live upstream: totalCount is the WHOLE fleet, fleetStats has no `combined`,
+  // departure_time is a UNIX-seconds integer, operator/type casing is inconsistent.
+  const upstream = {
+    totalCount: 1781,
+    starlinkPlanes: [
+      { TailNumber: 'N51', fleet: 'mainline', Aircraft: 'Boeing 737-924(ER)', OperatedBy: 'United Airlines', DateFound: '2024-01-01', WiFi: 'Starlink' },
+      { TailNumber: 'N32', fleet: 'express', Aircraft: 'Bombardier CRJ-550', OperatedBy: 'Skywest dba UAX', DateFound: '2026-05-31', WiFi: 'StrLnk' },
+    ],
+    fleetStats: {
+      mainline: { starlink: 51, total: 1122 },
+      express: { starlink: 320, total: 659 },
+    },
+    flightsByTail: {
+      N32: [
+        { flight_number: 'SKW2', departure_airport: 'MKE', arrival_airport: 'IAH', departure_time: 1780318800, arrival_time: 1780329600, airline: 'UA' },
+        { flight_number: 'SKW1', departure_airport: 'DEN', arrival_airport: 'MKE', departure_time: 1780270800, arrival_time: 1780280100, airline: 'UA' },
+      ],
+    },
+    lastUpdated: '2026-05-31T23:02:04.479Z',
+  };
+
+  it('reports the real Starlink count, NOT upstream.totalCount (the whole fleet)', () => {
+    const out = normalizeStarlinkPayload(upstream, '2026-05-31T23:40:00.000Z');
+    expect(out.totalCount).toBe(2);
+    expect(out.totalCount).not.toBe(1781);
+  });
+
+  it('normalises operator casing and airframe types', () => {
+    const out = normalizeStarlinkPayload(upstream, '2026-05-31T23:40:00.000Z');
+    expect(out.aircraft[0]).toMatchObject({ tail: 'N51', fleet: 'Mainline', type: '737-900ER', operator: 'United Airlines', wifi: 'Starlink' });
+    expect(out.aircraft[1]).toMatchObject({ tail: 'N32', fleet: 'Express', type: 'CRJ-550', operator: 'SkyWest dba UAX', dateFound: '2026-05-31' });
+  });
+
+  it('derives fleetStats incl. rollout percentages when upstream omits `combined`', () => {
+    const out = normalizeStarlinkPayload(upstream, '2026-05-31T23:40:00.000Z');
+    expect(out.fleetStats).toMatchObject({
+      mainline: 51, express: 320, total: 371,
+      mainlineTotal: 1122, expressTotal: 659, fleetTotal: 1781,
+      mainlinePct: 5, expressPct: 49,
+    });
+  });
+
+  it('converts flight epochs to ISO + numeric ts and sorts chronologically', () => {
+    const out = normalizeStarlinkPayload(upstream, '2026-05-31T23:40:00.000Z');
+    const flights = out.flightsByTail.N32;
+    // Input was out of order (SKW2 then SKW1); normaliser sorts ascending by departure.
+    expect(flights.map(f => f.flight_number)).toEqual(['SKW1', 'SKW2']);
+    expect(flights[0].departure_ts).toBe(1780270800);
+    expect(flights[0].departure_time).toBe(new Date(1780270800 * 1000).toISOString());
+    expect(flights[0].arrival_time).toBe(new Date(1780280100 * 1000).toISOString());
+    expect(flights[0].origin).toBe('DEN');
+    expect(flights[0].destination).toBe('MKE');
+  });
+
+  it('handles an empty / malformed payload without throwing', () => {
+    expect(normalizeStarlinkPayload({}).totalCount).toBe(0);
+    expect(normalizeStarlinkPayload(null).aircraft).toEqual([]);
+    expect(normalizeStarlinkPayload({ starlinkPlanes: [] }).fleetStats).toBeNull();
+  });
+});

--- a/tests/sync-starlink.test.js
+++ b/tests/sync-starlink.test.js
@@ -25,17 +25,18 @@ function mockUpstream(planes = 2) {
     starlinkPlanes: Array.from({ length: planes }, (_, i) => ({
       TailNumber: `N${10000 + i}`,
       fleet: i % 2 === 0 ? 'mainline' : 'express',
-      Aircraft: 'B738',
-      OperatedBy: 'United Airlines',
+      Aircraft: 'Boeing 737-824',
+      OperatedBy: 'Skywest dba UAX',
+      DateFound: '2020-01-01',
+      WiFi: 'Starlink',
     })),
-    totalCount: planes,
+    totalCount: 1781, // upstream's whole-fleet number; must not become the Starlink count
     fleetStats: {
       mainline: { starlink: 1, total: 800 },
       express: { starlink: 1, total: 500 },
-      combined: { starlink: planes, total: 1300 },
     },
     flightsByTail: {},
-    lastUpdated: '2026-04-04T12:00:00Z',
+    lastUpdated: '2026-05-31T23:02:04.479Z',
   };
 }
 
@@ -94,8 +95,24 @@ describe('sync-starlink cron', () => {
 
     const cache = (globalThis).__starlinkCache;
     expect(cache.aircraft[0].tail).toBe('N10000');
-    expect(cache.aircraft[0].fleet).toBe('Mainline'); // capitalized
-    expect(cache.aircraft[0].type).toBe('B738');
+    expect(cache.aircraft[0].fleet).toBe('Mainline');        // capitalized
+    expect(cache.aircraft[0].type).toBe('737-800');          // normalized from "Boeing 737-824"
+    expect(cache.aircraft[0].operator).toBe('SkyWest dba UAX'); // normalized casing
+    expect(cache.totalCount).toBe(1);                        // real Starlink count, not upstream 1781
+  });
+
+  it('refuses to persist an empty board (does not poison the snapshot/cache)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => mockUpstream(0),
+    });
+
+    const res = createRes();
+    await handler(makeReq(), res);
+
+    expect(res.statusCode).toBe(502);
+    expect(res.body.error).toMatch(/0 Starlink/);
+    expect((globalThis).__starlinkCache).toBeUndefined();
   });
 
   it('returns 502 when upstream returns error status', async () => {


### PR DESCRIPTION
Fixes the Starlink connection and the data it serves. Verified against the live `unitedstarlinktracker.com/api/data` payload (371 Starlink aircraft at time of writing). See [[the-blue-board]] audit context.

## Data correctness (we were serving bad data)
- **Count:** the endpoint served `upstream.totalCount` = **1781** — that's United's *entire* tracked fleet, not the Starlink count (**371**). Now serves the real count. The old test masked it because its mock made the two numbers equal.
- **Operator filter** split `"Skywest dba UAX"` (122) from `"SkyWest dba UAX"` (27) into two rows. Carrier casing is now canonicalised (7→6 operators live).
- **Type filter** had near-duplicates: `"Bombardier CRJ-550"` vs `"CRJ-550"`, and United customer codes (`737-824`, `737-924(ER)`, `A321-271NX`) vs marketing names. Collapsed to one label per airframe, aligned with the mainline fleet vocabulary (11→7 types live).
- **Flight times** were raw UNIX-seconds integers in a field typed `string`. Now emit ISO 8601 + a numeric `departure_ts`, and the "next flight" picks the next *upcoming* departure (not blindly `flights[0]`, which could already have departed).

## The "connection" was architecturally broken
The `sync-starlink` cron wrote `globalThis.__starlinkCache`, but on Vercel the cron runs in a different lambda than the serving endpoint, so that global was **never visible** — a no-op that burned a 727KB upstream fetch every 4h while every cold serving instance independently re-fetched. Same per-instance-state bug PR #177 fixed for the FR24 cost guard; fixed the same way:
- New durable Supabase snapshot `starlink_snapshot` (`sql/008`, RLS-locked, service-role only). Cron writes it; endpoint reads it cross-instance.
- Endpoint serve order: cron-global → in-memory → **Supabase** → upstream; degrades to stale snapshot → committed static file (never blank). `X-Starlink-Source` header reports the path.
- Cron refuses to persist an empty board (no empty-poison).

## Dashboard (give good data)
- Next-flight column shows the next upcoming departure **time**.
- **NEW** text badge (amber, per DESIGN.md — not an emoji) for aircraft equipped in the last 7 days (`DateFound`).
- Stats add an **Express-fleet %** chip and a **"+N New (7d)"** chip.

## Refactor / tests
- Shared `api/_starlink-normalize.ts` now owns the transform (was duplicated across the cron and the endpoint, free to drift).
- Tests updated to the **real** upstream shape (epoch times, no `combined`, mixed casing) so they actually catch the count bug, + new `_starlink-normalize` unit tests. **595 tests pass**, typecheck clean, build OK.

## ⚠️ Deploy action
Apply `sql/008_starlink_snapshot.sql` to Supabase (and ensure `SUPABASE_SERVICE_ROLE_KEY` is set). Safe no-op until then — the endpoint falls back to direct upstream fetch + static file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)