### PR TITLE
fix(ui): canopy polish — readable rotating ticker, stacked stats, drop countdown

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -35,15 +35,20 @@ h1,h2,h3,h4,h5,h6,.tab-btn{font-family:var(--font-display)}
 #map::after{content:'';position:absolute;inset:0;pointer-events:none;background:radial-gradient(120% 90% at 50% 38%,transparent 42%,rgba(7,11,18,.5) 100%)}
 
 /* Ticker — alert zone inline inside the canopy, flex-grows to fill the middle */
-/* Ticker fix: full canopy height + vertical centering so items sit mid-bar, not at the top.
-   Marquee animates .ticker (transform) and measures .ticker-cycle width — height-only
-   changes here do not affect the horizontal width measurement, so the scroll is preserved. */
-.ticker-wrap{flex:1 1 120px;min-width:0;display:flex;align-items:center;gap:7px;padding:0 4px;overflow:hidden;background:none;border:none;height:100%;position:static;z-index:auto}
+/* Ticker: fade-rotation mode — one item at a time, fully readable, crossfading every 5s.
+   The marquee scroll only runs in containers ≥700px wide (initTickerAnimation checks), which
+   never happens in the canopy. Items are absolutely positioned against .ticker and toggled by
+   the rotation JS via .mobile-active / .mobile-fade-out. */
+.ticker-wrap{flex:1 1 160px;min-width:0;display:flex;align-items:center;gap:7px;padding:0 4px;overflow:hidden;background:none;border:none;height:100%;position:static;z-index:auto}
 .ticker-label{display:none}
-.ticker{display:flex;align-items:center;flex:1 1 auto;min-width:0;height:100%;white-space:nowrap;will-change:transform;overflow:hidden}
+.ticker{display:block;position:relative;flex:1 1 auto;min-width:0;height:100%;white-space:nowrap}
+/* Belt-and-suspenders: the canopy ticker never scrolls, even if stale JS sets an inline animation */
+#header .ticker{animation:none!important;transform:none!important}
 .ticker-cycle{display:flex;align-items:center;height:100%;flex:none}
 @keyframes tickerScroll{0%{transform:translate3d(0,0,0)}100%{transform:translate3d(var(--ticker-offset,-50%),0,0)}}
-.ticker-item{display:inline-flex;align-items:center;padding:0 40px;font-family:var(--font-ui);font-size:11px;font-weight:500;letter-spacing:.3px;color:var(--ua-text)}
+.ticker .ticker-item{display:none;position:absolute;inset:0;align-items:center;overflow:hidden;text-overflow:ellipsis;font-family:var(--font-ui);font-size:11px;font-weight:500;letter-spacing:.3px;color:var(--ua-text);transition:opacity .4s ease}
+.ticker .ticker-item.mobile-active{display:flex;opacity:1}
+.ticker .ticker-item.mobile-fade-out{opacity:0}
 .ticker-item.info{color:var(--ua-green)}.ticker-item.advisory{color:var(--ua-yellow)}.ticker-item.critical{color:var(--ua-red)}
 
 /* CANOPY (= #header restyled as the floating top bar) */
@@ -66,10 +71,9 @@ h1,h2,h3,h4,h5,h6,.tab-btn{font-family:var(--font-display)}
 .status-dot.live{background:var(--ua-green);box-shadow:0 0 6px rgba(34,197,94,.6);animation:pulse 2s ease-in-out infinite}
 #countdown{font-variant-numeric:tabular-nums;color:var(--ua-muted);font-family:var(--font-mono);font-size:10px;white-space:nowrap}
 #clock{font-family:var(--font-mono);font-size:11px;font-weight:600;letter-spacing:.4px;color:var(--ua-text);flex-shrink:0;font-variant-numeric:tabular-nums}
-/* BUG 1 fix: below ~1500px the canopy is tight — drop the ~95px "Next refresh" countdown text
-   to free space for the search + hub bar. Scoped above the mobile breakpoint so it never
-   collides with the mobile rule (which already hides #countdown at ≤768px). */
-@media(max-width:1500px){#header-right #countdown{display:none}}
+/* "Next refresh" countdown removed from the canopy at all widths (it ate ~95px and the clock
+   already communicates recency). The element stays in the DOM — JS keeps writing to it. */
+#header-right #countdown{display:none}
 
 /* HUB CLUSTER (= #hub-health-bar inline in the canopy) */
 /* main rule restyled in the "Hub Health Bar" section further down */
@@ -133,7 +137,7 @@ main{display:contents}
    min-width:0 lets it shrink; the media query below hides it entirely once the cap squeezes it
    below ~3 stats (≤1080px), since a 30–110px corner sliver reads as broken. Mobile (≤768px) hides
    it via the existing rule. */
-#stats-bar{position:fixed;left:16px;bottom:24px;z-index:715;display:flex;align-items:center;padding:8px 12px;gap:0;flex-wrap:nowrap;background:linear-gradient(180deg,var(--ua-panel) 0%,rgba(17,26,39,.96) 100%);border:1px solid var(--ua-border);border-radius:6px;font-size:10px;min-width:0;max-width:calc(50vw - 416px);overflow:hidden;scrollbar-width:none}
+#stats-bar{position:fixed;left:16px;bottom:24px;z-index:715;display:flex;align-items:center;padding:7px 8px;gap:0;flex-wrap:wrap;row-gap:6px;background:linear-gradient(180deg,var(--ua-panel) 0%,rgba(17,26,39,.96) 100%);border:1px solid var(--ua-border);border-radius:6px;font-size:10px;min-width:0;max-width:calc(50vw - 416px);overflow:hidden;scrollbar-width:none}
 /* Hide the capsule in the dead zone (769–1080px) where the dock-clearance cap collapses it to an
    unreadable corner sliver. Scoped above the 768px mobile breakpoint so it never double-fires. */
 @media(min-width:769px) and (max-width:1080px){#stats-bar{display:none}}
@@ -141,9 +145,11 @@ main{display:contents}
    broken; .stat-item padding spaces them. */
 #stats-bar .stat-sep{display:none}
 #stats-bar::-webkit-scrollbar{display:none}
-.stat-item{display:flex;align-items:baseline;gap:4px;padding:0 9px;white-space:nowrap}
-.stat-val{color:var(--ua-text);font-weight:700;font-size:10px;font-family:var(--font-mono);font-variant-numeric:tabular-nums}
-.stat-label{color:var(--ua-dim);font-size:9px;letter-spacing:.6px;text-transform:uppercase}
+/* Stacked value-over-label (approved variant-j format): half the width of the old inline
+   layout, so all 5 stats fit in one row at ≥1440px and wrap cleanly below that. */
+.stat-item{display:flex;flex-direction:column;align-items:center;gap:1px;padding:0 7px;white-space:nowrap}
+.stat-val{color:var(--ua-text);font-weight:700;font-size:13px;line-height:1.1;font-family:var(--font-mono);font-variant-numeric:tabular-nums}
+.stat-label{color:var(--ua-dim);font-size:7px;letter-spacing:.5px;text-transform:uppercase}
 .stat-sep{color:var(--ua-border);margin:0 4px}
 
 /* ATTRIBUTION (new — fixed micro-text bottom-left, below the stats capsule) */
@@ -778,12 +784,10 @@ tbody td{padding:5px 8px;white-space:nowrap}
   /* ── Non-map tab panels clear the two-row canopy (top) and floating dock (bottom) ── */
   .tab-content.active{top:98px;bottom:74px}
   #tab-live.active{top:0;bottom:0}
-  /* ── Ticker: hidden on mobile (the two-row canopy prioritizes hub values; ticker folds) ── */
+  /* ── Ticker: hidden on mobile (the two-row canopy prioritizes hub values; ticker folds).
+     Fade-rotation item styles live in the base rules now (they apply at all widths). ── */
   .ticker-wrap{display:none}
-  .ticker{animation:none!important;transform:none!important;overflow:hidden;position:relative}
-  .ticker .ticker-item{display:none;position:absolute;left:0;right:0;top:0;height:100%;align-items:center;overflow:hidden;text-overflow:ellipsis;padding:0 10px;transition:opacity .4s ease}
-  .ticker .ticker-item.mobile-active{display:flex;opacity:1}
-  .ticker .ticker-item.mobile-fade-out{opacity:0}
+  .ticker{animation:none!important;transform:none!important}
   /* ── Mobile dock = #mobile-bottom-nav restyled as a floating rounded bar 12px above bottom ── */
   #mobile-bottom-nav button .bnav-icon{font-size:20px}
   #mobile-bottom-nav button .bnav-label{font-size:11px}

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -591,10 +591,17 @@ switchToTab = function(tabId, updateHash) {
   }
 })();
 
-// ═══ MOBILE TICKER ROTATION (Change 3) ═══
+// ═══ TICKER FADE ROTATION (mobile + canopy) ═══
 (function(){
   var mobileTickerQuery = window.matchMedia('(max-width: 768px)');
-  var isMobile = function() { return mobileTickerQuery.matches; };
+  // Fade-rotation applies on mobile AND whenever the ticker lives inside the canopy
+  // (#header). A marquee scroll is unreadable in the canopy's narrow flex zone: content
+  // clips and there are long blank gaps between cycles. Structural check (not a width
+  // measurement) so it can't race against data population changing the zone's size.
+  var useFadeRotation = function() {
+    if (mobileTickerQuery.matches) return true;
+    return !!document.querySelector('#header .ticker-wrap');
+  };
   var rotateInterval = null;
   var fadeTimeout = null;
   var currentIndex = 0;
@@ -618,7 +625,7 @@ switchToTab = function(tabId, updateHash) {
     var items = ticker.querySelectorAll('.ticker-item');
     var uniqueCount = Math.ceil(items.length / 2);
 
-    if (!isMobile() || uniqueCount === 0) {
+    if (!useFadeRotation() || uniqueCount === 0) {
       clearMobileTickerState();
       return;
     }
@@ -641,7 +648,7 @@ switchToTab = function(tabId, updateHash) {
     if (uniqueCount <= 1) return;
 
     rotateInterval = setInterval(function() {
-      if (!isMobile()) { clearInterval(rotateInterval); rotateInterval = null; return; }
+      if (!useFadeRotation()) { clearInterval(rotateInterval); rotateInterval = null; return; }
       var items = ticker.querySelectorAll('.ticker-item');
       var uniqueCount = Math.ceil(items.length / 2);
       if (uniqueCount <= 1) return;
@@ -668,8 +675,9 @@ switchToTab = function(tabId, updateHash) {
   }
 
   function handleTickerViewportChange() {
-    if (isMobile()) setupMobileTicker();
-    else clearMobileTickerState();
+    // setupMobileTicker self-gates on useFadeRotation(), which covers both
+    // mobile and the narrow canopy zone — just re-run it on breakpoint changes.
+    setupMobileTicker();
   }
 
   // Mobile browsers emit resize events while their toolbar expands/collapses.
@@ -1753,8 +1761,11 @@ function initTickerAnimation(tickerEl) {
   // Cancel any previous animation
   if (_tickerRafId) { cancelAnimationFrame(_tickerRafId); _tickerRafId = null; }
 
-  // Mobile uses fade-rotation via setupMobileTicker — skip desktop scroll animation
-  if (window.innerWidth <= 768) {
+  // Fade-rotation (via the ticker rotation IIFE) handles mobile AND the canopy ticker —
+  // the marquee scroll only makes sense in a wide standalone bar. Structural check: if the
+  // ticker lives inside #header (the canopy), never run the scroll animation. This cannot
+  // race against data population the way a width measurement could.
+  if (window.innerWidth <= 768 || tickerEl.closest('#header')) {
     tickerEl.style.animation = '';
     tickerEl.style.transform = '';
     return;


### PR DESCRIPTION
## Follow-up to #191 — the remaining canopy issues

| Issue (on prod now) | Fix |
|---|---|
| Ticker shows "all systems nor…" then goes **blank for ~20s** | The canopy was still running the full-width marquee scroll: 1,200px of content clipped to a ~200px box. Now uses **fade-rotation** — one fully readable alert at a time, crossfading every 5s (the same machinery mobile uses). |
| Stats cut off bottom-left | Switched to the approved **stacked value-over-label** format — half the width, all 5 stats fit in one row at ≥1440px, wraps cleanly below that. |
| "Next refresh" countdown | **Removed at all widths** (frees ~95px of canopy space). The clock stays. |

## Changes
- `public/css/style.css` — ticker fade-mode styles, stacked stats, countdown hide
- `src/dashboard/main.js` — ticker mode selection: fade whenever the ticker lives in the canopy (structural check, no race conditions); marquee scroll never runs there

## QA
- ✅ Injected prod-rendered content at **1512×900** (your MacBook viewport) and 1440×900
- ✅ Fade rotation verified advancing items every 5s; scroll animation confirmed dead
- ✅ All 5 stats visible, 76px clearance to the dock
- ✅ Search stays 200px; clock visible; mobile unaffected (ticker hidden there by design)
- ✅ `bun test` unchanged (543 pass / 28 pre-existing fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)