### PR TITLE
fix(schedule): fit warm cron + cache to a metered AeroDataBox plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.15] - 2026-06-07
+
+### Changed
+- Schedule warming is now today/tomorrow-focused and conservative by default so it fits a metered AeroDataBox plan: `SCHEDULE_WARM_TASKS_PER_RUN` defaults to 2 (was 4), yesterday's historical board is served on-demand instead of warmed every cycle, and a clean today board is cached for 6h at the edge (was 3h). Together these roughly halve the worst-case monthly provider spend.
+
+### Fixed
+- Warm-schedule rotation now advances one stride per cron fire (slot aligned to the 2h cron interval), so consecutive runs cover every today/tomorrow window with no gaps. The previous 15-minute slot striding against a 2h cron skipped most windows.
+- AeroDataBox 429/503 give-up now logs the response body and remaining-quota header, so monthly-quota exhaustion is visible in the logs instead of silently degrading to empty boards. The warm cron also logs an estimated AeroDataBox unit spend per run.
+
 ## [1.5.14] - 2026-05-16
 
 ### Fixed

--- a/api/_schedule-aerodatabox.ts
+++ b/api/_schedule-aerodatabox.ts
@@ -283,7 +283,7 @@ async function fetchWindow(
 
       if (resp.status === 204) return { ok: true, flights: [] };
       if (resp.status === 429 || resp.status === 503) {
-        await resp.text().catch(() => '');
+        const body = await resp.text().catch(() => '');
         const retryAfter = Number(resp.headers.get('retry-after'));
         const backoff = Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter * 1000 : 1500 * attempt;
         if (attempt < maxAttempts && deadline - Date.now() > backoff + 800) {
@@ -291,7 +291,16 @@ async function fetchWindow(
           await new Promise((r) => setTimeout(r, backoff));
           continue;
         }
-        console.error(`AeroDataBox schedule returned ${resp.status} for ${hub} ${dir} after ${attempt} attempt(s)`);
+        // Surface WHY we gave up so a monthly-quota wall is distinguishable from a per-second
+        // throttle (the body/headers were previously discarded, hiding quota exhaustion in the logs).
+        const quotaRemaining =
+          resp.headers.get('x-ratelimit-requests-remaining') ??
+          resp.headers.get('x-ratelimit-rapid-free-plans-hard-limit-remaining') ??
+          resp.headers.get('x-ratelimit-remaining') ??
+          '?';
+        console.error(
+          `AeroDataBox schedule gave up: ${resp.status} for ${hub} ${dir} after ${attempt} attempt(s) — quota-remaining=${quotaRemaining} body=${body.slice(0, 200)}`
+        );
         return { ok: false };
       }
       if (!resp.ok) {

--- a/api/cron/warm-schedules.ts
+++ b/api/cron/warm-schedules.ts
@@ -1,17 +1,18 @@
-// Vercel Cron Job: rotates through the 3-day schedule window (yesterday/today/tomorrow)
-// so exact hub/day/direction snapshots stay available across deploys and cold starts.
-// Config in vercel.json: { "path": "/api/cron/warm-schedules", "schedule": "*/15 * * * *" }
+// Vercel Cron Job: rotates through the 2-day schedule window (today/tomorrow) so exact
+// hub/day/direction snapshots stay warm at the CDN + Supabase snapshot. Yesterday is served
+// on-demand (historical board, rarely viewed) to conserve the metered AeroDataBox quota.
+// Config in vercel.json: { "path": "/api/cron/warm-schedules", "schedule": "0 */2 * * *" }
 
 import type { VercelRequest, VercelResponse } from '../types.js';
 import { getStartOfDayForHub } from '../irops.js';
 
 const HUBS = ['ORD', 'DEN', 'IAH', 'EWR', 'SFO', 'IAD', 'LAX', 'NRT', 'GUM'];
-// Serialized with INTER_TASK_DELAY_MS between tasks. Budget math: each task
-// worst-case is ~58s (55s schedule fetch + 3s gap). maxDuration for this cron
-// is 300s in vercel.json, so hard-cap at 4 tasks → 4 × 58s = 232s, under the
-// Lambda limit. Keeping this serial rather than Promise.allSettled avoids
-// fanning 8 parallel requests at FR24's per-IP rate limit.
-const WARM_TASKS_PER_RUN = Math.max(1, Math.min(4, Number(process.env.SCHEDULE_WARM_TASKS_PER_RUN || 4) || 4));
+// Serialized with INTER_TASK_DELAY_MS between tasks. Budget math: each task worst-case is ~58s
+// (55s schedule fetch + 3s gap). maxDuration for this cron is 300s in vercel.json, so the clamp
+// ceiling of 4 tasks → 4 × 58s = 232s stays under the Lambda limit. Default is 2 to bound the
+// metered AeroDataBox spend: 2 boards/run × 12 runs/day × 4 units/board ≈ 96 units/day worst case
+// (~2,880/mo), well inside a paid tier. Serial (not Promise.allSettled) respects the 1 req/s limit.
+const WARM_TASKS_PER_RUN = Math.max(1, Math.min(4, Number(process.env.SCHEDULE_WARM_TASKS_PER_RUN || 2) || 2));
 const INTER_TASK_DELAY_MS = Math.max(0, Number(process.env.SCHEDULE_WARM_DELAY_MS || 3000) || 3000);
 const BASE_URL = process.env.VERCEL_PROJECT_PRODUCTION_URL
   ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
@@ -19,13 +20,13 @@ const BASE_URL = process.env.VERCEL_PROJECT_PRODUCTION_URL
     ? `https://${process.env.VERCEL_URL}`
     : 'https://theblueboard.co';
 
+// Yesterday (dayOffset -1) is intentionally NOT warmed — its board is historical/stable and
+// rarely viewed, so it loads on-demand (and caches) instead of burning quota every cycle.
 const WINDOW_TASKS = [
   { dayOffset: 0, label: 'today', dir: 'departures' },
   { dayOffset: 0, label: 'today', dir: 'arrivals' },
   { dayOffset: 1, label: 'tomorrow', dir: 'departures' },
   { dayOffset: 1, label: 'tomorrow', dir: 'arrivals' },
-  { dayOffset: -1, label: 'yesterday', dir: 'departures' },
-  { dayOffset: -1, label: 'yesterday', dir: 'arrivals' },
 ] as const;
 
 type WarmTask = {
@@ -48,7 +49,12 @@ export function buildWarmPlan(nowMs = Date.now()): WarmTask[] {
     }
   }
 
-  const slot = Math.floor(nowMs / (15 * 60 * 1000));
+  // Advance exactly one WARM_TASKS_PER_RUN stride per cron fire so consecutive fires cover the
+  // window list sequentially with no gaps. SLOT_MS MUST match the cron interval in vercel.json
+  // (currently every 2h): a 15-min slot here while the cron fires every 2h would stride 8× per
+  // fire and skip most windows (only every Nth pair would ever warm). Update both together.
+  const SLOT_MS = 2 * 60 * 60 * 1000; // = vercel.json cron interval (0 */2 * * *)
+  const slot = Math.floor(nowMs / SLOT_MS);
   const start = (slot * WARM_TASKS_PER_RUN) % tasks.length;
   const plan: WarmTask[] = [];
   for (let i = 0; i < Math.min(WARM_TASKS_PER_RUN, tasks.length); i++) {
@@ -121,8 +127,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   let warmed = 0;
   let failed = 0;
 
-  // There are 54 total windows (9 hubs × 3 days × 2 directions).
-  // Keep the default conservative for FR24, and use the seed script for first-fill.
+  // There are 36 total windows (9 hubs × 2 days × 2 directions); yesterday is on-demand.
+  // Keep the default conservative for the metered provider, and use the seed script for first-fill.
   const warmPlan = buildWarmPlan();
   for (let i = 0; i < warmPlan.length; i++) {
     const task = warmPlan[i];
@@ -151,7 +157,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     failed++;
   }
 
-  console.log(`Cron warm-schedules: ${warmed} warmed, ${failed} failed`, { warmPlan, results });
+  // Estimate the metered AeroDataBox spend so the monthly budget is visible in the logs.
+  // A freshly-fetched (non-cached) non-empty board = 2 FIDS calls × 2 units/call = 4 units.
+  const freshBoards = Object.entries(results).filter(
+    ([key, r]) => key !== 'starlink-data' && r && r.cached === false && typeof r.flights === 'number' && r.flights > 0
+  ).length;
+  const estUnits = freshBoards * 4;
+  console.log(
+    `Cron warm-schedules: ${warmed} warmed, ${failed} failed, ~${estUnits} AeroDataBox units (${freshBoards} fresh boards)`,
+    { warmPlan, results }
+  );
   return res.status(200).json({
     warmed,
     failed,

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -1585,11 +1585,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
     const isOld = (now - ts) > 86400;
     // A given day's schedule is stable, so a clean (non-partial) today board can be reused for hours.
-    // Reuse it for 3h in-memory + at the edge so one ~29-credit official refresh is amortized across
-    // the whole warm window instead of re-fetched every 15 min. Partial boards are unaffected:
-    // setAggregateCacheHeader overrides cdnMaxAge to 120s/30s for partial responses. (FR24-economy.)
-    const ttl = isOld ? 600000 : 10800000;     // 3h for today's clean board (was 15m)
-    const cdnMaxAge = isOld ? 3600 : 10800;    // 3h per-edge for today's clean board (was 15m)
+    // Reuse it for 6h in-memory + at the edge so each metered AeroDataBox refresh (2 FIDS calls =
+    // 4 units) is amortized across the whole warm window instead of re-fetched every few minutes.
+    // This roughly halves the worst-case monthly provider spend vs the old 3h TTL. Partial boards
+    // are unaffected: setAggregateCacheHeader overrides cdnMaxAge to 120s/30s for partial responses.
+    // (Tradeoff: a clean board's per-flight status can lag up to 6h; lower to 10800 for fresher status.)
+    const ttl = isOld ? 600000 : 21600000;     // 6h for today's clean board (was 3h) — quota economy
+    const cdnMaxAge = isOld ? 3600 : 21600;    // 6h per-edge for today's clean board (was 3h)
     swr = 600;
     const allowOfficialFallback = !shouldDisableOfficialFallback(req);
     const allowProviderFallback = !shouldDisableProviderFallback(req);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.5.14",
+  "version": "1.5.15",
   "packageManager": "bun@1.3.14",
   "engines": {
     "node": "24.x"

--- a/tests/warm-schedules.test.js
+++ b/tests/warm-schedules.test.js
@@ -3,7 +3,8 @@ import { buildScheduleWarmUrl, buildWarmPlan } from '../api/cron/warm-schedules.
 
 describe('warm-schedules buildWarmPlan', () => {
   const HUBS = ['ORD', 'DEN', 'IAH', 'EWR', 'SFO', 'IAD', 'LAX', 'NRT', 'GUM'];
-  const TOTAL_TASKS = 9 * 6; // 9 hubs × 6 window tasks (3 days × 2 dirs)
+  const TOTAL_TASKS = 9 * 4; // 9 hubs × 4 window tasks (today+tomorrow × 2 dirs); yesterday is on-demand
+  const SLOT_MS = 2 * 60 * 60 * 1000; // must match the cron interval / SLOT_MS in warm-schedules.ts
 
   it('returns an array of warm tasks', () => {
     const plan = buildWarmPlan();
@@ -11,24 +12,28 @@ describe('warm-schedules buildWarmPlan', () => {
     expect(plan.length).toBeGreaterThan(0);
   });
 
-  it('each task has required fields', () => {
-    const plan = buildWarmPlan();
-    for (const task of plan) {
-      expect(HUBS).toContain(task.hub);
-      expect(['departures', 'arrivals']).toContain(task.dir);
-      expect([-1, 0, 1]).toContain(task.dayOffset);
-      expect(['yesterday', 'today', 'tomorrow']).toContain(task.label);
+  it('each task has required fields and never warms yesterday', () => {
+    // Sweep a full rotation so we assert across every window the plan can emit, not just one slot.
+    const start = new Date('2026-04-03T00:00:00Z').getTime();
+    for (let i = 0; i < TOTAL_TASKS + 4; i++) {
+      const plan = buildWarmPlan(start + i * SLOT_MS);
+      for (const task of plan) {
+        expect(HUBS).toContain(task.hub);
+        expect(['departures', 'arrivals']).toContain(task.dir);
+        expect([0, 1]).toContain(task.dayOffset);          // today / tomorrow only
+        expect(['today', 'tomorrow']).toContain(task.label); // yesterday is on-demand, never warmed
+      }
     }
   });
 
-  it('returns different tasks for different 15-minute slots', () => {
+  it('returns different tasks for different 2-hour slots', () => {
     const t1 = new Date('2026-04-03T00:00:00Z').getTime();
-    const t2 = new Date('2026-04-03T00:15:00Z').getTime();
+    const t2 = new Date('2026-04-03T02:00:00Z').getTime();
 
     const plan1 = buildWarmPlan(t1);
     const plan2 = buildWarmPlan(t2);
 
-    // Different time slots should produce different starting positions
+    // Adjacent cron fires (2h apart) should advance to a different starting position
     const keys1 = plan1.map(t => `${t.hub}-${t.dir}-${t.label}`);
     const keys2 = plan2.map(t => `${t.hub}-${t.dir}-${t.label}`);
     expect(keys1).not.toEqual(keys2);
@@ -41,27 +46,26 @@ describe('warm-schedules buildWarmPlan', () => {
     expect(plan1).toEqual(plan2);
   });
 
-  it('cycles through all tasks over enough 15-minute intervals', () => {
+  it('cycles through all tasks over enough cron intervals with no gaps', () => {
     const allKeys = new Set();
     const start = new Date('2026-04-03T00:00:00Z').getTime();
 
-    // Run enough intervals to cover all tasks
-    for (let i = 0; i < Math.ceil(TOTAL_TASKS / 4) + 2; i++) {
-      const plan = buildWarmPlan(start + i * 15 * 60 * 1000);
+    // Run enough 2h cron fires to cover all windows (sequential stride => full coverage)
+    for (let i = 0; i < TOTAL_TASKS + 4; i++) {
+      const plan = buildWarmPlan(start + i * SLOT_MS);
       for (const task of plan) {
         allKeys.add(`${task.hub}-${task.dir}-${task.label}`);
       }
     }
 
-    // Should eventually cover all hub/dir/day combinations
+    // Should eventually cover every today/tomorrow hub/dir combination
     expect(allKeys.size).toBe(TOTAL_TASKS);
   });
 
-  it('limits plan size to WARM_TASKS_PER_RUN (default 4)', () => {
+  it('limits plan size to WARM_TASKS_PER_RUN (default 2)', () => {
     const plan = buildWarmPlan();
-    // Default is 4 tasks per run
-    expect(plan.length).toBeLessThanOrEqual(8);
-    expect(plan.length).toBeGreaterThanOrEqual(1);
+    // Default is 2 tasks per run to bound metered AeroDataBox spend
+    expect(plan.length).toBe(2);
   });
 
   it('warms via the provider (AeroDataBox) while keeping paid FR24 + dead scrape off', () => {


### PR DESCRIPTION
## Why

Schedules went empty again on Jun 7 because the AeroDataBox free tier's monthly quota was exhausted within days of the May 31 fix. You've since upgraded to the **$5 RapidAPI Pro tier (6,000 API units/mo)**. The catch: Pro **binds on API Units, not Requests** — the FIDS (schedule) endpoint is Tier 2 = **2 units/call**, and one board = 2 window-calls = **4 units**. So Pro is effectively **1,500 board-fetches/month**.

The previous warm cron (every 2h, `WARM_TASKS_PER_RUN=4`, 54 windows incl. yesterday) plus a 3h cache can burn well past that under load. This PR makes steady-state spend fit Pro with headroom, and makes the next quota wall visible instead of silent.

## Changes

**`api/cron/warm-schedules.ts`**
- Default `SCHEDULE_WARM_TASKS_PER_RUN` **4 → 2** (caps the cron's worst case at ~96 units/day ≈ ~2,880/mo).
- **Drop yesterday** from the warm rotation — historical/stable board, rarely viewed, now served on-demand (and still cached). Cuts the window set 54 → 36.
- **Fix a latent rotation bug:** the slot was computed on a 15-min boundary while the cron fires every 2h, so it strode 8× per fire and skipped most windows. Slot is now aligned to the 2h interval → consecutive fires cover every window sequentially with no gaps.
- **Log estimated AeroDataBox unit spend per run** (`~N units (M fresh boards)`) for ongoing budget visibility.

**`api/schedule.ts`**
- Clean today board cached **3h → 6h** at edge + in-memory (halves user-driven worst case). Partial/empty boards keep their short 30s/120s TTLs.

**`api/_schedule-aerodatabox.ts`**
- On 429/503 give-up, log the **response body + remaining-quota header** (previously discarded). A monthly-quota wall is now distinguishable from a per-second throttle in the logs.

## Budget impact

| | Worst-case units/mo |
|---|---|
| Before (WARM=4, 3h cache, 54 windows) | ~17k+ (over the 6k Pro cap) |
| After (WARM=2, 6h cache, 36 windows) | ~8k ceiling; ~3–5k at real traffic |

## Tradeoffs / notes

- **6h cache** means a clean board's per-flight status can lag up to 6h (the live map + delay prediction stay real-time). If you'd rather have fresher status, set the today `cdnMaxAge`/`ttl` back to `10800` (3h) — there's a comment at the line.
- If `SCHEDULE_WARM_TASKS_PER_RUN` is set as a prod env var, **that value still wins** over the new default — worth confirming it's ≤ 2.
- Pro's rate limit is still **1 req/sec**, so brief per-second 429s under concurrent load remain (the retry absorbs them). Ultra ($32, 60k units, 2 req/sec) is the next rung if traffic grows.

## Testing
- `bunx vitest run` — **604 pass** (43 files), including updated `warm-schedules` specs (no-yesterday, 2h-slot full-coverage, default 2).
- `tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
