### PR TITLE
feat(starlink): installation velocity chart — monthly installs + cumulative rollout

### DIFF
--- a/docs/superpowers/specs/2026-06-01-starlink-velocity-chart-design.md
+++ b/docs/superpowers/specs/2026-06-01-starlink-velocity-chart-design.md
@@ -1,0 +1,77 @@
+# Starlink Installation Velocity Chart — Design Spec
+
+**Date:** 2026-06-01
+**Status:** Approved (comp A — "Ops Bars", selected by Jonah from rendered comps)
+**Builds on:** the dedicated STARLINK tab (#188), spec `2026-06-01-starlink-tab-design.md`
+
+## Problem
+
+The STARLINK tab shows the rollout's current state (371 equipped, fleet percentages) but nothing
+about its **velocity** — how fast United is equipping aircraft month over month, and how the
+rollout has shifted from Express (2025) to Mainline (2026). The data to show this already exists:
+every aircraft carries `dateFound`.
+
+## The chart (comp A — Ops Bars)
+
+A chart card on the STARLINK tab, directly under the hero band, above the filters:
+
+- **Card chrome**: same amber-left-bordered card as the hero. Label `INSTALLATION VELOCITY`
+  (mono, amber, uppercase) · sub `Aircraft equipped per month · <first month> – <current month>`.
+- **Stacked bars per month**: Express (green, `--ua-green`) below, Mainline (accent blue,
+  `--ua-accent`) above, total count label over each bar.
+- **Cumulative line**: amber (`--ua-amber`), 2px, dot per month, riding over the bars on its own
+  scale (0 → live total). End label shows the current total.
+- **Outlier handling**: any month whose total exceeds the visual cap (45/month) renders as a capped
+  bar with a jagged break marker and a `N*` label; a footnote explains the Dec 2025 tracker
+  catch-up batch (117 aircraft on Dec 3).
+- **Zero months**: rendered as empty slots — the time axis is continuous from the first install
+  month to the current month.
+- **Legend**: Express · Mainline · Cumulative.
+- **Left axis**: monthly installs (0–cap). **Right axis**: cumulative (amber, 0–total).
+
+## Data flow
+
+Zero API changes. Everything derives from `STARLINK_DB[].dateFound` + `.fleet`, which the tab
+already loads:
+
+```
+src/lib/starlink-utils.js (NEW — unit-testable, mirrors fleet-utils.js)
+  bucketInstallsByMonth(aircraft, nowDate?) →
+    [{ ym: '2025-03', label: 'MAR 25', express: 7, mainline: 0, total: 7, cumulative: 7 }, ...]
+  - continuous month range: first dateFound month → current month (zero months included)
+  - aircraft without a parseable dateFound are excluded from bars but counted in a returned
+    `undated` count (cumulative line still ends at aircraft.length when undated === 0)
+  - label rule: 'MMM' uppercase; January and the first month carry the 2-digit year ('MAR 25')
+
+src/dashboard/main.js
+  renderSlChart() — builds the SVG from bucketInstallsByMonth(STARLINK_DB); called from
+  initStarlinkTab() after renderSlHero(). Pure-SVG string assembly (no chart library), all
+  dynamic text through escapeHtml.
+```
+
+## Markup / styles
+
+- `public/index.html`: `<div class="sl-chart-card" id="sl-chart-card" style="display:none">` between
+  `.sl-hero` and `.sl-filters`, containing label, sub, `<svg id="sl-chart" viewBox="0 0 940 280">`,
+  legend, and footnote container.
+- `public/css/style.css`: `.sl-chart-card`, `.sl-chart-label`, `.sl-chart-sub`, `.sl-chart-legend`,
+  `.sl-chart-footnote` — all from existing tokens. Mobile (≤600px): card gets horizontal scroll
+  (`overflow-x:auto`) with a min-width on the SVG so bars stay readable.
+
+## Degraded modes
+
+| Condition | Behavior |
+|---|---|
+| No aircraft have `dateFound` (static fallback) | Chart card stays `display:none` |
+| Some aircraft missing `dateFound` | Bars show dated aircraft only; footnote appends "+N undated" |
+| Single month of data | Renders one bar + flat cumulative line (no special case needed) |
+
+## Verification
+
+1. Unit tests (`tests/starlink-utils.test.js`): month bucketing, fleet split, zero-month
+   continuity, cumulative math, undated handling, label formatting, Dec-batch data shape.
+2. `bun run typecheck` + `bunx vitest run` + `bun run build`.
+3. Browser QA (local build + prod data proxy): chart renders under hero, bars/line/labels match
+   live data, break marker + footnote on Dec, mobile 375px horizontal scroll, card hidden when
+   data degraded.
+4. PR off `main`; chart visible after merge.

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -410,6 +410,18 @@ tbody td{padding:5px 8px;white-space:nowrap}
 .sl-btn-primary{background:var(--ua-blue);border-color:var(--ua-blue);color:#fff}
 .sl-btn-primary:hover{background:#0068c0;border-color:#0068c0;color:#fff}
 .sl-empty{text-align:center;padding:30px;color:var(--ua-muted);font-size:11px}
+.sl-chart-card{background:linear-gradient(180deg,var(--ua-panel) 0%,rgba(17,26,39,.6) 100%);border:1px solid var(--ua-border);border-left:3px solid var(--ua-amber);border-radius:0 6px 6px 0;padding:16px 20px;margin-bottom:14px}
+.sl-chart-label{font-family:var(--font-mono);font-size:10px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;color:var(--ua-amber);margin-bottom:2px}
+.sl-chart-sub{font-family:var(--font-mono);font-size:9px;color:var(--ua-dim);margin-bottom:14px;text-transform:uppercase;letter-spacing:.5px}
+.sl-chart-scroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
+#sl-chart{display:block;width:100%;height:auto;min-width:680px}
+#sl-chart text{font-family:var(--font-mono)}
+.sl-chart-legend{display:flex;gap:16px;margin-top:10px;font-family:var(--font-mono);font-size:9px;text-transform:uppercase;letter-spacing:.5px;color:var(--ua-muted)}
+.sl-chart-legend span{display:inline-flex;align-items:center;gap:6px}
+.sl-swatch{width:10px;height:10px;border-radius:2px;display:inline-block}
+.sl-swatch-line{background:var(--ua-amber);height:2px;width:14px}
+.sl-chart-footnote{font-family:var(--font-mono);font-size:8px;color:var(--ua-dim);margin-top:8px}
+.sl-chart-footnote:empty{display:none}
 @media (max-width:600px){
   .sl-hero{grid-template-columns:1fr;gap:14px}
   .sl-hero-chips{flex-direction:row;align-items:flex-start;flex-wrap:wrap}

--- a/public/index.html
+++ b/public/index.html
@@ -555,6 +555,17 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
       </div>
       <div class="sl-hero-chips" id="sl-hero-chips"></div>
     </div>
+    <div class="sl-chart-card" id="sl-chart-card" style="display:none">
+      <div class="sl-chart-label">Installation Velocity</div>
+      <div class="sl-chart-sub" id="sl-chart-sub">Aircraft equipped per month</div>
+      <div class="sl-chart-scroll"><svg id="sl-chart" viewBox="0 0 940 280" role="img" aria-label="Starlink installations per month"></svg></div>
+      <div class="sl-chart-legend">
+        <span><span class="sl-swatch" style="background:var(--ua-green)"></span>Express</span>
+        <span><span class="sl-swatch" style="background:var(--ua-accent)"></span>Mainline</span>
+        <span><span class="sl-swatch sl-swatch-line"></span>Cumulative</span>
+      </div>
+      <div class="sl-chart-footnote" id="sl-chart-footnote"></div>
+    </div>
     <div class="sl-filters" id="sl-filters">
       <input type="text" id="sl-search" aria-label="Search Starlink aircraft" placeholder="Search tail...">
       <select id="sl-filter-fleet" aria-label="Starlink fleet filter"><option value="">All Fleets</option><option value="Mainline">Mainline</option><option value="Express">Express</option></select>

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -4,6 +4,7 @@ import { formatDelayExplainFAAStatus, getScheduleRiskContext } from '../lib/dela
 import { getMetarStationForIata, INTL_AIRPORTS } from '../lib/airport-metadata.js';
 import { chunkMetarStationIds, normalizeMetarPayload } from '../lib/metar.js';
 import { categorizeFleetStatus, FLEET_HEALTH_CATEGORIES, FLEET_FAMILIES, normalizeWifi, WIFI_DISPLAY, sortFleetData, filterFleetData, parseFleetDeepLink, TAB_MAP, VALID_FLEET_VIEWS } from '../lib/fleet-utils.js';
+import { bucketInstallsByMonth } from '../lib/starlink-utils.js';
 import { getFlightPopupMetrics } from '../lib/flight-popup.js';
 import { getScheduleFleetFamily } from '../lib/schedule-filters.js';
 import { getStartOfHubDay, getHubDayLabel } from '../lib/hubTz.js';
@@ -2490,7 +2491,125 @@ function initStarlinkTab() {
     });
   }
   renderSlHero();
+  renderSlChart();
   renderSlTable();
+}
+
+// ═══ INSTALLATION VELOCITY CHART ═══
+// Stacked monthly bars (Express green / Mainline blue) + amber cumulative line, built as pure SVG
+// from STARLINK_DB dateFound. No chart library. Spec: 2026-06-01-starlink-velocity-chart-design.md
+function renderSlChart() {
+  const card = document.getElementById('sl-chart-card');
+  const svg = document.getElementById('sl-chart');
+  if (!card || !svg) return;
+
+  const { months, undated } = bucketInstallsByMonth(STARLINK_DB);
+  // Degraded mode (static fallback has no dateFound): keep the card hidden entirely
+  if (months.length === 0) { card.style.display = 'none'; return; }
+  card.style.display = '';
+
+  // Date-range subtitle — full month + year on both ends for clarity
+  const subEl = document.getElementById('sl-chart-sub');
+  if (subEl) {
+    const fmtYm = (ym) => {
+      const [y, mo] = ym.split('-');
+      return ['JAN','FEB','MAR','APR','MAY','JUN','JUL','AUG','SEP','OCT','NOV','DEC'][Number(mo) - 1] + ' ' + y;
+    };
+    subEl.textContent = 'Aircraft equipped per month · ' + fmtYm(months[0].ym) + ' – ' + fmtYm(months[months.length - 1].ym);
+  }
+
+  // ── Scales ──
+  // Outlier-aware bar cap: if the biggest month dwarfs the second biggest (the Dec '25 tracker
+  // catch-up batch), cap the bar axis at the second biggest + headroom and mark capped bars.
+  const sorted = months.map(m => m.total).sort((a, b) => b - a);
+  const maxT = sorted[0] || 0, secondT = sorted[1] || 0;
+  const hasOutlier = months.length > 2 && maxT > 2 * secondT;
+  const cap = Math.max(5, Math.ceil((hasOutlier ? secondT * 1.2 : maxT) / 5) * 5);
+  const maxCum = months[months.length - 1].cumulative || 1;
+
+  // ── Geometry ──
+  const W = 940, H = 280, padL = 40, padR = 46, padT = 18, padB = 34;
+  const cw = W - padL - padR, ch = H - padT - padB;
+  const n = months.length, step = cw / n, bw = Math.max(8, Math.floor(step * 0.56));
+
+  let s = '';
+
+  // Left-axis gridlines (monthly installs)
+  [0, Math.round(cap / 3), Math.round(cap * 2 / 3), cap].forEach(v => {
+    const y = padT + ch - (v / cap) * ch;
+    s += '<line x1="' + padL + '" y1="' + y + '" x2="' + (W - padR) + '" y2="' + y + '" stroke="var(--ua-border-subtle)" stroke-width="1"/>';
+    s += '<text x="' + (padL - 6) + '" y="' + (y + 3) + '" fill="var(--ua-dim)" font-size="9" text-anchor="end">' + v + '</text>';
+  });
+
+  // Bars
+  const cappedMonths = [];
+  months.forEach((d, i) => {
+    const x = padL + i * step + (step - bw) / 2;
+    const isCapped = d.total > cap;
+    const visTotal = Math.min(d.total, cap);
+    // Express portion fills from the bottom; Mainline stacks on top (proportional within the cap)
+    const eVis = isCapped ? visTotal * (d.express / d.total) : d.express;
+    const mVis = visTotal - eVis;
+    const eh = (eVis / cap) * ch;
+    const mh = (mVis / cap) * ch;
+    const yE = padT + ch - eh;
+    const yM = yE - mh;
+    if (eVis > 0) s += '<rect x="' + x + '" y="' + yE + '" width="' + bw + '" height="' + eh + '" fill="var(--ua-green)" opacity="0.85" rx="1"/>';
+    if (mVis > 0) s += '<rect x="' + x + '" y="' + yM + '" width="' + bw + '" height="' + mh + '" fill="var(--ua-accent)" opacity="0.9" rx="1"/>';
+
+    if (isCapped) {
+      cappedMonths.push(d);
+      // Jagged break marker across the bar top + count label
+      const yTop = padT;
+      let zig = 'M ' + (x - 2) + ' ' + (yTop + 8);
+      for (let z = 0; z < Math.ceil((bw + 4) / 8); z++) zig += ' l 4 -5 l 4 5';
+      s += '<path d="' + zig + '" stroke="var(--ua-dim)" fill="none" stroke-width="1.5"/>';
+      s += '<text x="' + (x + bw / 2) + '" y="' + (yTop - 6) + '" fill="var(--ua-green)" font-size="10" font-weight="700" text-anchor="middle">' + d.total + '*</text>';
+    } else if (d.total > 0) {
+      s += '<text x="' + (x + bw / 2) + '" y="' + (padT + ch - (visTotal / cap) * ch - 5) + '" fill="var(--ua-muted)" font-size="9" text-anchor="middle">' + d.total + '</text>';
+    }
+
+    // Month label (thin out on dense charts: always label months that carry a year, else every other)
+    const showLabel = n <= 18 || d.label.indexOf(' ') !== -1 || i % 2 === 0;
+    if (showLabel) s += '<text x="' + (x + bw / 2) + '" y="' + (H - padB + 16) + '" fill="var(--ua-dim)" font-size="8.5" text-anchor="middle">' + d.label + '</text>';
+  });
+
+  // Cumulative line + dots (right axis scale)
+  let path = '';
+  months.forEach((d, i) => {
+    const x = padL + i * step + step / 2;
+    const y = padT + ch - (d.cumulative / maxCum) * ch;
+    path += (i === 0 ? 'M' : 'L') + x + ' ' + y + ' ';
+  });
+  s += '<path d="' + path + '" stroke="var(--ua-amber)" stroke-width="2" fill="none"/>';
+  months.forEach((d, i) => {
+    const x = padL + i * step + step / 2;
+    const y = padT + ch - (d.cumulative / maxCum) * ch;
+    s += '<circle cx="' + x + '" cy="' + y + '" r="2.5" fill="var(--ua-amber)"/>';
+  });
+
+  // Right-axis labels (cumulative) + end value
+  [0, Math.round(maxCum / 4), Math.round(maxCum / 2), Math.round(maxCum * 3 / 4), maxCum].forEach(v => {
+    const y = padT + ch - (v / maxCum) * ch;
+    s += '<text x="' + (W - padR + 8) + '" y="' + (y + 3) + '" fill="var(--ua-amber)" opacity="0.7" font-size="9">' + v + '</text>';
+  });
+  const lastY = padT + ch - ch;
+  s += '<text x="' + (W - padR - 4) + '" y="' + (lastY - 4) + '" fill="var(--ua-amber)" font-size="11" font-weight="700" text-anchor="end">' + maxCum + '</text>';
+
+  svg.innerHTML = s;
+
+  // Footnote: capped months (with the known Dec '25 batch context) + undated count
+  const fnEl = document.getElementById('sl-chart-footnote');
+  if (fnEl) {
+    const notes = [];
+    cappedMonths.forEach(d => {
+      let note = '* ' + d.label + ': ' + d.total + ' (exceeds chart scale)';
+      if (d.ym === '2025-12') note += ' — includes a 117-aircraft tracker catch-up batch on Dec 3';
+      notes.push(note);
+    });
+    if (undated > 0) notes.push(undated + ' aircraft have no recorded install date');
+    fnEl.textContent = notes.join(' · ');
+  }
 }
 
 // Hero band: equipped count, Express/Mainline rollout bars, new-this-week + airborne-now chips.

--- a/src/lib/starlink-utils.js
+++ b/src/lib/starlink-utils.js
@@ -1,0 +1,73 @@
+// ═══ STARLINK UTILITIES ═══
+// Pure data functions for the STARLINK tab, extracted for testability (mirrors fleet-utils.js).
+
+const MONTH_LABELS = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
+
+/**
+ * Bucket Starlink aircraft into a continuous month-by-month installation series.
+ *
+ * @param {Array<{dateFound?: string, fleet?: string}>} aircraft - entries from /api/starlink-data
+ * @param {Date} [nowDate] - "today"; the series always extends to this month
+ * @returns {{ months: Array<{ym: string, label: string, express: number, mainline: number, total: number, cumulative: number}>, undated: number, total: number }}
+ *
+ * Rules:
+ * - The series is continuous from the first install month to nowDate's month — months with zero
+ *   installs are included so the time axis never lies.
+ * - Aircraft whose dateFound is missing/unparseable are excluded from the bars and reported in
+ *   `undated` (the chart footnote surfaces them).
+ * - Labels are 'MMM' uppercase; the first month and every January carry a 2-digit year ('MAR 25').
+ */
+export function bucketInstallsByMonth(aircraft, nowDate = new Date()) {
+  if (!Array.isArray(aircraft) || aircraft.length === 0) {
+    return { months: [], undated: 0, total: 0 };
+  }
+
+  // Parse each aircraft's install month (UTC, from the YYYY-MM-DD prefix)
+  const counts = new Map(); // ym -> {express, mainline}
+  let undated = 0;
+  let firstYm = null;
+
+  for (const a of aircraft) {
+    const raw = typeof a?.dateFound === 'string' ? a.dateFound.slice(0, 10) : '';
+    const m = /^(\d{4})-(\d{2})/.exec(raw);
+    if (!m || isNaN(Date.parse(raw))) { undated++; continue; }
+    const ym = `${m[1]}-${m[2]}`;
+    if (!counts.has(ym)) counts.set(ym, { express: 0, mainline: 0 });
+    const bucket = counts.get(ym);
+    if (String(a.fleet).toLowerCase() === 'mainline') bucket.mainline++;
+    else bucket.express++;
+    if (firstYm === null || ym < firstYm) firstYm = ym;
+  }
+
+  if (firstYm === null) {
+    return { months: [], undated, total: aircraft.length };
+  }
+
+  // Walk a continuous range from firstYm to nowDate's month
+  const endYear = nowDate.getUTCFullYear();
+  const endMonth = nowDate.getUTCMonth(); // 0-based
+  let [year, month] = firstYm.split('-').map(Number);
+  month -= 1; // 0-based
+
+  const months = [];
+  let cumulative = 0;
+  let isFirst = true;
+
+  while (year < endYear || (year === endYear && month <= endMonth)) {
+    const ym = `${year}-${String(month + 1).padStart(2, '0')}`;
+    const bucket = counts.get(ym) || { express: 0, mainline: 0 };
+    const total = bucket.express + bucket.mainline;
+    cumulative += total;
+
+    const needsYear = isFirst || month === 0; // first month and every January
+    const label = MONTH_LABELS[month] + (needsYear ? ' ' + String(year).slice(2) : '');
+
+    months.push({ ym, label, express: bucket.express, mainline: bucket.mainline, total, cumulative });
+
+    isFirst = false;
+    month++;
+    if (month > 11) { month = 0; year++; }
+  }
+
+  return { months, undated, total: aircraft.length };
+}

--- a/tests/starlink-utils.test.js
+++ b/tests/starlink-utils.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { bucketInstallsByMonth } from '../src/lib/starlink-utils.js';
+
+// Helper to build aircraft entries the way /api/starlink-data shapes them
+const ac = (dateFound, fleet = 'Express') => ({ tail: 'N1', fleet, type: 'ERJ-175', operator: 'SkyWest dba UAX', dateFound, wifi: 'Starlink' });
+
+describe('bucketInstallsByMonth', () => {
+  it('buckets aircraft into months with fleet split and cumulative totals', () => {
+    const aircraft = [
+      ac('2025-03-15'), ac('2025-03-20'),               // Mar: 2 express
+      ac('2025-05-01', 'Mainline'),                      // May: 1 mainline
+    ];
+    const { months, undated, total } = bucketInstallsByMonth(aircraft, new Date('2025-05-15T12:00:00Z'));
+
+    expect(total).toBe(3);
+    expect(undated).toBe(0);
+    expect(months.map(m => m.ym)).toEqual(['2025-03', '2025-04', '2025-05']);
+
+    expect(months[0]).toMatchObject({ ym: '2025-03', express: 2, mainline: 0, total: 2, cumulative: 2 });
+    // zero-install month is included to keep the time axis continuous
+    expect(months[1]).toMatchObject({ ym: '2025-04', express: 0, mainline: 0, total: 0, cumulative: 2 });
+    expect(months[2]).toMatchObject({ ym: '2025-05', express: 0, mainline: 1, total: 1, cumulative: 3 });
+  });
+
+  it('extends the range to the current month even with no recent installs', () => {
+    const aircraft = [ac('2025-03-15')];
+    const { months } = bucketInstallsByMonth(aircraft, new Date('2025-07-10T12:00:00Z'));
+    expect(months.map(m => m.ym)).toEqual(['2025-03', '2025-04', '2025-05', '2025-06', '2025-07']);
+    expect(months[4]).toMatchObject({ total: 0, cumulative: 1 });
+  });
+
+  it('labels months MMM uppercase, with the year on the first month and every January', () => {
+    const aircraft = [ac('2025-11-15'), ac('2026-01-05'), ac('2026-02-10')];
+    const { months } = bucketInstallsByMonth(aircraft, new Date('2026-02-20T12:00:00Z'));
+    expect(months.map(m => m.label)).toEqual(['NOV 25', 'DEC', 'JAN 26', 'FEB']);
+  });
+
+  it('counts aircraft with missing or unparseable dateFound as undated (excluded from bars)', () => {
+    const aircraft = [
+      ac('2025-03-15'),
+      ac(''), ac(undefined), ac('not-a-date'),
+    ];
+    const { months, undated, total } = bucketInstallsByMonth(aircraft, new Date('2025-03-20T12:00:00Z'));
+    expect(total).toBe(4);
+    expect(undated).toBe(3);
+    expect(months).toHaveLength(1);
+    expect(months[0]).toMatchObject({ total: 1, cumulative: 1 });
+  });
+
+  it('returns empty months when no aircraft have dates', () => {
+    const { months, undated, total } = bucketInstallsByMonth([ac(''), ac(undefined)], new Date('2026-01-01T12:00:00Z'));
+    expect(months).toEqual([]);
+    expect(undated).toBe(2);
+    expect(total).toBe(2);
+  });
+
+  it('returns empty result for empty/invalid input', () => {
+    expect(bucketInstallsByMonth([], new Date())).toEqual({ months: [], undated: 0, total: 0 });
+    expect(bucketInstallsByMonth(null, new Date())).toEqual({ months: [], undated: 0, total: 0 });
+  });
+
+  it('handles the real-world shape: Express-heavy 2025, Mainline ramp in 2026, Dec batch', () => {
+    // Condensed version of the live distribution
+    const aircraft = [
+      ...Array.from({ length: 7 }, () => ac('2025-03-10')),
+      ...Array.from({ length: 157 }, () => ac('2025-12-03')),          // the Dec batch
+      ...Array.from({ length: 3 }, () => ac('2026-05-20', 'Express')),
+      ...Array.from({ length: 17 }, () => ac('2026-05-21', 'Mainline')),
+    ];
+    const { months } = bucketInstallsByMonth(aircraft, new Date('2026-05-31T12:00:00Z'));
+
+    const dec = months.find(m => m.ym === '2025-12');
+    expect(dec).toMatchObject({ express: 157, mainline: 0, total: 157 });
+
+    const may26 = months.find(m => m.ym === '2026-05');
+    expect(may26).toMatchObject({ express: 3, mainline: 17, total: 20, cumulative: 184 });
+
+    // continuous axis: Mar 2025 → May 2026 = 15 months
+    expect(months).toHaveLength(15);
+  });
+});


### PR DESCRIPTION
## What

Adds the **Installation Velocity** chart to the STARLINK tab (between the hero and the table) — the "Ops Bars" design picked from rendered comps:

- **Stacked monthly bars**: Express (green) + Mainline (blue), count labels, continuous time axis from the first install (Mar 2025) to the current month
- **Amber cumulative line** on its own axis, ending at the live total (371 today)
- **Outlier handling**: Dec 2025's 157-install spike (117 of which hit the tracker in a single catch-up batch on Dec 3) renders as a capped bar with a break marker + `157*` label and an honest footnote — so it doesn't squash every other month
- **The story it tells**: Express built the base through 2025; Mainline is ramping now (8 → 13 → 11 → 17/month in 2026)

Pure SVG built in vanilla JS — **no chart library added**. Zero API changes; everything derives from `dateFound` already served by `/api/starlink-data`.

## Code structure

- `src/lib/starlink-utils.js` (new) — `bucketInstallsByMonth()`: pure, unit-tested data function (mirrors the `fleet-utils.js` pattern). **Tests written first** (TDD), 7 cases: fleet split, zero-month continuity, cumulative math, undated handling, label rules, the real-world Dec-batch shape.
- `main.js` — `renderSlChart()`: SVG renderer with outlier-aware cap, dual axes, range subtitle. Wired into `initStarlinkTab()`.
- Chart card markup + `.sl-chart-*` styles, all from DESIGN.md tokens (amber featured-card chrome, JetBrains Mono, green/blue/amber).

## Degraded modes

| Condition | Behavior |
|---|---|
| Static-fallback data (no `dateFound`) | Chart card stays hidden — never an empty chart |
| Some aircraft undated | Footnote appends "N aircraft have no recorded install date" |
| Mobile ≤600px | Chart scrolls horizontally, bars stay readable |

## QA

| Check | Result |
|---|---|
| 604 tests (7 new) · typecheck · build | ✅ |
| Desktop QA (local build + prod data): bars/line/labels/footnote match live distribution | ✅ |
| Subtitle range "MAR 2025 – JUN 2026", auto-extends as months roll | ✅ |
| Dec break marker + catch-up-batch footnote | ✅ |
| Mobile 375px render + horizontal scroll | ✅ |
| Card hidden in degraded (static-fallback) mode | ✅ |

Spec: `docs/superpowers/specs/2026-06-01-starlink-velocity-chart-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)