### PR TITLE
feat(dashboard): dedicated top-level STARLINK tab with clickable expanding rows

### DIFF
--- a/docs/superpowers/specs/2026-06-01-starlink-tab-design.md
+++ b/docs/superpowers/specs/2026-06-01-starlink-tab-design.md
@@ -1,0 +1,140 @@
+# STARLINK Tab — Design Spec
+
+**Date:** 2026-06-01
+**Status:** Approved (mockup Direction A — "NOC Console", selected by Jonah)
+**Supersedes:** PR #180 (`feat/starlink-top-level-tab`, the shortcut-tab approach)
+
+## Problem
+
+Starlink coverage is The Blue Board's most differentiated dataset (371 equipped aircraft, live
+flight assignments, install dates), but it is buried as a sub-tab under FLEET and its data is the
+only table on the site whose rows are not clickable. Users — including the owner — repeatedly
+cannot find it.
+
+## Goals
+
+1. Starlink gets a top-level 🛰️ STARLINK nav tab (desktop tab bar + mobile More menu), deep-linkable
+   as `#starlink`.
+2. Every tail in the table is clickable and expands inline into that aircraft's flight timeline and
+   actions ("NOC Console" direction).
+3. The tab leads with rollout stats: equipped count, Express/Mainline progress bars, new-this-week,
+   airborne-now.
+4. Looks excellent per DESIGN.md: dark NOC, Satoshi/DM Sans/JetBrains Mono, amber used only for
+   emphasis (NEW badges, hero number, featured borders).
+5. Zero API changes — the data is already served by `/api/starlink-data` (fixed/enriched in PR #185/#187).
+
+## Non-Goals
+
+- No new backend endpoints or schema changes.
+- No per-flight pages or flight-detail modals (the timeline rows are informational).
+- No changes to the LIVE OPS map beyond reusing the existing `focusFlight()` to track an airborne
+  Starlink aircraft.
+
+## Architecture
+
+### Navigation
+
+- `public/index.html`: add `<button class="tab-btn" data-tab="tab-starlink">🛰️ STARLINK</button>`
+  between FLEET and DELAYS·WEATHER·HUBS in `#tab-bar`; add the same entry to `#mobile-more-menu`.
+- `src/dashboard/main.js`: add `'tab-starlink': '#starlink'` to `TAB_HASHES`; add a
+  `tab-starlink` init branch in `switchToTab()`'s requestAnimationFrame block that calls
+  `initStarlinkTab()` and — mirroring the FLEET branch — `refreshFlights()` when `allFlights` is
+  empty, so airborne status works when a user deep-links straight to `#starlink`.
+- A real `<div class="tab-content" id="tab-starlink" role="tabpanel">` panel — NOT PR #180's
+  virtual mapping onto `#tab-fleet`.
+
+### Tab content (`#tab-starlink`)
+
+Three zones, top to bottom:
+
+1. **Hero band** (`.sl-hero`, amber-left-bordered card per DESIGN.md "Featured/highlight"):
+   - Left: `371` (JetBrains Mono 32px, amber) over "AIRCRAFT EQUIPPED" micro-label.
+   - Center: two progress bars — Express `320/659 · 49%` (green fill), Mainline `51/1122 · 5%`
+     (accent-blue fill).
+   - Right: chips — `+N NEW THIS WEEK` (amber soft) and `● N AIRBORNE NOW` (green soft, live).
+2. **Filter bar** (`.sl-filters`, mirrors existing fleet-controls pattern):
+   - Tail search input, Fleet select, Type select, Operator select (populated from data, already
+     deduped server-side), and a "★ New this week" toggle chip.
+   - Sortable column headers (same `data-*-sort` pattern as the existing Starlink table).
+3. **Aircraft table** (`#sl-table` / `#sl-tbody`):
+   - Columns: Tail · Fleet · Type · Operator · Status · Next Flight.
+   - Tail cell: `.ac-reg-link`-styled clickable + NEW badge when `dateFound` ≤ 7 days.
+   - Status: `● Airborne` (green badge, matched against the live flight feed) or `Scheduled` (muted).
+   - Next Flight: next upcoming flight number + route + local HH:MM (existing logic, moved here).
+   - **Row expansion**: clicking anywhere on the row (except links/buttons inside it) toggles an
+     inset `<tr class="sl-expand">` directly below it containing:
+     - Meta cards: Starlink Since (amber, relative + absolute) · Operator · Airframe · Flights Today.
+     - Flight timeline: up to 5 upcoming flights as `flight_number · ORG → DST · HH:MM – HH:MM` rows.
+     - Actions: `📡 Track on Live Map` (only when airborne; calls `focusFlight(icao24)` and switches
+       to LIVE OPS) · `Aircraft Details` (existing modal) · `Planespotters ↗` (external).
+     - Only one row expanded at a time; clicking another tail collapses the previous. Re-sorting,
+       filtering, or searching collapses any expanded row (the table fully re-renders).
+
+### FLEET tab cleanup
+
+- Remove the Starlink sub-tab button (`#fleet-subtab-starlink`), its panel (`#fleet-view-starlink`),
+  its filter row (`#fleet-controls-starlink`), and `renderStarlinkTable()`/`initStarlinkFilters()`
+  (logic moves to the new tab's renderer).
+- Keep: fleet-pulse rollout chips/progress (Zone 1), `SL` badges in the fleet & airborne tables,
+  `STARLINK_TAILS` set, and the `fleet-starlink-source` attribution line (moves into the new tab's
+  footer).
+- The fleet sub-tab count (`fleet-subtab-count-starlink`) and `switchFleetView('starlink')`
+  references are removed; deep links that used FLEET→Starlink now route to `#starlink`.
+
+### Data flow
+
+```
+loadFleetData() [existing, unchanged]
+  ├── /api/starlink-data → STARLINK_DB, STARLINK_FLIGHTS_BY_TAIL, STARLINK_FLEET_STATS, STARLINK_LAST_UPDATED
+  └── /data/fleet.json   → FLEET_DB (for Aircraft Details modal)
+
+initStarlinkTab() [new, called on first tab activation]
+  ├── renderStarlinkHero()    ← STARLINK_FLEET_STATS + dateFound counts + airborne count
+  ├── renderStarlinkTable()   ← STARLINK_DB filtered/sorted (rebuilt; lives in new tab)
+  └── wireStarlinkFilters()   ← once
+
+Airborne matching [new helper]
+  starlinkAirborne(): Map<tail → {icao24, flight}> built from allFlights (live feed already polled
+  by LIVE OPS); refreshed on tab activation and on the existing flight-refresh cycle.
+
+Row expansion [new, delegated via existing data-action click handler]
+  data-action="sl-expand" data-tail="N75432" → toggle .sl-expand row, render timeline from
+  STARLINK_FLIGHTS_BY_TAIL[tail]
+  data-action="sl-track" data-icao24="..." → switchToTab('tab-live') + focusFlight(icao24)
+```
+
+### Styling (`public/css/style.css`)
+
+New classes, all from DESIGN.md tokens: `.sl-hero`, `.sl-hero-num`, `.sl-bars`, `.sl-bar-track/.fill`,
+`.sl-chip`, `.sl-filters`, `.sl-table` (inherits existing table styles), `.sl-expand`,
+`.sl-meta-grid/.sl-meta`, `.sl-fl-row`, `.sl-actions/.sl-btn`, `.sl-live-badge`. Reuses
+`.starlink-new-badge` and `.starlink-next-time` from PR #185. Single 600px responsive breakpoint:
+hero stacks vertically, meta grid 2-col, table horizontal-scrolls.
+
+## Degraded modes
+
+| Condition | Behavior |
+|---|---|
+| Static fallback only (no fleetStats/flights) | Hero shows count only (bars hidden), Status + Next Flight columns hidden, expanded row shows meta + Planespotters only |
+| Live feed unavailable | Airborne chip hidden, Status column shows `—`, no Track action |
+| Aircraft not in FLEET_DB (Express) | "Aircraft Details" still opens the modal with its existing Express fallback content |
+| flightsByTail missing a tail | Expanded row shows "No upcoming flights in feed" placeholder |
+
+## Verification plan
+
+1. `bun run typecheck` + `bunx vitest run` (full suite stays green — no api changes expected).
+2. `bun run build` (vite dashboard + astro).
+3. Browser QA against a local server via gstack browse: tab appears + hash routing, hero numbers
+   match `/api/starlink-data`, tail click expands/collapses, only-one-expanded invariant, NEW
+   badge filter, Track-on-Map jumps to LIVE OPS focused on the right plane, Aircraft Details modal,
+   mobile (375px) layout, FLEET tab still works minus the removed sub-tab.
+4. PR with before/after screenshots; close PR #180 referencing this PR.
+
+## Files touched
+
+- `public/index.html` — tab button, mobile menu entry, `#tab-starlink` panel markup, remove fleet
+  starlink sub-tab markup
+- `src/dashboard/main.js` — TAB_HASHES, switchToTab branch, initStarlinkTab + renderers + airborne
+  matcher + delegated actions, remove old renderStarlinkTable/initStarlinkFilters
+- `public/css/style.css` — `.sl-*` styles
+- `docs/superpowers/specs/2026-06-01-starlink-tab-design.md` — this spec

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -358,6 +358,65 @@ tbody td{padding:5px 8px;white-space:nowrap}
 .starlink-new-badge{display:inline-block;vertical-align:middle;font-family:var(--font-mono);font-size:9px;font-weight:600;text-transform:uppercase;letter-spacing:.5px;padding:1px 5px;border-radius:3px;background:var(--ua-amber-soft);color:var(--ua-amber)}
 .starlink-next-time{color:var(--ua-muted);font-family:var(--font-mono)}
 
+/* ═══ STARLINK TAB ═══ */
+#tab-starlink{padding:16px;flex:1;min-height:0;overflow-y:auto}
+.sl-zone{max-width:1100px;margin:0 auto}
+.sl-hero-label{font-family:var(--font-mono);font-size:10px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;color:var(--ua-amber);margin-bottom:10px}
+.sl-hero{display:grid;grid-template-columns:auto 1fr auto;gap:24px;align-items:center;background:linear-gradient(180deg,var(--ua-panel) 0%,rgba(17,26,39,.6) 100%);border:1px solid var(--ua-border);border-left:3px solid var(--ua-amber);border-radius:0 6px 6px 0;padding:16px 20px;margin-bottom:14px}
+.sl-hero-num{font-family:var(--font-mono);font-size:32px;font-weight:700;color:var(--ua-amber);line-height:1}
+.sl-hero-sub{font-family:var(--font-mono);font-size:9px;text-transform:uppercase;letter-spacing:1px;color:var(--ua-muted);margin-top:4px}
+.sl-bars{display:flex;flex-direction:column;gap:10px;min-width:0}
+.sl-bar-row{display:grid;grid-template-columns:64px 1fr 110px;gap:10px;align-items:center;font-family:var(--font-mono);font-size:10px}
+.sl-bar-label{color:var(--ua-muted);text-transform:uppercase;letter-spacing:.5px}
+.sl-bar-track{height:6px;background:var(--ua-border);border-radius:3px;overflow:hidden}
+.sl-bar-fill{height:100%;border-radius:3px;width:0;transition:width .5s ease}
+.sl-bar-fill-express{background:var(--ua-green)}
+.sl-bar-fill-mainline{background:var(--ua-accent)}
+.sl-bar-val{color:var(--ua-text);text-align:right;white-space:nowrap}
+.sl-hero-chips{display:flex;flex-direction:column;gap:8px;align-items:flex-end}
+.sl-chip{display:inline-flex;align-items:center;gap:6px;font-family:var(--font-mono);font-size:10px;padding:4px 10px;border-radius:3px;white-space:nowrap}
+.sl-chip-new{background:var(--ua-amber-soft);border:1px solid rgba(196,163,90,.25);color:var(--ua-amber)}
+.sl-chip-live{background:rgba(34,197,94,.1);border:1px solid rgba(34,197,94,.2);color:var(--ua-green)}
+.sl-filters{display:flex;gap:8px;margin-bottom:12px;flex-wrap:wrap;align-items:center}
+.sl-filters input,.sl-filters select{background:var(--ua-panel);color:var(--ua-text);border:1px solid var(--ua-border);padding:5px 10px;font-family:var(--font-mono);font-size:10px;border-radius:3px}
+.sl-new-toggle{background:var(--ua-panel);color:var(--ua-amber);border:1px solid rgba(196,163,90,.4);padding:5px 10px;font-family:var(--font-mono);font-size:10px;border-radius:3px;cursor:pointer;transition:background .15s ease,border-color .15s ease}
+.sl-new-toggle[aria-pressed="true"]{background:var(--ua-amber-soft);border-color:var(--ua-amber)}
+.sl-table-wrap{max-height:none}
+#sl-table .sl-row{cursor:pointer}
+#sl-table .sl-row:hover td{background:rgba(0,93,170,.06)}
+#sl-table .sl-row.expanded td{background:var(--ua-blue-soft)}
+#sl-table .sl-row:focus-visible{outline:2px solid var(--ua-accent);outline-offset:-2px}
+.sl-tail{color:var(--ua-accent);font-weight:700}
+.sl-live-badge{display:inline-block;font-size:9px;font-weight:600;font-family:var(--font-mono);color:var(--ua-green);background:rgba(34,197,94,.1);border:1px solid rgba(34,197,94,.2);padding:1px 6px;border-radius:3px;text-transform:uppercase;letter-spacing:.5px}
+.sl-status-sched{color:var(--ua-dim);font-size:10px;font-family:var(--font-mono)}
+.sl-expand>td{padding:0!important;border-left:3px solid var(--ua-amber);background:var(--ua-panel);white-space:normal}
+.sl-expand-inner{padding:14px 16px}
+.sl-meta-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:10px;margin-bottom:12px}
+.sl-meta{background:var(--ua-panel-elevated);border:1px solid var(--ua-border);border-radius:4px;padding:8px 10px}
+.sl-meta-k{font-family:var(--font-mono);font-size:8px;text-transform:uppercase;letter-spacing:.5px;color:var(--ua-dim)}
+.sl-meta-v{font-family:var(--font-mono);font-size:12px;font-weight:600;margin-top:2px;color:var(--ua-text)}
+.sl-meta-amber{color:var(--ua-amber)}
+.sl-timeline-label{font-family:var(--font-mono);font-size:9px;text-transform:uppercase;letter-spacing:.5px;color:var(--ua-dim);margin:8px 0 6px}
+.sl-fl-row{display:grid;grid-template-columns:80px 1fr auto;gap:14px;padding:6px 0;border-bottom:1px dashed var(--ua-border-subtle);font-family:var(--font-mono);font-size:11px;align-items:center}
+.sl-fl-row:last-of-type{border-bottom:none}
+.sl-fl-num{color:var(--ua-accent);font-weight:600}
+.sl-fl-route{color:var(--ua-text)}
+.sl-arrow{color:var(--ua-dim)}
+.sl-fl-time{color:var(--ua-muted);font-size:10px}
+.sl-fl-empty{color:var(--ua-muted);font-size:11px;padding:8px 0}
+.sl-actions{display:flex;gap:8px;margin-top:12px;flex-wrap:wrap}
+.sl-btn{font-family:var(--font-mono);font-size:10px;font-weight:600;padding:6px 14px;border-radius:3px;border:1px solid var(--ua-border);background:var(--ua-panel-elevated);color:var(--ua-text);cursor:pointer;text-decoration:none;display:inline-flex;align-items:center;gap:4px;transition:border-color .15s ease,color .15s ease}
+.sl-btn:hover{border-color:var(--ua-accent);color:var(--ua-accent)}
+.sl-btn-primary{background:var(--ua-blue);border-color:var(--ua-blue);color:#fff}
+.sl-btn-primary:hover{background:#0068c0;border-color:#0068c0;color:#fff}
+.sl-empty{text-align:center;padding:30px;color:var(--ua-muted);font-size:11px}
+@media (max-width:600px){
+  .sl-hero{grid-template-columns:1fr;gap:14px}
+  .sl-hero-chips{flex-direction:row;align-items:flex-start;flex-wrap:wrap}
+  .sl-meta-grid{grid-template-columns:repeat(2,1fr)}
+  .sl-bar-row{grid-template-columns:56px 1fr 90px}
+}
+
 /* Special Aircraft Badge & Tracker */
 .special-badge{background:rgba(139,92,246,.2);color:#a78bfa;padding:2px 6px;border-radius:3px;font-size:9px;font-weight:700;font-family:var(--font-mono)}
 .special-airborne-badge{background:rgba(34,197,94,.25);color:var(--ua-green);padding:2px 6px;border-radius:3px;font-size:9px;font-weight:700;font-family:var(--font-mono);animation:pulse 1.5s ease-in-out infinite}

--- a/public/index.html
+++ b/public/index.html
@@ -212,6 +212,7 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
   <button class="tab-btn active" data-tab="tab-live" role="tab" tabindex="0" aria-selected="true" aria-controls="tab-live"><span aria-hidden="true">📡</span> LIVE OPS</button>
   <button class="tab-btn" data-tab="tab-schedule" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-schedule"><span aria-hidden="true">📅</span> SCHEDULE</button>
   <button class="tab-btn" data-tab="tab-fleet" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-fleet"><span aria-hidden="true">✈️</span> FLEET</button>
+  <button class="tab-btn" data-tab="tab-starlink" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-starlink"><span aria-hidden="true">🛰️</span> STARLINK</button>
   <button class="tab-btn" data-tab="tab-weather" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-weather"><span aria-hidden="true">🌦</span> DELAYS · WEATHER · HUBS</button>
   <button class="tab-btn" data-tab="tab-analytics" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-analytics" aria-label="Stats"><span aria-hidden="true">📊</span> STATS</button>
   <button class="tab-btn" data-tab="tab-sources" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-sources"><span aria-hidden="true">ℹ️</span> SOURCES</button>
@@ -223,12 +224,14 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
   <button data-tab="tab-weather" role="tab" aria-selected="false" aria-controls="tab-weather"><span class="bnav-icon" aria-hidden="true">🌦</span><span class="bnav-label">Weather</span></button>
   <button data-tab="tab-schedule" role="tab" aria-selected="false" aria-controls="tab-schedule"><span class="bnav-icon" aria-hidden="true">📅</span><span class="bnav-label">Schedule</span></button>
   <button data-tab="tab-fleet" role="tab" aria-selected="false" aria-controls="tab-fleet"><span class="bnav-icon" aria-hidden="true">✈️</span><span class="bnav-label">Fleet</span></button>
+  <button data-tab="tab-starlink" class="bnav-overflow-item" role="tab" aria-selected="false" aria-controls="tab-starlink"><span class="bnav-icon" aria-hidden="true">🛰️</span><span class="bnav-label">Starlink</span></button>
   <button data-tab="tab-myflight" class="bnav-overflow-item" role="tab" aria-selected="false" aria-controls="tab-myflight"><span class="bnav-icon" aria-hidden="true">🎫</span><span class="bnav-label">My Flights</span></button>
   <button data-tab="tab-analytics" class="bnav-overflow-item" role="tab" aria-selected="false" aria-controls="tab-analytics"><span class="bnav-icon" aria-hidden="true">📊</span><span class="bnav-label">Stats</span></button>
   <button data-tab="tab-sources" class="bnav-overflow-item" role="tab" aria-selected="false" aria-controls="tab-sources"><span class="bnav-icon" aria-hidden="true">ℹ️</span><span class="bnav-label">Sources</span></button>
   <button id="mobile-more-btn" aria-label="More tabs" aria-expanded="false" aria-controls="mobile-more-menu"><span class="bnav-icon" aria-hidden="true">▾</span><span class="bnav-label">More</span></button>
 </nav>
 <div id="mobile-more-menu" aria-label="Additional navigation tabs">
+  <button data-tab="tab-starlink"><span class="bnav-icon" aria-hidden="true">🛰️</span> Starlink</button>
   <button data-tab="tab-myflight"><span class="bnav-icon" aria-hidden="true">🎫</span> My Flights</button>
   <button data-tab="tab-analytics"><span class="bnav-icon" aria-hidden="true">📊</span> Stats</button>
   <button data-tab="tab-sources"><span class="bnav-icon" aria-hidden="true">ℹ️</span> Sources</button>
@@ -504,7 +507,7 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
     <div class="fleet-subtab-bar" id="fleet-subtab-bar" role="tablist" aria-label="Aircraft lookup views">
       <button class="fleet-subtab active" role="tab" aria-selected="true" data-action="fleet-subtab" data-view="all" id="fleet-subtab-all">All Aircraft <span class="fleet-subtab-count" id="fleet-subtab-count-all"></span></button>
       <button class="fleet-subtab" role="tab" aria-selected="false" data-action="fleet-subtab" data-view="airborne" id="fleet-subtab-airborne">Airborne Now <span class="fleet-subtab-count" id="fleet-subtab-count-airborne"></span></button>
-      <button class="fleet-subtab" role="tab" aria-selected="false" data-action="fleet-subtab" data-view="starlink" id="fleet-subtab-starlink">Starlink <span class="fleet-subtab-count" id="fleet-subtab-count-starlink"></span></button>
+      <button class="fleet-subtab" role="tab" aria-selected="false" data-action="switch-tab" data-tab="tab-starlink" id="fleet-subtab-starlink">🛰️ Starlink <span class="fleet-subtab-count" id="fleet-subtab-count-starlink"></span></button>
       <button class="fleet-subtab" role="tab" aria-selected="false" data-action="fleet-subtab" data-view="special" id="fleet-subtab-special">Special <span class="fleet-subtab-count" id="fleet-subtab-count-special"></span></button>
     </div>
     <div class="fleet-lookup-seat-config" id="fleet-lookup-seat-config"></div>
@@ -514,13 +517,6 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
       <select id="fleet-filter-wifi" aria-label="Fleet WiFi filter"><option value="">All WiFi</option></select>
       <select id="fleet-filter-status" aria-label="Fleet status filter"><option value="">All Status</option><option value="active">Active</option><option value="stored">Stored/Maint</option><option value="starlink">Starlink</option><option value="special">Special/Named</option></select>
       <button class="refresh-btn" data-action="refresh-fleet-data">Refresh</button>
-    </div>
-    <div class="fleet-controls fleet-controls-starlink" id="fleet-controls-starlink" style="display:none">
-      <input type="text" id="starlink-search" aria-label="Search Starlink aircraft" placeholder="Search tail...">
-      <select id="starlink-filter-fleet" aria-label="Starlink fleet filter"><option value="">All Fleets</option><option value="Mainline">Mainline</option><option value="Express">Express</option></select>
-      <select id="starlink-filter-type" aria-label="Starlink type filter"><option value="">All Types</option></select>
-      <select id="starlink-filter-operator" aria-label="Starlink operator filter"><option value="">All Operators</option></select>
-      <span id="starlink-filtered-count" class="fleet-filtered-count"></span>
     </div>
     <!-- All Aircraft table -->
     <div class="fleet-table-wrap fleet-view-panel active" id="fleet-view-all">
@@ -537,18 +533,50 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
         <tbody id="airborne-tbody"></tbody>
       </table>
     </div>
-    <!-- Starlink table -->
-    <div class="fleet-table-wrap fleet-view-panel" id="fleet-view-starlink" style="display:none">
-      <table id="starlink-table" aria-label="Starlink-equipped aircraft">
-        <thead><tr><th scope="col" data-starlink-sort="tail">Tail</th><th scope="col" data-starlink-sort="fleet">Fleet</th><th scope="col" data-starlink-sort="type">Type</th><th scope="col" data-starlink-sort="operator">Operator</th><th scope="col" id="starlink-next-flight-th" style="display:none">Next Flight</th></tr></thead>
-        <tbody id="starlink-tbody"></tbody>
-      </table>
-    </div>
     <!-- Special Aircraft table -->
     <div class="fleet-table-wrap fleet-view-panel" id="fleet-view-special" style="display:none">
       <div id="special-aircraft-content"><div class="fleet-loading-text">Loading special aircraft...</div></div>
     </div>
-    <div class="fleet-starlink-source" id="fleet-starlink-source" style="display:none">Starlink data via <a href="https://unitedstarlinktracker.com" target="_blank" rel="noopener noreferrer" class="fleet-source-link">unitedstarlinktracker.com</a> · <span id="starlink-updated" class="fleet-starlink-updated">live</span> · <span id="starlink-count">258</span> aircraft</div>
+  </div>
+</div>
+
+<!-- TAB: STARLINK -->
+<div class="tab-content" id="tab-starlink" role="tabpanel" aria-label="Starlink-equipped fleet">
+  <div class="sl-zone">
+    <div class="sl-hero-label">Starlink Rollout</div>
+    <div class="sl-hero">
+      <div class="sl-hero-left">
+        <div class="sl-hero-num" id="sl-hero-count">—</div>
+        <div class="sl-hero-sub">Aircraft Equipped</div>
+      </div>
+      <div class="sl-bars" id="sl-bars">
+        <div class="sl-bar-row"><span class="sl-bar-label">Express</span><div class="sl-bar-track"><div class="sl-bar-fill sl-bar-fill-express" id="sl-bar-express"></div></div><span class="sl-bar-val" id="sl-bar-express-val"></span></div>
+        <div class="sl-bar-row"><span class="sl-bar-label">Mainline</span><div class="sl-bar-track"><div class="sl-bar-fill sl-bar-fill-mainline" id="sl-bar-mainline"></div></div><span class="sl-bar-val" id="sl-bar-mainline-val"></span></div>
+      </div>
+      <div class="sl-hero-chips" id="sl-hero-chips"></div>
+    </div>
+    <div class="sl-filters" id="sl-filters">
+      <input type="text" id="sl-search" aria-label="Search Starlink aircraft" placeholder="Search tail...">
+      <select id="sl-filter-fleet" aria-label="Starlink fleet filter"><option value="">All Fleets</option><option value="Mainline">Mainline</option><option value="Express">Express</option></select>
+      <select id="sl-filter-type" aria-label="Starlink type filter"><option value="">All Types</option></select>
+      <select id="sl-filter-operator" aria-label="Starlink operator filter"><option value="">All Operators</option></select>
+      <button id="sl-filter-new" class="sl-new-toggle" aria-pressed="false" type="button">★ New this week</button>
+      <span id="sl-filtered-count" class="fleet-filtered-count"></span>
+    </div>
+    <div class="fleet-table-wrap sl-table-wrap">
+      <table id="sl-table" aria-label="Starlink-equipped aircraft">
+        <thead><tr>
+          <th scope="col" data-sl-sort="tail">Tail</th>
+          <th scope="col" data-sl-sort="fleet">Fleet</th>
+          <th scope="col" data-sl-sort="type">Type</th>
+          <th scope="col" data-sl-sort="operator">Operator</th>
+          <th scope="col" id="sl-status-th">Status</th>
+          <th scope="col" id="sl-next-th">Next Flight</th>
+        </tr></thead>
+        <tbody id="sl-tbody"><tr><td colspan="6" class="fleet-loading-text">Loading Starlink fleet…</td></tr></tbody>
+      </table>
+    </div>
+    <div class="fleet-starlink-source" id="sl-source">Starlink data via <a href="https://unitedstarlinktracker.com" target="_blank" rel="noopener noreferrer" class="fleet-source-link">unitedstarlinktracker.com</a> · <span id="sl-updated" class="fleet-starlink-updated">live</span> · <span id="sl-count">—</span> aircraft</div>
   </div>
 </div>
 

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -375,7 +375,7 @@ function getBasemapTileOptions() {
 }
 
 // ═══ TAB SWITCHING ═══
-const TAB_HASHES = {'tab-myflight':'#myflight','tab-live':'#live','tab-schedule':'#schedule','tab-fleet':'#fleet','tab-weather':'#weather','tab-analytics':'#stats','tab-sources':'#sources'};
+const TAB_HASHES = {'tab-myflight':'#myflight','tab-live':'#live','tab-schedule':'#schedule','tab-fleet':'#fleet','tab-starlink':'#starlink','tab-weather':'#weather','tab-analytics':'#stats','tab-sources':'#sources'};
 const HASH_TABS = Object.fromEntries(Object.entries(TAB_HASHES).map(([k,v])=>[v,k]));
 
 function switchToTab(tabId, updateHash) {
@@ -394,6 +394,7 @@ function switchToTab(tabId, updateHash) {
     if (tabId === 'tab-live' && map) map.invalidateSize();
     if (tabId === 'tab-schedule') { initScheduleTab(); if (schedInitialized && !schedAllFlights.length && !schedLoading) loadScheduleData(); }
     if (tabId === 'tab-fleet') { if (!allFlights.length && !flightsLoading) refreshFlights(); updateLiveFleetPanel(); }
+    if (tabId === 'tab-starlink') { if (!allFlights.length && !flightsLoading) refreshFlights(); initStarlinkTab(); }
     if (tabId === 'tab-weather') initWeatherTab();
     if (tabId === 'tab-analytics') updateAnalytics();
   });
@@ -439,6 +440,7 @@ document.getElementById('tab-bar')?.addEventListener('keydown', function(e) {
     'live': 'tab-live',
     'schedule': 'tab-schedule',
     'fleet': 'tab-fleet',
+    'starlink': 'tab-starlink',
     'weather': 'tab-weather',
     'irops': 'tab-weather',
     'stats': 'tab-analytics',
@@ -469,7 +471,10 @@ document.getElementById('tab-bar')?.addEventListener('keydown', function(e) {
       // Fleet tab: support sub-tab deep links via ?view=starlink|airborne|special
       if (tab === 'fleet') {
         const viewParam = params.get('view');
-        if (viewParam && ['starlink','airborne','special'].includes(viewParam)) {
+        if (viewParam === 'starlink') {
+          // Starlink is now its own top-level tab — redirect the legacy fleet sub-view deep link.
+          switchToTab('tab-starlink');
+        } else if (viewParam && ['airborne','special'].includes(viewParam)) {
           // Defer to after fleet data loads
           const waitForFleet = setInterval(() => {
             if (typeof switchFleetView === 'function' && FLEET_DB.length > 0) {
@@ -1053,6 +1058,7 @@ async function refreshFlights() {
     [updateMarkers, updateStats, updateHubStats, updateTicker].forEach(fn => { try { fn(); } catch(e) { console.error(fn.name + ':', e); } });
     try { if (document.getElementById('tab-myflight')?.classList.contains('active')) renderMyFlights(); } catch(e) { console.error('renderMyFlights:', e); }
     try { if (document.getElementById('tab-fleet')?.classList.contains('active')) updateLiveFleetPanel(); } catch(e) { console.error('updateLiveFleetPanel:', e); }
+    try { if (document.getElementById('tab-starlink')?.classList.contains('active') && slInitialized) { renderSlHero(); renderSlTable(); } } catch(e) { console.error('renderStarlinkTab:', e); }
     try { if (document.getElementById('tab-analytics')?.classList.contains('active')) updateAnalytics(); } catch(e) { console.error('updateAnalytics:', e); }
     // Handle deep link: ?flight=UA1234 on first load (also supports ?q= for SearchAction compatibility)
     if (!deepLinkHandled) {
@@ -1846,14 +1852,7 @@ function initFleetTab() {
     }
   }
 
-  // Update Starlink tracker freshness indicator
-  if (STARLINK_LAST_UPDATED) {
-    const updatedEl = document.getElementById('starlink-updated');
-    if (updatedEl) {
-      const ago = Math.round((Date.now() - new Date(STARLINK_LAST_UPDATED).getTime()) / 60000);
-      updatedEl.textContent = ago < 60 ? ('Updated ' + ago + 'm ago') : ago < 1440 ? ('Updated ' + Math.round(ago/60) + 'h ago') : ('Updated ' + Math.round(ago/1440) + 'd ago');
-    }
-  }
+  // (Starlink freshness indicator moved to the dedicated STARLINK tab — see renderSlHero)
 
   // Populate filters
   const wifiTypes = [...new Set(FLEET_DB.map(a => normalizeWifi(a.w)).filter(Boolean))].sort();
@@ -1872,8 +1871,6 @@ function initFleetTab() {
   renderFleetComposition();
   renderFleetTable();
   renderAgeChart();
-  renderStarlinkTable();
-  initStarlinkFilters();
   renderFleetHealth();
   renderSpecialAircraftPanel();
   updateFleetSubtabCounts();
@@ -2190,22 +2187,12 @@ function switchFleetView(view) {
     activePanel.classList.add('active');
     activePanel.style.display = '';
   }
-  // Show/hide appropriate controls
+  // Show controls (the Starlink sub-view moved to its own top-level tab — its sub-tab button is now
+  // a switch-tab redirect, so this function never receives view === 'starlink')
   const mainControls = document.getElementById('fleet-controls');
-  const starlinkControls = document.getElementById('fleet-controls-starlink');
-  const starlinkSource = document.getElementById('fleet-starlink-source');
-  if (view === 'starlink') {
-    mainControls.style.display = 'none';
-    starlinkControls.style.display = '';
-    if (starlinkSource) starlinkSource.style.display = '';
-  } else {
-    mainControls.style.display = '';
-    starlinkControls.style.display = 'none';
-    if (starlinkSource) starlinkSource.style.display = 'none';
-  }
+  if (mainControls) mainControls.style.display = '';
   // Render the active view
   if (view === 'airborne') renderAirborneTable();
-  else if (view === 'starlink') renderStarlinkTable();
   else if (view === 'special') renderSpecialAircraftPanel();
   else renderFleetTable();
 }
@@ -2423,7 +2410,14 @@ function renderAgeChart() {
     Object.entries(decades).map(([k, v]) => `<span style="margin-right:8px">${k}: <strong>${v}</strong></span>`).join('');
 }
 
-let starlinkSortKey = 'tail', starlinkSortAsc = true;
+// ═══ STARLINK TAB ═══
+// Dedicated top-level tab (#tab-starlink): rollout hero + filterable table where every row expands
+// inline into that aircraft's flight timeline and actions. Spec:
+// docs/superpowers/specs/2026-06-01-starlink-tab-design.md
+let slSortKey = 'tail', slSortAsc = true;
+let slInitialized = false;
+let slExpandedTail = null;   // tail of the one currently-expanded row (null = none)
+let slShowNewOnly = false;   // "★ New this week" quick filter
 
 // A plane counts as "newly equipped" if upstream first recorded its Starlink (DateFound) within the
 // last 7 days. Computed against the live clock so the badge ages out on its own.
@@ -2443,78 +2437,233 @@ function formatFlightTime(ts) {
   return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 
-function initStarlinkFilters() {
-  // Populate type and operator dropdowns from actual data
-  const types = [...new Set(STARLINK_DB.map(s => s.type))].sort();
-  const operators = [...new Set(STARLINK_DB.map(s => s.operator))].sort();
-  const typeSelect = document.getElementById('starlink-filter-type');
-  const opSelect = document.getElementById('starlink-filter-operator');
-  types.forEach(t => { const o = document.createElement('option'); o.value = t; o.textContent = t; typeSelect.appendChild(o); });
-  operators.forEach(t => { const o = document.createElement('option'); o.value = t; o.textContent = t; opSelect.appendChild(o); });
-
-  // Event listeners for filters
-  ['starlink-search', 'starlink-filter-fleet', 'starlink-filter-type', 'starlink-filter-operator'].forEach(id => {
-    document.getElementById(id).addEventListener(id === 'starlink-search' ? 'input' : 'change', renderStarlinkTable);
-  });
-
-  // Sort headers
-  document.querySelectorAll('[data-starlink-sort]').forEach(th => {
-    th.addEventListener('click', () => {
-      const key = th.getAttribute('data-starlink-sort');
-      if (starlinkSortKey === key) starlinkSortAsc = !starlinkSortAsc;
-      else { starlinkSortKey = key; starlinkSortAsc = true; }
-      renderStarlinkTable();
-    });
-  });
+// Map of tail → live airborne flight from the LIVE OPS feed. One pass over allFlights; cheap enough
+// to rebuild per render.
+function getStarlinkAirborneMap() {
+  const live = {};
+  for (const f of allFlights) {
+    if (f.onGround) continue;
+    const reg = (f.reg || '').replace(/-/g, '').toUpperCase();
+    if (reg && STARLINK_TAILS.has(reg)) live[reg] = f;
+  }
+  return live;
 }
 
-function renderStarlinkTable() {
-  const search = (document.getElementById('starlink-search').value || '').trim().toUpperCase();
-  const fleetFilter = document.getElementById('starlink-filter-fleet').value;
-  const typeFilter = document.getElementById('starlink-filter-type').value;
-  const opFilter = document.getElementById('starlink-filter-operator').value;
+// Idempotent init for the STARLINK tab — wires filters/sort once, then (re)renders hero + table.
+function initStarlinkTab() {
+  if (!slInitialized && STARLINK_DB.length > 0) {
+    slInitialized = true;
+
+    // Populate type and operator dropdowns from actual data (already normalized server-side)
+    const types = [...new Set(STARLINK_DB.map(s => s.type))].sort();
+    const operators = [...new Set(STARLINK_DB.map(s => s.operator))].sort();
+    const typeSelect = document.getElementById('sl-filter-type');
+    const opSelect = document.getElementById('sl-filter-operator');
+    types.forEach(t => { const o = document.createElement('option'); o.value = t; o.textContent = t; typeSelect.appendChild(o); });
+    operators.forEach(t => { const o = document.createElement('option'); o.value = t; o.textContent = t; opSelect.appendChild(o); });
+
+    // Filter listeners — any change collapses the expanded row and re-renders
+    ['sl-search', 'sl-filter-fleet', 'sl-filter-type', 'sl-filter-operator'].forEach(id => {
+      document.getElementById(id).addEventListener(id === 'sl-search' ? 'input' : 'change', () => {
+        slExpandedTail = null;
+        renderSlTable();
+      });
+    });
+
+    // "★ New this week" quick filter toggle
+    document.getElementById('sl-filter-new').addEventListener('click', function() {
+      slShowNewOnly = !slShowNewOnly;
+      this.setAttribute('aria-pressed', slShowNewOnly ? 'true' : 'false');
+      slExpandedTail = null;
+      renderSlTable();
+    });
+
+    // Sort headers
+    document.querySelectorAll('[data-sl-sort]').forEach(th => {
+      th.addEventListener('click', () => {
+        const key = th.getAttribute('data-sl-sort');
+        if (slSortKey === key) slSortAsc = !slSortAsc;
+        else { slSortKey = key; slSortAsc = true; }
+        slExpandedTail = null;
+        renderSlTable();
+      });
+    });
+  }
+  renderSlHero();
+  renderSlTable();
+}
+
+// Hero band: equipped count, Express/Mainline rollout bars, new-this-week + airborne-now chips.
+function renderSlHero() {
+  const countEl = document.getElementById('sl-hero-count');
+  if (!countEl) return;
+  const fs = STARLINK_FLEET_STATS;
+  const total = fs ? fs.total : STARLINK_DB.length;
+  countEl.textContent = total || '—';
+
+  // Rollout bars need fleet denominators — hide them in degraded (static-fallback) mode
+  const barsEl = document.getElementById('sl-bars');
+  if (fs && fs.expressTotal && fs.mainlineTotal) {
+    barsEl.style.display = '';
+    const expressPct = (fs.expressPct != null) ? fs.expressPct : Math.round(fs.express / fs.expressTotal * 100);
+    const mainlinePct = (fs.mainlinePct != null) ? fs.mainlinePct : Math.round(fs.mainline / fs.mainlineTotal * 100);
+    document.getElementById('sl-bar-express').style.width = expressPct + '%';
+    document.getElementById('sl-bar-mainline').style.width = mainlinePct + '%';
+    document.getElementById('sl-bar-express-val').textContent = fs.express + ' / ' + fs.expressTotal + ' · ' + expressPct + '%';
+    document.getElementById('sl-bar-mainline-val').textContent = fs.mainline + ' / ' + fs.mainlineTotal + ' · ' + mainlinePct + '%';
+  } else {
+    barsEl.style.display = 'none';
+  }
+
+  // Chips: new this week (amber) + airborne now (green; only when the live feed has data).
+  // Note: counts are integers derived from our own data — safe for innerHTML.
+  const newThisWeek = STARLINK_DB.filter(s => isRecentlyFound(s.dateFound)).length;
+  const airborneCount = Object.keys(getStarlinkAirborneMap()).length;
+  let chips = '';
+  if (newThisWeek > 0) chips += '<span class="sl-chip sl-chip-new">+' + newThisWeek + ' NEW THIS WEEK</span>';
+  if (airborneCount > 0) chips += '<span class="sl-chip sl-chip-live">● ' + airborneCount + ' AIRBORNE NOW</span>';
+  document.getElementById('sl-hero-chips').innerHTML = chips;
+
+  // Source line: count + freshness
+  document.getElementById('sl-count').textContent = STARLINK_DB.length;
+  if (STARLINK_LAST_UPDATED) {
+    const ago = Math.round((Date.now() - new Date(STARLINK_LAST_UPDATED).getTime()) / 60000);
+    document.getElementById('sl-updated').textContent = ago < 60 ? ('Updated ' + ago + 'm ago') : ago < 1440 ? ('Updated ' + Math.round(ago/60) + 'h ago') : ('Updated ' + Math.round(ago/1440) + 'd ago');
+  }
+}
+
+// The aircraft table. Every row toggles an inline expansion (one at a time).
+function renderSlTable() {
+  const tbody = document.getElementById('sl-tbody');
+  if (!tbody) return;
+
+  if (STARLINK_DB.length === 0) {
+    tbody.innerHTML = '<tr><td colspan="6" class="sl-empty">Starlink fleet data unavailable — try refreshing the page.</td></tr>';
+    return;
+  }
+
+  const search = (document.getElementById('sl-search').value || '').trim().toUpperCase();
+  const fleetFilter = document.getElementById('sl-filter-fleet').value;
+  const typeFilter = document.getElementById('sl-filter-type').value;
+  const opFilter = document.getElementById('sl-filter-operator').value;
 
   let filtered = STARLINK_DB.filter(s => {
     if (search && !s.tail.toUpperCase().includes(search)) return false;
     if (fleetFilter && s.fleet !== fleetFilter) return false;
     if (typeFilter && s.type !== typeFilter) return false;
     if (opFilter && s.operator !== opFilter) return false;
+    if (slShowNewOnly && !isRecentlyFound(s.dateFound)) return false;
     return true;
   });
 
   filtered.sort((a, b) => {
-    const va = (a[starlinkSortKey] || '').toLowerCase();
-    const vb = (b[starlinkSortKey] || '').toLowerCase();
-    return starlinkSortAsc ? va.localeCompare(vb) : vb.localeCompare(va);
+    const va = (a[slSortKey] || '').toLowerCase();
+    const vb = (b[slSortKey] || '').toLowerCase();
+    return slSortAsc ? va.localeCompare(vb) : vb.localeCompare(va);
   });
 
-  document.getElementById('starlink-filtered-count').textContent = filtered.length < STARLINK_DB.length ? `${filtered.length} of ${STARLINK_DB.length}` : '';
-  document.getElementById('starlink-count').textContent = STARLINK_DB.length;
+  document.getElementById('sl-filtered-count').textContent = filtered.length < STARLINK_DB.length ? `${filtered.length} of ${STARLINK_DB.length}` : '';
 
   const hasFlights = Object.keys(STARLINK_FLIGHTS_BY_TAIL).length > 0;
+  const liveMap = getStarlinkAirborneMap();
+  const hasLive = allFlights.length > 0;
   const nowSec = Date.now() / 1000;
-  document.getElementById('starlink-tbody').innerHTML = filtered.map(s => {
-    let nextFlightHtml = '';
+
+  // Hide the Status / Next Flight columns when the data behind them is unavailable (degraded modes)
+  document.getElementById('sl-status-th').style.display = hasLive ? '' : 'none';
+  document.getElementById('sl-next-th').style.display = hasFlights ? '' : 'none';
+
+  if (filtered.length === 0) {
+    tbody.innerHTML = '<tr><td colspan="6" class="sl-empty">No aircraft match your filters.</td></tr>';
+    return;
+  }
+
+  const rows = [];
+  for (const s of filtered) {
+    const live = liveMap[s.tail];
+    const expanded = slExpandedTail === s.tail;
+
+    let statusHtml = '';
+    if (hasLive) {
+      statusHtml = live
+        ? '<td><span class="sl-live-badge">● Airborne</span></td>'
+        : '<td><span class="sl-status-sched">Scheduled</span></td>';
+    }
+
+    let nextHtml = '';
     if (hasFlights) {
       const flights = STARLINK_FLIGHTS_BY_TAIL[s.tail];
       if (flights && flights.length > 0) {
-        // Next UPCOMING departure (flights are chronological; allow a 30-min grace for one that
-        // just left), falling back to the latest known flight if all are in the past.
+        // Next UPCOMING departure (flights are chronological; 30-min grace for one that just left),
+        // falling back to the latest known flight if all are in the past.
         const next = flights.find(f => (f.departure_ts || 0) >= nowSec - 1800) || flights[flights.length - 1];
         const t = formatFlightTime(next.departure_ts);
-        const timeHtml = t ? ` <span class="starlink-next-time">${escapeHtml(t)}</span>` : '';
-        nextFlightHtml = `<td style="font-size:9px">${escapeHtml(next.flight_number || '')} ${escapeHtml((next.origin || '') + '→' + (next.destination || ''))}${timeHtml}</td>`;
+        nextHtml = `<td style="font-size:9px">${escapeHtml(next.flight_number || '')} ${escapeHtml((next.origin || '') + '→' + (next.destination || ''))}${t ? ` <span class="starlink-next-time">${escapeHtml(t)}</span>` : ''}</td>`;
       } else {
-        nextFlightHtml = '<td style="font-size:9px;color:var(--ua-muted)">—</td>';
+        nextHtml = '<td style="font-size:9px;color:var(--ua-muted)">—</td>';
       }
     }
-    const newBadge = isRecentlyFound(s.dateFound) ? ` <span class="starlink-new-badge" title="Starlink equipment first seen ${escapeHtml(s.dateFound)}">NEW</span>` : '';
-    return `<tr><td style="font-weight:700;color:var(--ua-green)">${escapeHtml(s.tail)}${newBadge}</td><td>${escapeHtml(s.fleet)}</td><td>${escapeHtml(s.type)}</td><td style="font-size:10px">${escapeHtml(s.operator)}</td>${nextFlightHtml}</tr>`;
-  }).join('');
 
-  // Toggle next-flight column header visibility
-  const nextFlightHeader = document.getElementById('starlink-next-flight-th');
-  if (nextFlightHeader) nextFlightHeader.style.display = hasFlights ? '' : 'none';
+    const newBadge = isRecentlyFound(s.dateFound) ? ` <span class="starlink-new-badge" title="Starlink equipment first seen ${escapeHtml(s.dateFound)}">NEW</span>` : '';
+    rows.push(`<tr class="sl-row${expanded ? ' expanded' : ''}" data-action="sl-row-toggle" data-tail="${escapeHtml(s.tail)}" tabindex="0" role="button" aria-expanded="${expanded}">` +
+      `<td><span class="sl-tail">${escapeHtml(s.tail)}</span>${newBadge}</td>` +
+      `<td>${escapeHtml(s.fleet)}</td><td>${escapeHtml(s.type)}</td><td style="font-size:10px">${escapeHtml(s.operator)}</td>` +
+      statusHtml + nextHtml + '</tr>');
+
+    if (expanded) rows.push(renderSlExpand(s, live, hasFlights, hasLive, nowSec));
+  }
+  tbody.innerHTML = rows.join('');
+}
+
+// The inline expansion row: meta cards + flight timeline + actions.
+function renderSlExpand(s, live, hasFlights, hasLive, nowSec) {
+  const colspan = 4 + (hasLive ? 1 : 0) + (hasFlights ? 1 : 0);
+
+  let sinceHtml = 'Unknown';
+  if (s.dateFound) {
+    const days = Math.max(0, Math.round((Date.now() - Date.parse(s.dateFound)) / 86400000));
+    sinceHtml = escapeHtml(s.dateFound) + ' · ' + (days === 0 ? 'today' : days + 'd ago');
+  }
+
+  // Flight timeline: up to 5 upcoming flights
+  const flights = STARLINK_FLIGHTS_BY_TAIL[s.tail] || [];
+  const upcoming = flights.filter(f => (f.departure_ts || 0) >= nowSec - 1800).slice(0, 5);
+  let timelineHtml = '<div class="sl-timeline-label">Upcoming Flights</div>';
+  if (upcoming.length > 0) {
+    timelineHtml += upcoming.map(f => {
+      const dep = formatFlightTime(f.departure_ts);
+      const arrMs = f.arrival_time ? Date.parse(f.arrival_time) : NaN;
+      const arr = isNaN(arrMs) ? '' : formatFlightTime(arrMs / 1000);
+      return `<div class="sl-fl-row"><span class="sl-fl-num">${escapeHtml(f.flight_number || '')}</span>` +
+        `<span class="sl-fl-route">${escapeHtml(f.origin || '')} <span class="sl-arrow">→</span> ${escapeHtml(f.destination || '')}</span>` +
+        `<span class="sl-fl-time">${escapeHtml(dep)}${arr ? ' – ' + escapeHtml(arr) : ''}</span></div>`;
+    }).join('');
+  } else {
+    timelineHtml += '<div class="sl-fl-empty">No upcoming flights in the feed</div>';
+  }
+
+  // Actions: track on map (airborne only) + aircraft details + planespotters
+  let actions = '';
+  if (live && live.icao24) {
+    actions += `<button class="sl-btn sl-btn-primary" data-action="sl-track" data-icao24="${escapeHtml(live.icao24)}">📡 Track on Live Map</button>`;
+  }
+  actions += `<button class="sl-btn" data-action="aircraft-detail" data-reg="${escapeHtml(s.tail)}">Aircraft Details</button>`;
+  actions += `<a class="sl-btn" href="https://www.planespotters.net/search?q=${encodeURIComponent(s.tail)}" target="_blank" rel="noopener noreferrer">Planespotters ↗</a>`;
+
+  return `<tr class="sl-expand"><td colspan="${colspan}"><div class="sl-expand-inner">` +
+    `<div class="sl-meta-grid">` +
+      `<div class="sl-meta"><div class="sl-meta-k">Starlink Since</div><div class="sl-meta-v sl-meta-amber">${sinceHtml}</div></div>` +
+      `<div class="sl-meta"><div class="sl-meta-k">Operator</div><div class="sl-meta-v">${escapeHtml(s.operator)}</div></div>` +
+      `<div class="sl-meta"><div class="sl-meta-k">Airframe</div><div class="sl-meta-v">${escapeHtml(s.type)}</div></div>` +
+      `<div class="sl-meta"><div class="sl-meta-k">Fleet</div><div class="sl-meta-v">${escapeHtml(s.fleet)}</div></div>` +
+    `</div>` + timelineHtml + `<div class="sl-actions">${actions}</div>` +
+  `</div></td></tr>`;
+}
+
+// Toggle a row's inline expansion (only one open at a time).
+function toggleStarlinkExpand(tail) {
+  slExpandedTail = (slExpandedTail === tail) ? null : tail;
+  renderSlTable();
 }
 
 // ═══ FLEET DATA REFRESH ═══
@@ -5997,6 +6146,16 @@ document.addEventListener('click', function(e) {
     case 'close-delay-explain': {
       const dem = document.getElementById('delay-explain-modal');
       if (dem) dem.style.display = 'none';
+      break;
+    }
+    case 'sl-row-toggle': {
+      const slTail = actionEl.dataset.tail;
+      if (slTail) toggleStarlinkExpand(slTail);
+      break;
+    }
+    case 'sl-track': {
+      const slIcao = actionEl.dataset.icao24;
+      if (slIcao) focusFlight(slIcao); // focusFlight switches to LIVE OPS and centers the map
       break;
     }
     case 'aircraft-detail': {


### PR DESCRIPTION
## What

Starlink gets a first-class **🛰️ STARLINK** top-level tab (`#starlink`), and every aircraft row is now clickable — expanding inline into that plane's flight timeline and actions. Built per the approved design spec (`docs/superpowers/specs/2026-06-01-starlink-tab-design.md`, mockup Direction A "NOC Console").

**The tab:**
- **Hero**: equipped count (371, amber per DESIGN.md), Express **49%** / Mainline **5%** rollout bars, `+2 NEW THIS WEEK` + `● N AIRBORNE NOW` (live) chips
- **Filters**: tail search, fleet/type/operator, **★ New this week** toggle, sortable headers
- **Table**: Tail · Fleet · Type · Operator · **Status** (`● Airborne` matched against the live feed / `Scheduled`) · Next Flight (next *upcoming* + local time)
- **Click any row** → inline expansion: Starlink-since/operator/airframe/fleet meta cards, up-to-5-flight timeline, and **📡 Track on Live Map** (airborne only — jumps to LIVE OPS focused on that plane) / **Aircraft Details** / **Planespotters**
- Live-updates with the existing 30s flight refresh while the tab is open

**FLEET cleanup**: old Starlink sub-view removed; its sub-tab button now redirects here (count badge + muscle memory preserved). Legacy `?tab=fleet&view=starlink` deep links redirect. Fleet-pulse chips + SL badges unchanged.

**Zero API changes** — renders entirely from `/api/starlink-data` (#185/#187) + the existing live feed.

## QA (local build, prod data proxied)

| Check | Result |
|---|---|
| Tab in nav (desktop + mobile More menu), `#starlink` hash | ✅ |
| Hero: 371 · Express 320/659·49% · Mainline 51/1122·5% · +2 new · 51-52 airborne | ✅ |
| 371 rows; Status + Next Flight columns; 2 NEW badges | ✅ |
| Row expansion: meta cards + 5-flight timeline + actions; one-at-a-time invariant; re-click collapses | ✅ |
| ★ New this week filter → "2 of 371", all rows badged | ✅ |
| Track on Live Map → switches to LIVE OPS + opens the plane's map popup | ✅ |
| Aircraft Details modal (mainline + Express fallback) | ✅ |
| Fresh deep-link `/#starlink` (desktop + mobile 375px) | ✅ |
| Legacy `?tab=fleet&view=starlink` redirect | ✅ |
| FLEET regression: All Aircraft / Airborne / Special sub-tabs + chips intact | ✅ |
| `bun run typecheck` · `bunx vitest run` (597 tests) · `bun run build` | ✅ |

## Supersedes

Closes #180 — that PR made STARLINK a shortcut into the FLEET sub-view; this gives it a real dedicated tab with richer interaction, per the design review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)