### PR TITLE
v1.5.16 fix: unfreeze schedule boards + close the unmetered quota-burn surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.16] - 2026-06-10
+
+### Fixed
+- Schedule boards no longer freeze after their first fetch of the day. Every cache-fallback serve path hardcoded `disableProviderFallback`, so a board fetched once (usually the evening before, as "tomorrow") was served stale all day while self-reporting completeness 1.0 — live delays, cancellations, and gate changes never appeared. The warm cron now sends an authenticated `forceRefresh` that actually refetches the board, background refreshes may use the provider once data is older than 3h (one provider refresh per board per hour), and a warm that comes back stale, degraded, CDN-cached, or otherwise un-refetched counts as a FAILED warm instead of a green "ok".
+- The warm rotation now refreshes every today board 3×/day (~every 8h) and each tomorrow board once, on an hourly cron — ~288 AeroDataBox units/day, exactly the metered-plan budget that previously went unspent. Warm day-keys are computed with the DST-safe hub-local helper, so pre-6AM slots no longer spend quota on mislabeled yesterday boards.
+- The degraded-board banner now shows a humanized data age ("30h ago", not "1775m ago"), escalates teal → amber → red as the board ages past 1h/6h, and no longer promises a refresh that wasn't happening.
+- A run of the warm cron that warmed no schedule board returns 503 so Vercel cron monitoring goes red during exactly the frozen-board incident class (the always-green Starlink ping no longer masks it).
+
+### Security
+- `/api/schedule` now rejects non-United-hub airport codes and snaps timestamps to the hub-local day start. Previously any 3-4 letter code at 1-second timestamp granularity busted all four cache tiers and fired two metered AeroDataBox calls per unique combination — one IP at the allowed rate could drain the monthly quota in under two hours, recreating the June outage on demand.
+- Provider spend now has a cross-instance daily unit budget (default 400, `AERODATABOX_DAILY_UNIT_BUDGET`; `0` is honored as a kill switch) persisted via an atomic Supabase counter (`sql/009_provider_spend.sql` — apply manually in the SQL editor). Authorized cron warms bypass the organic budget (they are ring-bounded) but keep a hydrated 3× absolute ceiling so even a leaked cron secret cannot spend unboundedly.
+- Cron authorization is now timing-safe and fails closed when `CRON_SECRET` is unset (the literal string "Bearer undefined" previously authenticated), shared via `api/_cron-auth.ts`.
+- Any `forceRefresh`-flavored request responds `Cache-Control: no-store` regardless of authorization, so an unauthenticated probe of the predictable warm URL can no longer pin a 6h CDN object on the cron's own URL key and re-freeze boards behind a green cron.
+
 ## [1.5.15] - 2026-06-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Curated United Airlines news hub with individual article pages, source links, an
     │  /api/fr24-usage    — FR24 credit monitor│
     │                                          │
     │  Cron jobs (vercel.json):                │
-    │  /api/cron/warm-schedules  — every 15min │
+    │  /api/cron/warm-schedules  — hourly      │
     │  /api/cron/sync-starlink   — every 4hrs  │
     └──────────┬──────────────────────────────┘
                │
@@ -107,7 +107,7 @@ Curated United Airlines news hub with individual article pages, source links, an
 ### Why Server-Side Proxies?
 
 - **Rate limiting** — One server fetches data for all users, not 500 browsers hammering APIs independently
-- **Caching** — Schedule data cached 60s (live) / 5min (historical), IROPS cached 5min, reducing upstream load by 90%+
+- **Caching** — Complete schedule boards cached up to 6h at the edge (60s when partial), IROPS cached 5min, reducing upstream load by 90%+
 - **UA filtering** — Server filters to United flights only, shrinking payloads dramatically
 - **CORS** — Some sources (AWC, FAA) don't allow direct browser requests
 - **Batching** — METAR data for all 9 hubs fetched in a single request
@@ -119,6 +119,7 @@ Curated United Airlines news hub with individual article pages, source links, an
 | Source | Data | Freshness | Notes |
 |--------|------|-----------|-------|
 | [Flightradar24](https://flightradar24.com) | Live positions, schedules, flight lookup | ~15s–60s | Server-side proxy with caching; schedules can recover through a configured FR24 scraper transport when direct fetches are blocked |
+| [AeroDataBox](https://aerodatabox.com) | Hub schedule boards (refresh + fallback) | Hourly warm + on-demand | Metered RapidAPI provider; spend capped by a cross-instance daily unit budget |
 | [Aviation Weather Center](https://aviationweather.gov) | METAR observations | ~5min | NOAA/CORS proxy, batched |
 | [FAA NAS Status](https://nasstatus.faa.gov) | Delays & ground stops | ~5min | XML→JSON proxy |
 | [United Fleet Site](https://unitedfleetsite.com/) | Fleet database | Daily | Community-maintained |
@@ -205,7 +206,7 @@ Curated United Airlines news hub with individual article pages, source links, an
 │   ├── icons/                    # PWA app icons (192px, 512px)
 │   └── robots.txt                # Search engine directives
 ├── api/
-│   ├── schedule.ts               # FR24 schedule proxy (cached, rate-limited)
+│   ├── schedule.ts               # Hub schedule boards (FR24 + AeroDataBox, cached, rate-limited, quota-guarded)
 │   ├── irops.ts                  # Server-side IROPS aggregation (5min cache)
 │   ├── fr24-feed.ts              # Live flight feed proxy
 │   ├── fr24-flight.ts            # FR24 official API flight lookup
@@ -216,7 +217,7 @@ Curated United Airlines news hub with individual article pages, source links, an
 │   ├── waitlist.ts               # Waitlist signup + welcome email
 │   ├── news-notify.ts            # News digest email broadcasts
 │   ├── fr24-usage.ts             # FR24 credit usage monitor
-│   ├── cron/warm-schedules.ts    # Schedule cache warming (every 15min)
+│   ├── cron/warm-schedules.ts    # Schedule cache warming (hourly, quota-budgeted)
 │   └── cron/sync-starlink.ts     # Starlink data sync (every 4hrs)
 ├── sql/                          # Supabase migration files
 ├── scripts/                      # Build + seed scripts

--- a/TODOS.md
+++ b/TODOS.md
@@ -16,7 +16,7 @@
 
 ### Security hygiene (backlog)
 
-- [ ] [#6] CRON_SECRET timing-safe compare across `api/cron/refresh-tsa.ts:10`, `api/cron/sync-starlink.ts:11`, `api/cron/warm-schedules.ts:79`, `api/news-notify.ts:50-51`. Bundle with auth hardening pass.
+- [ ] [#6] CRON_SECRET timing-safe compare across `api/cron/refresh-tsa.ts:10`, `api/cron/sync-starlink.ts:11`, `api/news-notify.ts:50-51`. Bundle with auth hardening pass. (partial: warm-schedules + the /api/schedule forceRefresh gate shipped timing-safe fail-closed auth in v1.5.16 via `api/_cron-auth.ts` — reuse it for the remaining three)
 - [ ] [#26 extension] Evaluate moving waitlist off hand-rolled Supabase+Resend → Loops/Resend Audiences/ConvertKit.
 - [ ] [README drift] Audit README claims vs actual codebase ("strict CSP", "zero inline handlers", "fully escaped") and either fix the code or fix the docs.
 

--- a/api/_cost-state.ts
+++ b/api/_cost-state.ts
@@ -67,6 +67,117 @@ export async function hydrateQuotaBlock(): Promise<number> {
   }
 }
 
+// ── AeroDataBox daily unit budget ──
+//
+// The schedule provider is METERED (RapidAPI bills per call: 1 board = 2 FIDS calls = 4 units).
+// The per-IP rate limiter is in-memory per lambda instance, so it cannot bound global spend under
+// fan-out — one IP at the allowed rate can drain a monthly tier in hours. This counter is the
+// cross-instance hard stop: once the day's units cross the budget, fetchViaAeroDataBox refuses to
+// call upstream until the next UTC day. Persistence uses the increment_adb_units RPC
+// (sql/009_provider_spend.sql); like the quota block above, every Supabase failure degrades to
+// in-memory per-instance accounting — never worse than no guard at all.
+
+const ADB_HYDRATE_TTL_MS = 10_000;
+
+let adbDay = '';            // UTC day (YYYY-MM-DD) the counter applies to
+let adbUnits = 0;           // units spent today, as best known by this instance
+let lastAdbHydratedAt = 0;
+
+function utcToday(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function rollAdbDay(): void {
+  const today = utcToday();
+  if (adbDay !== today) {
+    adbDay = today;
+    adbUnits = 0;
+  }
+}
+
+export function getAdbUnitsToday(): number {
+  rollAdbDay();
+  return adbUnits;
+}
+
+export function getAdbDailyUnitBudget(): number {
+  const configured = Number(process.env.AERODATABOX_DAILY_UNIT_BUDGET);
+  return Number.isFinite(configured) && configured > 0 ? configured : 400;
+}
+
+/** True once today's known spend has reached the daily budget. Sync; safe in the hot path. */
+export function isAdbBudgetExhausted(): boolean {
+  return getAdbUnitsToday() >= getAdbDailyUnitBudget();
+}
+
+/**
+ * Record provider spend: bump the in-memory counter immediately, then write-through via the
+ * atomic increment RPC and adopt the returned cross-instance total. Callers may ignore the
+ * promise (fire-and-forget); never throws.
+ */
+export async function recordAdbUnits(units: number): Promise<void> {
+  const n = Number(units);
+  if (!Number.isFinite(n) || n <= 0) return;
+  rollAdbDay();
+  adbUnits += n;
+
+  try {
+    const supabase = typeof getSupabaseAdmin === 'function' ? await getSupabaseAdmin() : null;
+    if (!supabase || typeof supabase.rpc !== 'function') return;
+
+    const { data, error } = await supabase.rpc('increment_adb_units', { p_day: adbDay, p_units: n });
+    if (error) {
+      console.error('adb-spend increment failed:', error.message);
+      return;
+    }
+    const total = Number(data);
+    rollAdbDay();
+    if (Number.isFinite(total)) adbUnits = Math.max(adbUnits, total);
+  } catch (error: any) {
+    console.error('adb-spend increment threw:', error?.message || error);
+  }
+}
+
+/**
+ * Pull today's cross-instance spend into the in-memory counter, at most once per
+ * ADB_HYDRATE_TTL_MS. Never throws; on any failure the in-memory value stands.
+ */
+export async function hydrateAdbSpend(): Promise<number> {
+  rollAdbDay();
+  const now = Date.now();
+  if (now - lastAdbHydratedAt < ADB_HYDRATE_TTL_MS) return adbUnits;
+  lastAdbHydratedAt = now;
+
+  try {
+    const supabase = typeof getSupabaseAdmin === 'function' ? await getSupabaseAdmin() : null;
+    if (!supabase || typeof supabase.from !== 'function') return adbUnits;
+
+    const { data, error } = await supabase
+      .from('schedule_provider_spend')
+      .select('units')
+      .eq('day', adbDay)
+      .limit(1);
+    if (error) {
+      console.error('adb-spend read failed:', error.message);
+      return adbUnits;
+    }
+    const units = Number((data as Array<{ units: number }> | null)?.[0]?.units);
+    rollAdbDay();
+    if (Number.isFinite(units)) adbUnits = Math.max(adbUnits, units);
+    return adbUnits;
+  } catch (error: any) {
+    console.error('adb-spend read threw:', error?.message || error);
+    return adbUnits;
+  }
+}
+
+/** Test helper: clear ADB spend state so it does not leak across tests. Production never calls it. */
+export function __resetAdbSpendForTests(): void {
+  adbDay = '';
+  adbUnits = 0;
+  lastAdbHydratedAt = 0;
+}
+
 /**
  * Write-through a new quota block so other instances honour it on their next hydrate. Fire-and-
  * forget from the caller's perspective; never throws.

--- a/api/_cost-state.ts
+++ b/api/_cost-state.ts
@@ -121,8 +121,11 @@ export function getAdbUnitsToday(): number {
 }
 
 export function getAdbDailyUnitBudget(): number {
+  // An explicit 0 is a kill switch (operator says: stop all metered spend NOW) and must be
+  // honoured — substituting the default would fail open with real money. Garbage (negative,
+  // NaN) falls back to the default.
   const configured = Number(process.env.AERODATABOX_DAILY_UNIT_BUDGET);
-  return Number.isFinite(configured) && configured > 0 ? configured : 400;
+  return Number.isFinite(configured) && configured >= 0 ? configured : 400;
 }
 
 /** True once today's known spend has reached the daily budget. Sync; safe in the hot path. */

--- a/api/_cost-state.ts
+++ b/api/_cost-state.ts
@@ -87,6 +87,26 @@ function utcToday(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
+// Schema-missing must be loudly distinguishable from a transient Supabase blip: with sql/009
+// unapplied, the cross-instance ceiling silently doesn't exist (per-instance only) while
+// everything else looks healthy — the same invisible-drift failure mode as the migration-006
+// incident. PGRST202 = missing RPC; 42P01 = missing table.
+let warnedAdbSchemaMissing = false;
+function logAdbPersistError(op: string, error: { code?: string; message?: string }): void {
+  const code = String(error?.code || '');
+  const message = String(error?.message || '');
+  if (code === 'PGRST202' || code === '42P01' || /increment_adb_units.*not.*found|schedule_provider_spend.*does not exist/i.test(message)) {
+    if (!warnedAdbSchemaMissing) {
+      warnedAdbSchemaMissing = true;
+      console.error(
+        'sql/009_provider_spend.sql is NOT applied — the AeroDataBox budget is per-instance only (no cross-instance ceiling). Apply it via the Supabase SQL editor.'
+      );
+    }
+    return;
+  }
+  console.error(`adb-spend ${op} failed:`, message);
+}
+
 function rollAdbDay(): void {
   const today = utcToday();
   if (adbDay !== today) {
@@ -128,7 +148,7 @@ export async function recordAdbUnits(units: number): Promise<void> {
 
     const { data, error } = await supabase.rpc('increment_adb_units', { p_day: issuedForDay, p_units: n });
     if (error) {
-      console.error('adb-spend increment failed:', error.message);
+      logAdbPersistError('increment', error);
       return;
     }
     const total = Number(data);
@@ -163,7 +183,7 @@ export async function hydrateAdbSpend(): Promise<number> {
       .eq('day', issuedForDay)
       .limit(1);
     if (error) {
-      console.error('adb-spend read failed:', error.message);
+      logAdbPersistError('read', error);
       return adbUnits;
     }
     const units = Number((data as Array<{ units: number }> | null)?.[0]?.units);
@@ -183,6 +203,7 @@ export function __resetAdbSpendForTests(): void {
   adbDay = '';
   adbUnits = 0;
   lastAdbHydratedAt = 0;
+  warnedAdbSchemaMissing = false;
 }
 
 /**

--- a/api/_cost-state.ts
+++ b/api/_cost-state.ts
@@ -120,19 +120,23 @@ export async function recordAdbUnits(units: number): Promise<void> {
   if (!Number.isFinite(n) || n <= 0) return;
   rollAdbDay();
   adbUnits += n;
+  const issuedForDay = adbDay;
 
   try {
     const supabase = typeof getSupabaseAdmin === 'function' ? await getSupabaseAdmin() : null;
     if (!supabase || typeof supabase.rpc !== 'function') return;
 
-    const { data, error } = await supabase.rpc('increment_adb_units', { p_day: adbDay, p_units: n });
+    const { data, error } = await supabase.rpc('increment_adb_units', { p_day: issuedForDay, p_units: n });
     if (error) {
       console.error('adb-spend increment failed:', error.message);
       return;
     }
     const total = Number(data);
     rollAdbDay();
-    if (Number.isFinite(total)) adbUnits = Math.max(adbUnits, total);
+    // Only adopt the returned total if UTC midnight did not pass mid-flight — it is the running
+    // total for the day the RPC was issued for, and adopting yesterday's total into a fresh day
+    // would falsely block the provider until the next reset.
+    if (Number.isFinite(total) && adbDay === issuedForDay) adbUnits = Math.max(adbUnits, total);
   } catch (error: any) {
     console.error('adb-spend increment threw:', error?.message || error);
   }
@@ -147,6 +151,7 @@ export async function hydrateAdbSpend(): Promise<number> {
   const now = Date.now();
   if (now - lastAdbHydratedAt < ADB_HYDRATE_TTL_MS) return adbUnits;
   lastAdbHydratedAt = now;
+  const issuedForDay = adbDay;
 
   try {
     const supabase = typeof getSupabaseAdmin === 'function' ? await getSupabaseAdmin() : null;
@@ -155,7 +160,7 @@ export async function hydrateAdbSpend(): Promise<number> {
     const { data, error } = await supabase
       .from('schedule_provider_spend')
       .select('units')
-      .eq('day', adbDay)
+      .eq('day', issuedForDay)
       .limit(1);
     if (error) {
       console.error('adb-spend read failed:', error.message);
@@ -163,7 +168,9 @@ export async function hydrateAdbSpend(): Promise<number> {
     }
     const units = Number((data as Array<{ units: number }> | null)?.[0]?.units);
     rollAdbDay();
-    if (Number.isFinite(units)) adbUnits = Math.max(adbUnits, units);
+    // Same mid-flight day-rollover guard as recordAdbUnits: never adopt yesterday's total into a
+    // fresh day.
+    if (Number.isFinite(units) && adbDay === issuedForDay) adbUnits = Math.max(adbUnits, units);
     return adbUnits;
   } catch (error: any) {
     console.error('adb-spend read threw:', error?.message || error);

--- a/api/_cron-auth.ts
+++ b/api/_cron-auth.ts
@@ -1,0 +1,23 @@
+// Shared cron authorization: timing-safe Bearer comparison against CRON_SECRET that fails
+// CLOSED when the secret is unset. A plain `auth !== `Bearer ${process.env.CRON_SECRET}``
+// with the env var missing compares against the literal string "Bearer undefined" — a
+// guessable constant that authenticates anyone. Used by the cron handlers and by
+// /api/schedule's forceRefresh gate.
+
+import { timingSafeEqual } from 'node:crypto';
+
+export function timingSafeEqualStr(a: string, b: string): boolean {
+  const ab = new TextEncoder().encode(a);
+  const bb = new TextEncoder().encode(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+/** True only when CRON_SECRET is configured AND the authorization header matches it. */
+export function isAuthorizedCronRequest(req: { headers?: Record<string, string | string[] | undefined> }): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return false;
+  const raw = req.headers?.authorization;
+  const auth = Array.isArray(raw) ? raw[0] || '' : raw || '';
+  return timingSafeEqualStr(auth, `Bearer ${secret}`);
+}

--- a/api/_hubs.ts
+++ b/api/_hubs.ts
@@ -1,0 +1,30 @@
+// Single source of truth for the United hub list and terminal assignments.
+// Shared by api/schedule.ts (request validation + terminals), api/_schedule-aerodatabox.ts
+// (terminals), and api/cron/warm-schedules.ts (warm rotation). The /api/schedule handler
+// rejects anything outside this set: every distinct hub value mints its own cache keys and,
+// on a miss, fires 2 metered AeroDataBox calls — an open-ended airport parameter is an
+// unmetered spend surface.
+
+export const UNITED_HUBS = ['ORD', 'DEN', 'IAH', 'EWR', 'SFO', 'IAD', 'LAX', 'NRT', 'GUM'] as const;
+
+export const UNITED_HUB_SET: ReadonlySet<string> = new Set(UNITED_HUBS);
+
+// Known United Airlines terminal assignments at each hub (used when the API doesn't provide
+// terminal data).
+export const UNITED_HUB_TERMINALS: Record<string, { domestic: string; international: string }> = {
+  ORD: { domestic: '1', international: '1' },       // Terminal 1 (Concourses B & C); Express uses T2
+  DEN: { domestic: 'B', international: 'B' },       // Concourse B
+  EWR: { domestic: 'C', international: 'C' },       // Terminal C (primary); some flights use Terminal A
+  IAH: { domestic: 'C', international: 'E' },       // Terminal C (domestic), Terminal E (international)
+  SFO: { domestic: '3', international: 'G' },       // Terminal 3 (domestic), International Terminal G
+  LAX: { domestic: '7', international: '7' },       // Terminals 7 & 8
+  IAD: { domestic: 'C', international: 'D' },       // Concourse C (domestic), Concourse D (international)
+  NRT: { domestic: '1', international: '1' },       // Terminal 1
+  GUM: { domestic: '1', international: '1' },       // Single terminal
+};
+
+export function getHubTerminal(iata: string, isIntl: boolean): string {
+  const hub = UNITED_HUB_TERMINALS[iata.toUpperCase()];
+  if (!hub) return '';
+  return isIntl ? hub.international : hub.domestic;
+}

--- a/api/_schedule-aerodatabox.ts
+++ b/api/_schedule-aerodatabox.ts
@@ -1,25 +1,11 @@
 import { HUB_TZ } from './irops.js';
 import { icaoToIata, isInternationalRoute } from '../src/lib/airport-metadata.js';
+import { getHubTerminal } from './_hubs.js';
+import { hydrateAdbSpend, isAdbBudgetExhausted, recordAdbUnits, getAdbUnitsToday, getAdbDailyUnitBudget } from './_cost-state.js';
 
 const AERODATABOX_BASE_URL = 'https://prod.api.market/api/v1/aedbx/aerodatabox';
-
-const UNITED_HUB_TERMINALS: Record<string, { domestic: string; international: string }> = {
-  ORD: { domestic: '1', international: '1' },
-  DEN: { domestic: 'B', international: 'B' },
-  EWR: { domestic: 'C', international: 'C' },
-  IAH: { domestic: 'C', international: 'E' },
-  SFO: { domestic: '3', international: 'G' },
-  LAX: { domestic: '7', international: '7' },
-  IAD: { domestic: 'C', international: 'D' },
-  NRT: { domestic: '1', international: '1' },
-  GUM: { domestic: '1', international: '1' },
-};
-
-function getHubTerminal(iata: string, isIntl: boolean): string {
-  const hub = UNITED_HUB_TERMINALS[iata.toUpperCase()];
-  if (!hub) return '';
-  return isIntl ? hub.international : hub.domestic;
-}
+// Each FIDS window request is billed at 2 units by the provider (1 board = 2 windows = 4 units).
+const ADB_UNITS_PER_REQUEST = 2;
 
 function partsToObj(parts: Intl.DateTimeFormatPart[]): Record<string, string> {
   const o: Record<string, string> = {};
@@ -278,6 +264,9 @@ async function fetchWindow(
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), Math.min(remaining, 15000));
     try {
+      // Count spend per request actually fired (retries bill too), before reading the outcome —
+      // a 429 storm then exhausts the budget quickly, which is exactly the circuit we want.
+      void recordAdbUnits(ADB_UNITS_PER_REQUEST);
       const resp = await fetch(url, { signal: controller.signal, headers });
       clearTimeout(timer);
 
@@ -327,6 +316,16 @@ async function fetchWindow(
 
 export async function fetchViaAeroDataBox(hub: string, dir: string, ts: number, timeoutMs = 12000) {
   if (!process.env.AERODATABOX_API_KEY) return null;
+
+  // Cross-instance daily spend stop: behave exactly as if the provider were unconfigured so
+  // callers fall through to their existing degraded paths instead of burning more quota.
+  await hydrateAdbSpend();
+  if (isAdbBudgetExhausted()) {
+    console.warn(
+      `AeroDataBox daily unit budget exhausted (${getAdbUnitsToday()}/${getAdbDailyUnitBudget()}); skipping ${hub} ${dir} until next UTC day`
+    );
+    return null;
+  }
 
   const startTime = Date.now();
   const date = hubLocalDate(hub, ts);

--- a/api/_schedule-aerodatabox.ts
+++ b/api/_schedule-aerodatabox.ts
@@ -345,7 +345,10 @@ export async function fetchViaAeroDataBox(
   // Authorized cron warms bypass the organic gate — their spend is hard-bounded by the warm ring
   // itself (~288 units/day) and they are the one path that keeps boards from freezing, so organic
   // traffic must never starve them. Their units are still recorded against the organic budget,
-  // and they keep a 3x absolute ceiling so a leaked cron secret cannot spend unboundedly.
+  // and they keep a 3x absolute ceiling so a leaked cron secret cannot spend unboundedly. Both
+  // gates hydrate first: an unhydrated ceiling reads a cold instance's 0 and is per-instance
+  // theater under fan-out (the hydrate is rate-limited to one Supabase read per 10s).
+  await hydrateAdbSpend();
   if (opts.bypassDailyBudget) {
     if (getAdbUnitsToday() >= getAdbDailyUnitBudget() * ADB_BYPASS_CEILING_MULTIPLIER) {
       console.error(
@@ -353,14 +356,11 @@ export async function fetchViaAeroDataBox(
       );
       return null;
     }
-  } else {
-    await hydrateAdbSpend();
-    if (isAdbBudgetExhausted()) {
-      console.warn(
-        `AeroDataBox daily unit budget exhausted (${getAdbUnitsToday()}/${getAdbDailyUnitBudget()}); skipping ${hub} ${dir} until next UTC day`
-      );
-      return null;
-    }
+  } else if (isAdbBudgetExhausted()) {
+    console.warn(
+      `AeroDataBox daily unit budget exhausted (${getAdbUnitsToday()}/${getAdbDailyUnitBudget()}); skipping ${hub} ${dir} until next UTC day`
+    );
+    return null;
   }
 
   const startTime = Date.now();

--- a/api/_schedule-aerodatabox.ts
+++ b/api/_schedule-aerodatabox.ts
@@ -314,13 +314,22 @@ async function fetchWindow(
   return { ok: false };
 }
 
-export async function fetchViaAeroDataBox(hub: string, dir: string, ts: number, timeoutMs = 12000) {
+export async function fetchViaAeroDataBox(
+  hub: string,
+  dir: string,
+  ts: number,
+  timeoutMs = 12000,
+  opts: { bypassDailyBudget?: boolean } = {}
+) {
   if (!process.env.AERODATABOX_API_KEY) return null;
 
   // Cross-instance daily spend stop: behave exactly as if the provider were unconfigured so
   // callers fall through to their existing degraded paths instead of burning more quota.
+  // Authorized cron warms bypass the gate — their spend is hard-bounded by the warm ring itself
+  // (~288 units/day) and they are the one path that keeps boards from freezing, so organic
+  // traffic must never starve them. Their units are still recorded against the organic budget.
   await hydrateAdbSpend();
-  if (isAdbBudgetExhausted()) {
+  if (!opts.bypassDailyBudget && isAdbBudgetExhausted()) {
     console.warn(
       `AeroDataBox daily unit budget exhausted (${getAdbUnitsToday()}/${getAdbDailyUnitBudget()}); skipping ${hub} ${dir} until next UTC day`
     );

--- a/api/_schedule-aerodatabox.ts
+++ b/api/_schedule-aerodatabox.ts
@@ -1,3 +1,4 @@
+import { waitUntil } from '@vercel/functions';
 import { HUB_TZ } from './irops.js';
 import { icaoToIata, isInternationalRoute } from '../src/lib/airport-metadata.js';
 import { getHubTerminal } from './_hubs.js';
@@ -6,6 +7,22 @@ import { hydrateAdbSpend, isAdbBudgetExhausted, recordAdbUnits, getAdbUnitsToday
 const AERODATABOX_BASE_URL = 'https://prod.api.market/api/v1/aedbx/aerodatabox';
 // Each FIDS window request is billed at 2 units by the provider (1 board = 2 windows = 4 units).
 const ADB_UNITS_PER_REQUEST = 2;
+// Budget-exempt (cron-forced) calls still hit an absolute ceiling at 3x the organic budget so a
+// leaked cron secret cannot spend unboundedly; the warm ring's own cadence keeps normal forced
+// spend far below this.
+const ADB_BYPASS_CEILING_MULTIPLIER = 3;
+
+// Persist the spend write even if Vercel freezes the lambda right after the response is sent —
+// a dropped RPC undercounts the cross-instance counter that IS the global spend ceiling.
+function recordAdbUnitsDurable(units: number): void {
+  const promise = recordAdbUnits(units);
+  try {
+    waitUntil(promise);
+  } catch {
+    // Outside a Vercel request context (tests, local scripts) waitUntil may throw; the promise
+    // still runs to completion in-process.
+  }
+}
 
 function partsToObj(parts: Intl.DateTimeFormatPart[]): Record<string, string> {
   const o: Record<string, string> = {};
@@ -266,7 +283,7 @@ async function fetchWindow(
     try {
       // Count spend per request actually fired (retries bill too), before reading the outcome —
       // a 429 storm then exhausts the budget quickly, which is exactly the circuit we want.
-      void recordAdbUnits(ADB_UNITS_PER_REQUEST);
+      recordAdbUnitsDurable(ADB_UNITS_PER_REQUEST);
       const resp = await fetch(url, { signal: controller.signal, headers });
       clearTimeout(timer);
 
@@ -325,15 +342,25 @@ export async function fetchViaAeroDataBox(
 
   // Cross-instance daily spend stop: behave exactly as if the provider were unconfigured so
   // callers fall through to their existing degraded paths instead of burning more quota.
-  // Authorized cron warms bypass the gate — their spend is hard-bounded by the warm ring itself
-  // (~288 units/day) and they are the one path that keeps boards from freezing, so organic
-  // traffic must never starve them. Their units are still recorded against the organic budget.
-  await hydrateAdbSpend();
-  if (!opts.bypassDailyBudget && isAdbBudgetExhausted()) {
-    console.warn(
-      `AeroDataBox daily unit budget exhausted (${getAdbUnitsToday()}/${getAdbDailyUnitBudget()}); skipping ${hub} ${dir} until next UTC day`
-    );
-    return null;
+  // Authorized cron warms bypass the organic gate — their spend is hard-bounded by the warm ring
+  // itself (~288 units/day) and they are the one path that keeps boards from freezing, so organic
+  // traffic must never starve them. Their units are still recorded against the organic budget,
+  // and they keep a 3x absolute ceiling so a leaked cron secret cannot spend unboundedly.
+  if (opts.bypassDailyBudget) {
+    if (getAdbUnitsToday() >= getAdbDailyUnitBudget() * ADB_BYPASS_CEILING_MULTIPLIER) {
+      console.error(
+        `AeroDataBox bypass ceiling hit (${getAdbUnitsToday()}/${getAdbDailyUnitBudget() * ADB_BYPASS_CEILING_MULTIPLIER}); refusing forced fetch for ${hub} ${dir}`
+      );
+      return null;
+    }
+  } else {
+    await hydrateAdbSpend();
+    if (isAdbBudgetExhausted()) {
+      console.warn(
+        `AeroDataBox daily unit budget exhausted (${getAdbUnitsToday()}/${getAdbDailyUnitBudget()}); skipping ${hub} ${dir} until next UTC day`
+      );
+      return null;
+    }
   }
 
   const startTime = Date.now();

--- a/api/cron/warm-schedules.ts
+++ b/api/cron/warm-schedules.ts
@@ -131,11 +131,18 @@ async function warmOne(hub: string, dir: string, timestamp: number, label: strin
         data.stale === true ||
         data.degraded === true ||
         Number(data?.meta?.dataAge || 0) > STALE_WARM_MAX_AGE_S;
+      // A warm that did not actually refetch warmed nothing: a CDN HIT means the lambda never
+      // ran (the stored body may be a frozen board recorded as cached:false hours ago), and
+      // cached:true means forceRefresh was silently ignored (e.g. CRON_SECRET missing from the
+      // schedule lambda's env). Both must read as failures, not green oks.
+      const notRefreshed = !servedStale && (/HIT/i.test(cdnStatus) || data.cached === true);
       const status = servedStale
         ? 'stale_served'
-        : partial
-          ? flights > 0 ? 'degraded_partial' : 'degraded_empty'
-          : 'ok';
+        : notRefreshed
+          ? 'not_refreshed'
+          : partial
+            ? flights > 0 ? 'degraded_partial' : 'degraded_empty'
+            : 'ok';
       return {
         key,
         result: {

--- a/api/cron/warm-schedules.ts
+++ b/api/cron/warm-schedules.ts
@@ -1,63 +1,88 @@
 // Vercel Cron Job: rotates through the 2-day schedule window (today/tomorrow) so exact
 // hub/day/direction snapshots stay warm at the CDN + Supabase snapshot. Yesterday is served
 // on-demand (historical board, rarely viewed) to conserve the metered AeroDataBox quota.
-// Config in vercel.json: { "path": "/api/cron/warm-schedules", "schedule": "0 */2 * * *" }
+// Config in vercel.json: { "path": "/api/cron/warm-schedules", "schedule": "0 * * * *" }
+//
+// Warm requests send forceRefresh=1 + the cron secret so /api/schedule actually REFETCHES the
+// board. Without it the handler serves the existing complete snapshot back to the cron, reports
+// "ok", and a board fetched once (usually the evening before, as "tomorrow") is never refreshed
+// again all day — the frozen-board failure mode this cron exists to prevent.
 
 import type { VercelRequest, VercelResponse } from '../types.js';
-import { getStartOfDayForHub } from '../irops.js';
+import { UNITED_HUBS } from '../_hubs.js';
+import { getStartOfHubDay } from '../../src/lib/hubTz.js';
 
-const HUBS = ['ORD', 'DEN', 'IAH', 'EWR', 'SFO', 'IAD', 'LAX', 'NRT', 'GUM'];
+const HUBS = UNITED_HUBS;
 // Serialized with INTER_TASK_DELAY_MS between tasks. Budget math: each task worst-case is ~58s
 // (55s schedule fetch + 3s gap). maxDuration for this cron is 300s in vercel.json, so the clamp
-// ceiling of 4 tasks → 4 × 58s = 232s stays under the Lambda limit. Default is 2 to bound the
-// metered AeroDataBox spend: 2 boards/run × 12 runs/day × 4 units/board ≈ 96 units/day worst case
-// (~2,880/mo), well inside a paid tier. Serial (not Promise.allSettled) respects the 1 req/s limit.
-const WARM_TASKS_PER_RUN = Math.max(1, Math.min(4, Number(process.env.SCHEDULE_WARM_TASKS_PER_RUN || 2) || 2));
-const INTER_TASK_DELAY_MS = Math.max(0, Number(process.env.SCHEDULE_WARM_DELAY_MS || 3000) || 3000);
+// ceiling of 4 tasks → 4 × 58s = 232s stays under the Lambda limit. Default is 3 on an HOURLY
+// cron: 3 tasks × 24 fires = 72 warm slots/day = exactly one full ring (today boards 3×/day,
+// tomorrow boards 1×/day) ≈ 72 fresh boards × 4 units = 288 AeroDataBox units/day, the metered
+// plan's budget. Serial (not Promise.allSettled) respects the provider's 1 req/s limit.
+function envNumber(name: string, fallback: number): number {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) ? value : fallback;
+}
+// Read per call (not at module load) so a runtime env change — or a test — actually takes effect,
+// and so an explicit '0' delay is honoured instead of being swallowed by `|| fallback`.
+const getWarmTasksPerRun = () => Math.max(1, Math.min(4, Math.floor(envNumber('SCHEDULE_WARM_TASKS_PER_RUN', 3))));
+const getInterTaskDelayMs = () => Math.max(0, envNumber('SCHEDULE_WARM_DELAY_MS', 3000));
+// A warm that came back stale/degraded did not warm anything — the handler served a frozen
+// fallback instead of refetching. Anything older than the clean-board TTL (6h) counts as failed.
+const STALE_WARM_MAX_AGE_S = 21600;
 const BASE_URL = process.env.VERCEL_PROJECT_PRODUCTION_URL
   ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
   : process.env.VERCEL_URL
     ? `https://${process.env.VERCEL_URL}`
     : 'https://theblueboard.co';
 
-// Yesterday (dayOffset -1) is intentionally NOT warmed — its board is historical/stable and
-// rarely viewed, so it loads on-demand (and caches) instead of burning quota every cycle.
-const WINDOW_TASKS = [
-  { dayOffset: 0, label: 'today', dir: 'departures' },
-  { dayOffset: 0, label: 'today', dir: 'arrivals' },
-  { dayOffset: 1, label: 'tomorrow', dir: 'departures' },
-  { dayOffset: 1, label: 'tomorrow', dir: 'arrivals' },
-] as const;
-
 type WarmTask = {
   hub: string;
   dir: 'departures' | 'arrivals';
-  dayOffset: -1 | 0 | 1;
-  label: 'yesterday' | 'today' | 'tomorrow';
+  dayOffset: 0 | 1;
+  label: 'today' | 'tomorrow';
 };
 
-export function buildWarmPlan(nowMs = Date.now()): WarmTask[] {
+// Yesterday (dayOffset -1) is intentionally NOT warmed — its board is historical/stable and
+// rarely viewed, so it loads on-demand (and caches) instead of burning quota every cycle.
+function windowTasks(dayOffset: 0 | 1, label: 'today' | 'tomorrow'): WarmTask[] {
   const tasks: WarmTask[] = [];
-  for (const task of WINDOW_TASKS) {
-    for (const hub of HUBS) {
-      tasks.push({
-        hub,
-        dir: task.dir,
-        dayOffset: task.dayOffset,
-        label: task.label,
-      });
-    }
+  for (const dir of ['departures', 'arrivals'] as const) {
+    for (const hub of HUBS) tasks.push({ hub, dir, dayOffset, label });
   }
+  return tasks;
+}
+
+// The warm ring: TODAY_ROUNDS rounds of all 18 today windows, with the 18 tomorrow windows split
+// evenly across the rounds. Striding through it sequentially warms each today board TODAY_ROUNDS
+// times per ring (~every 8h — delays/cancellations stay current) and each tomorrow board once
+// (schedule data is stable; it just needs to exist before midnight).
+const TODAY_ROUNDS = 3;
+function buildWarmRing(): WarmTask[] {
+  const today = windowTasks(0, 'today');
+  const tomorrow = windowTasks(1, 'tomorrow');
+  const perRound = Math.ceil(tomorrow.length / TODAY_ROUNDS);
+  const ring: WarmTask[] = [];
+  for (let round = 0; round < TODAY_ROUNDS; round++) {
+    ring.push(...today);
+    ring.push(...tomorrow.slice(round * perRound, (round + 1) * perRound));
+  }
+  return ring;
+}
+
+export function buildWarmPlan(nowMs = Date.now()): WarmTask[] {
+  const tasks = buildWarmRing();
 
   // Advance exactly one WARM_TASKS_PER_RUN stride per cron fire so consecutive fires cover the
-  // window list sequentially with no gaps. SLOT_MS MUST match the cron interval in vercel.json
-  // (currently every 2h): a 15-min slot here while the cron fires every 2h would stride 8× per
-  // fire and skip most windows (only every Nth pair would ever warm). Update both together.
-  const SLOT_MS = 2 * 60 * 60 * 1000; // = vercel.json cron interval (0 */2 * * *)
+  // ring sequentially with no gaps. SLOT_MS MUST match the cron interval in vercel.json
+  // (currently hourly): a 15-min slot here while the cron fires hourly would stride 4× per fire
+  // and skip most windows. Update both together.
+  const SLOT_MS = 60 * 60 * 1000; // = vercel.json cron interval (0 * * * *)
+  const tasksPerRun = getWarmTasksPerRun();
   const slot = Math.floor(nowMs / SLOT_MS);
-  const start = (slot * WARM_TASKS_PER_RUN) % tasks.length;
+  const start = (slot * tasksPerRun) % tasks.length;
   const plan: WarmTask[] = [];
-  for (let i = 0; i < Math.min(WARM_TASKS_PER_RUN, tasks.length); i++) {
+  for (let i = 0; i < Math.min(tasksPerRun, tasks.length); i++) {
     plan.push(tasks[(start + i) % tasks.length]);
   }
   return plan;
@@ -66,8 +91,9 @@ export function buildWarmPlan(nowMs = Date.now()): WarmTask[] {
 export function buildScheduleWarmUrl(hub: string, dir: string, timestamp: number): string {
   // Background warming uses the PROVIDER (AeroDataBox) — the only source that returns the full
   // board from Vercel — and keeps officialFallback off so warming never burns FR24 credits, and
-  // scraperFallback off (the FR24 scrape is Cloudflare-dead). With SCHEDULE_SOURCE_PRIORITY=provider
-  // this populates the CDN + Supabase snapshots so live user traffic is served from cache.
+  // scraperFallback off (the FR24 scrape is Cloudflare-dead). forceRefresh=1 (honoured only with
+  // the cron secret, sent by warmOne) bypasses the snapshot serve paths so the board is actually
+  // refetched instead of echoed back from the frozen cache.
   const params = new URLSearchParams({
     hub,
     dir,
@@ -75,6 +101,7 @@ export function buildScheduleWarmUrl(hub: string, dir: string, timestamp: number
     officialFallback: '0',
     providerFallback: '1',
     scraperFallback: '0',
+    forceRefresh: '1',
   });
   return `${BASE_URL}/api/schedule?${params}`;
 }
@@ -87,7 +114,11 @@ async function warmOne(hub: string, dir: string, timestamp: number, label: strin
     const timeout = setTimeout(() => controller.abort(), 55000);
     const resp = await fetch(url, {
       signal: controller.signal,
-      headers: { 'User-Agent': 'BlueBoard-CronWarmer/1.0' }
+      headers: {
+        'User-Agent': 'BlueBoard-CronWarmer/1.0',
+        // Authorizes forceRefresh on /api/schedule (same secret Vercel cron sends to this handler).
+        'Authorization': `Bearer ${process.env.CRON_SECRET}`,
+      }
     });
     clearTimeout(timeout);
     const cdnStatus = resp.headers.get('x-vercel-cache') || 'unknown';
@@ -95,9 +126,15 @@ async function warmOne(hub: string, dir: string, timestamp: number, label: strin
       const data = await resp.json() as any;
       const flights = Number(data.total || 0);
       const partial = data.partial === true;
-      const status = partial
-        ? flights > 0 ? 'degraded_partial' : 'degraded_empty'
-        : 'ok';
+      const servedStale =
+        data.stale === true ||
+        data.degraded === true ||
+        Number(data?.meta?.dataAge || 0) > STALE_WARM_MAX_AGE_S;
+      const status = servedStale
+        ? 'stale_served'
+        : partial
+          ? flights > 0 ? 'degraded_partial' : 'degraded_empty'
+          : 'ok';
       return {
         key,
         result: {
@@ -106,6 +143,7 @@ async function warmOne(hub: string, dir: string, timestamp: number, label: strin
           partial,
           cached: data.cached || false,
           cdn: cdnStatus,
+          dataAge: data?.meta?.dataAge,
           partialReason: data.meta?.partialReason,
           completeness: data.meta?.completeness,
         }
@@ -127,17 +165,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   let warmed = 0;
   let failed = 0;
 
-  // There are 36 total windows (9 hubs × 2 days × 2 directions); yesterday is on-demand.
-  // Keep the default conservative for the metered provider, and use the seed script for first-fill.
   const warmPlan = buildWarmPlan();
   for (let i = 0; i < warmPlan.length; i++) {
     const task = warmPlan[i];
-    const ts = getStartOfDayForHub(task.hub) + (task.dayOffset * 86400);
+    // getStartOfHubDay (NOT irops' getStartOfDayForHub): the IROPS helper rolls back to YESTERDAY
+    // before 6 AM hub-local and adds DST-naive +86400 for tomorrow, so ~25% of warm slots used to
+    // spend their quota on mislabeled day keys no user-facing view ever reads.
+    const ts = getStartOfHubDay(task.hub, task.dayOffset);
     const { key, result } = await warmOne(task.hub, task.dir, ts, task.label);
     results[key] = result;
     if (result.status === 'ok') warmed++; else failed++;
     if (i < warmPlan.length - 1) {
-      await new Promise(r => setTimeout(r, INTER_TASK_DELAY_MS));
+      await new Promise(r => setTimeout(r, getInterTaskDelayMs()));
     }
   }
 
@@ -167,7 +206,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     `Cron warm-schedules: ${warmed} warmed, ${failed} failed, ~${estUnits} AeroDataBox units (${freshBoards} fresh boards)`,
     { warmPlan, results }
   );
-  return res.status(200).json({
+  // A run that warmed NOTHING is an incident, not a success — return 5xx so Vercel's built-in
+  // cron monitoring (and any uptime check on this path) goes red instead of logging a quiet 200.
+  const statusCode = warmed === 0 && failed > 0 ? 503 : 200;
+  return res.status(statusCode).json({
     warmed,
     failed,
     warmPlan,

--- a/api/cron/warm-schedules.ts
+++ b/api/cron/warm-schedules.ts
@@ -10,6 +10,7 @@
 
 import type { VercelRequest, VercelResponse } from '../types.js';
 import { UNITED_HUBS } from '../_hubs.js';
+import { isAuthorizedCronRequest } from '../_cron-auth.js';
 import { getStartOfHubDay } from '../../src/lib/hubTz.js';
 
 const HUBS = UNITED_HUBS;
@@ -156,8 +157,9 @@ async function warmOne(hub: string, dir: string, timestamp: number, label: strin
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
-  // Vercel cron sends authorization header with CRON_SECRET
-  if (req.headers.authorization !== `Bearer ${process.env.CRON_SECRET}`) {
+  // Vercel cron sends authorization header with CRON_SECRET (timing-safe, fails closed on
+  // missing secret — see api/_cron-auth.ts).
+  if (!isAuthorizedCronRequest(req)) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
 

--- a/api/cron/warm-schedules.ts
+++ b/api/cron/warm-schedules.ts
@@ -162,6 +162,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   const results: Record<string, any> = {};
+  // Schedule warms are tracked separately from the Starlink ping: starlink-data has a 5-tier
+  // fallback chain and no AeroDataBox dependency, so it succeeds even mid-incident — counting it
+  // into one shared bucket would turn an every-board-frozen run into a green 200 (the exact
+  // masking this cron's 503 exists to kill).
+  let scheduleWarmed = 0;
+  let scheduleFailed = 0;
   let warmed = 0;
   let failed = 0;
 
@@ -174,7 +180,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const ts = getStartOfHubDay(task.hub, task.dayOffset);
     const { key, result } = await warmOne(task.hub, task.dir, ts, task.label);
     results[key] = result;
-    if (result.status === 'ok') warmed++; else failed++;
+    if (result.status === 'ok') { scheduleWarmed++; warmed++; } else { scheduleFailed++; failed++; }
     if (i < warmPlan.length - 1) {
       await new Promise(r => setTimeout(r, getInterTaskDelayMs()));
     }
@@ -206,12 +212,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     `Cron warm-schedules: ${warmed} warmed, ${failed} failed, ~${estUnits} AeroDataBox units (${freshBoards} fresh boards)`,
     { warmPlan, results }
   );
-  // A run that warmed NOTHING is an incident, not a success — return 5xx so Vercel's built-in
-  // cron monitoring (and any uptime check on this path) goes red instead of logging a quiet 200.
-  const statusCode = warmed === 0 && failed > 0 ? 503 : 200;
+  // A run that warmed NO schedule board is an incident, not a success — return 5xx so Vercel's
+  // built-in cron monitoring (and any uptime check on this path) goes red instead of logging a
+  // quiet 200. Gated on the schedule counters only; see the counter comment above.
+  const statusCode = scheduleWarmed === 0 && scheduleFailed > 0 ? 503 : 200;
   return res.status(statusCode).json({
     warmed,
     failed,
+    scheduleWarmed,
+    scheduleFailed,
     warmPlan,
     results,
     timestamp: new Date().toISOString()

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -1,7 +1,9 @@
+import { timingSafeEqual } from 'node:crypto';
 import type { VercelRequest, VercelResponse } from './types.js';
 import { createRateLimiter } from './_rate-limit.js';
 import { loadScheduleSnapshot, saveScheduleSnapshot, isSnapshotCandidateBetter } from './_schedule-snapshots.js';
-import { hydrateQuotaBlock, getMirroredQuotaBlockedUntil, persistQuotaBlock, resetMirroredQuotaBlock } from './_cost-state.js';
+import { hydrateQuotaBlock, getMirroredQuotaBlockedUntil, persistQuotaBlock, resetMirroredQuotaBlock, __resetAdbSpendForTests } from './_cost-state.js';
+import { UNITED_HUBS, UNITED_HUB_SET, getHubTerminal } from './_hubs.js';
 import { fetchViaAeroDataBox } from './_schedule-aerodatabox.js';
 import {
   FR24_SCHEDULE_HEADERS,
@@ -34,7 +36,7 @@ const MAX_COMPLETE_CACHE_SIZE = 128;
 const COMPLETE_CACHE_MAX_AGE = 21600000; // 6 hours
 const BATCH_DELAY = 500; // 500ms pause between parallel batches
 const STALE_GRACE = 120000; // serve stale data for up to 2min past expiry
-const TARGETED_OFFICIAL_RESCUE_HUBS = new Set(['ORD', 'DEN', 'IAH', 'EWR', 'SFO', 'IAD', 'LAX', 'NRT', 'GUM']);
+const TARGETED_OFFICIAL_RESCUE_HUBS: ReadonlySet<string> = new Set(UNITED_HUBS);
 
 // Busy hubs get more time to fetch all pages (capped at 55s for Vercel's 60s maxDuration)
 const HUB_TIMEOUT_MS: Record<string, number> = { ORD: 55000, EWR: 55000, IAH: 55000, SFO: 55000, LAX: 55000, DEN: 55000, IAD: 55000, NRT: 55000, GUM: 55000 };
@@ -44,24 +46,7 @@ const MAX_CONSECUTIVE_RATE_LIMIT_BATCHES = 2;
 const MIN_REMAINING_MS_TO_KEEP_PAGING = 8000;
 const MIN_REMAINING_MS_FOR_OFFICIAL_RESCUE = 6000;
 
-// Known United Airlines terminal assignments at each hub (used when API doesn't provide terminal data)
-const UNITED_HUB_TERMINALS: Record<string, { domestic: string; international: string }> = {
-  ORD: { domestic: '1', international: '1' },       // Terminal 1 (Concourses B & C); Express uses T2
-  DEN: { domestic: 'B', international: 'B' },       // Concourse B
-  EWR: { domestic: 'C', international: 'C' },       // Terminal C (primary); some flights use Terminal A
-  IAH: { domestic: 'C', international: 'E' },       // Terminal C (domestic), Terminal E (international)
-  SFO: { domestic: '3', international: 'G' },       // Terminal 3 (domestic), International Terminal G
-  LAX: { domestic: '7', international: '7' },       // Terminals 7 & 8
-  IAD: { domestic: 'C', international: 'D' },       // Concourse C (domestic), Concourse D (international)
-  NRT: { domestic: '1', international: '1' },       // Terminal 1
-  GUM: { domestic: '1', international: '1' },       // Single terminal
-};
-
-function getHubTerminal(iata: string, isIntl: boolean): string {
-  const hub = UNITED_HUB_TERMINALS[iata.toUpperCase()];
-  if (!hub) return '';
-  return isIntl ? hub.international : hub.domestic;
-}
+// Terminal assignments live in api/_hubs.ts (shared with _schedule-aerodatabox.ts).
 
 // Global concurrency limiter for FR24 outbound requests
 const MAX_CONCURRENT_FR24 = 6;
@@ -240,6 +225,60 @@ function shouldDisableScraperFallback(req: VercelRequest): boolean {
   const queryValue = getSingleQueryValue((req.query as Record<string, string | string[] | undefined>)?.scraperFallback).toLowerCase();
   const headerValue = getSingleQueryValue(req.headers?.['x-blueboard-scraper-fallback'] as string | string[] | undefined).toLowerCase();
   return ['0', 'false', 'off', 'no'].includes(queryValue) || ['0', 'false', 'off', 'no'].includes(headerValue);
+}
+
+function timingSafeEqualStr(a: string, b: string): boolean {
+  const ab = new TextEncoder().encode(a);
+  const bb = new TextEncoder().encode(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+/**
+ * forceRefresh=1 + the cron secret skips every cached/stale/persistent serve path and runs a full
+ * fetch. This is how the warm cron actually REFRESHES a board: without it, the handler serves the
+ * frozen snapshot back to the cron, reports "ok", and a complete board is never refetched all day
+ * (the frozen-board failure mode). Unauthorized force params are silently ignored — the request is
+ * served like any other, so probing this surface costs an attacker nothing and gains them nothing.
+ */
+function isAuthorizedForceRefresh(req: VercelRequest): boolean {
+  const wantsForce = ['1', 'true', 'yes', 'on'].includes(
+    getSingleQueryValue((req.query as Record<string, string | string[] | undefined>)?.forceRefresh).toLowerCase()
+  );
+  if (!wantsForce) return false;
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return false;
+  const auth = getSingleQueryValue(req.headers?.authorization as string | string[] | undefined);
+  return timingSafeEqualStr(auth, `Bearer ${secret}`);
+}
+
+// ── Background provider refresh gate ──
+// The degraded serve paths trigger a background refresh, but letting every user request fan that
+// refresh out to the metered provider would let traffic stampede the quota. Gate it: the provider
+// joins a background refresh only when the data being served is genuinely old (> 3h), and at most
+// once per board per hour per instance. The cross-instance ceiling is the daily unit budget in
+// _cost-state.ts. 3h keeps a today board no staler than ~3h under user traffic alone, and the
+// hourly per-key cooldown bounds worst case to 24 provider refreshes per board per day.
+const PROVIDER_REFRESH_STALE_MS = 3 * 60 * 60 * 1000;
+const PROVIDER_REFRESH_KEY_COOLDOWN_MS = 60 * 60 * 1000;
+const MAX_PROVIDER_REFRESH_KEYS = 512;
+const lastProviderRefreshAt = new Map<string, number>();
+
+export function shouldEnableProviderForBackgroundRefresh(
+  aggKey: string,
+  dataAgeMs: number,
+  allowProviderFallback: boolean,
+  nowMs = Date.now()
+): boolean {
+  if (!allowProviderFallback || !process.env.AERODATABOX_API_KEY) return false;
+  if (dataAgeMs <= PROVIDER_REFRESH_STALE_MS) return false;
+  const last = lastProviderRefreshAt.get(aggKey) || 0;
+  if (nowMs - last < PROVIDER_REFRESH_KEY_COOLDOWN_MS) return false;
+  if (lastProviderRefreshAt.size >= MAX_PROVIDER_REFRESH_KEYS) {
+    lastProviderRefreshAt.delete(lastProviderRefreshAt.keys().next().value!);
+  }
+  lastProviderRefreshAt.set(aggKey, nowMs);
+  return true;
 }
 
 async function fetchWithTimeout(url: string, deadlineMs?: number): Promise<Response> {
@@ -1155,6 +1194,7 @@ export function resetFallbackBreaker(): void {
   liveFeedCache = null;
   liveFeedInFlight = null;
   resetMirroredQuotaBlock();
+  __resetAdbSpendForTests();
 }
 
 /**
@@ -1166,6 +1206,7 @@ export function __resetScheduleCachesForTests(): void {
   lastCompleteCache.clear();
   lastCompleteByHubDir.clear();
   pendingAggs.clear();
+  lastProviderRefreshAt.clear();
 }
 
 async function tryOfficialFallback(
@@ -1567,22 +1608,31 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     // paid official API. (Audit P1: per-lambda cost guards do not bound global spend.)
     await hydrateQuotaBlock();
 
-    const { hub, dir = 'departures', timestamp, page } = req.query as Record<string, string>;
-    if (!hub || !timestamp) {
+    const { hub: hubParam, dir = 'departures', timestamp, page } = req.query as Record<string, string>;
+    if (!hubParam || !timestamp) {
       return res.status(400).json({ error: 'Missing required params: hub, timestamp' });
     }
     if (!['departures', 'arrivals'].includes(dir)) {
       return res.status(400).json({ error: 'dir must be departures or arrivals' });
     }
-    if (!/^[A-Z]{3,4}$/i.test(hub)) {
+    // Allowlist, not just a shape check: every distinct hub value mints its own cache keys across
+    // all four tiers and fires 2 metered provider calls on a miss, so an open airport parameter is
+    // an unmetered spend surface (a crawler iterating IATA codes recreates the quota outage).
+    const hub = hubParam.toUpperCase();
+    if (!/^[A-Z]{3,4}$/.test(hub) || !UNITED_HUB_SET.has(hub)) {
       return res.status(400).json({ error: 'Invalid hub code' });
     }
 
-    const ts = parseInt(timestamp, 10);
+    const tsParam = parseInt(timestamp, 10);
     const now = Math.floor(Date.now() / 1000);
-    if (isNaN(ts) || ts < now - 86400 * 7 || ts > now + 86400 * 7) {
+    if (isNaN(tsParam) || tsParam < now - 86400 * 7 || tsParam > now + 86400 * 7) {
       return res.status(400).json({ error: 'Invalid timestamp' });
     }
+    // Snap to the start of the hub-local day containing the timestamp. Board content only depends
+    // on the hub-local DAY (the provider fetch is windowed by hubLocalDate), so this is lossless —
+    // and it collapses cache-key cardinality from ~1.2M second-granularity values per hub/dir to
+    // ≤15 day keys, closing the second cache-busting spend surface.
+    const ts = getStartOfHubDay(hub, 0, new Date(tsParam * 1000));
     const isOld = (now - ts) > 86400;
     // A given day's schedule is stable, so a clean (non-partial) today board can be reused for hours.
     // Reuse it for 6h in-memory + at the edge so each metered AeroDataBox refresh (2 FIDS calls =
@@ -1626,7 +1676,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const currentAggKey = `agg:${hub}:${dir}:${ts}`;
     aggKey = currentAggKey;
 
-    const cached = cacheGet(currentAggKey);
+    // Authorized cron warms bypass every serve-from-cache path below: a complete snapshot would
+    // otherwise satisfy the warm request, report "ok", and never be refetched — freezing the board
+    // for the rest of the day while it self-reports completeness 1.0.
+    const forceRefresh = isAuthorizedForceRefresh(req);
+
+    const cached = forceRefresh ? null : cacheGet(currentAggKey);
     const hasImmediateScheduleRecovery =
       (allowScraperFallback && hasConfiguredFr24ScraperTransport()) ||
       (allowProviderFallback && !!process.env.AERODATABOX_API_KEY) ||
@@ -1637,25 +1692,29 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return res.status(200).json({ ...cached.data, cached: true });
     }
 
-    const stale = cacheGetStale(currentAggKey);
+    const stale = forceRefresh ? null : cacheGetStale(currentAggKey);
     if (stale && !stale.data.partial) {
       triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, {
         allowTargetedOfficialRescue: false,
         disableOfficialSource: !allowOfficialFallback,
-        disableProviderFallback: true,
+        disableProviderFallback: !shouldEnableProviderForBackgroundRefresh(
+          currentAggKey, Date.now() - stale.time, allowProviderFallback
+        ),
         disableScraperFallback: true,
       });
       res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
       return res.status(200).json({ ...stale.data, cached: true, stale: true });
     }
 
-    const exactLastComplete = getLastComplete(currentAggKey);
-    const fallbackComplete = exactLastComplete || getLastCompleteByHubDir(hub, dir, ts);
+    const exactLastComplete = forceRefresh ? null : getLastComplete(currentAggKey);
+    const fallbackComplete = forceRefresh ? null : (exactLastComplete || getLastCompleteByHubDir(hub, dir, ts));
     if (fallbackComplete) {
       triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, {
         allowTargetedOfficialRescue: false,
         disableOfficialSource: !allowOfficialFallback,
-        disableProviderFallback: true,
+        disableProviderFallback: !shouldEnableProviderForBackgroundRefresh(
+          currentAggKey, Date.now() - fallbackComplete.time, allowProviderFallback
+        ),
         disableScraperFallback: true,
       });
       res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
@@ -1663,7 +1722,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     let partialPersistentFallback: Awaited<ReturnType<typeof getPersistentFallback>> | null = null;
-    const persistentFallback = await getPersistentFallback(currentAggKey);
+    const persistentFallback = forceRefresh ? null : await getPersistentFallback(currentAggKey);
     if (persistentFallback) {
       const canAttemptRecoveryNow = persistentFallback.fallbackScope === 'persistent_partial' && hasImmediateScheduleRecovery;
       if (canAttemptRecoveryNow) {
@@ -1672,7 +1731,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, {
           allowTargetedOfficialRescue: allowOfficialFallback && persistentFallback.fallbackScope === 'persistent_partial',
           disableOfficialSource: !allowOfficialFallback,
-          disableProviderFallback: true,
+          disableProviderFallback: !shouldEnableProviderForBackgroundRefresh(
+            currentAggKey, Date.now() - persistentFallback.time, allowProviderFallback
+          ),
           disableScraperFallback: true,
         });
         res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
@@ -1725,7 +1786,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           return res.status(200).json(buildDegradedResponse(partialPersistentFallback, 'persistent_partial'));
         }
       }
-      setAggregateCacheHeader(res, result, cdnMaxAge, swr);
+      // The cron's force URL is its own CDN object (forceRefresh=1 is part of the query string).
+      // Never let it pin: a CDN HIT on the warm URL would silently skip the refresh next cycle.
+      // (The partial branches above set s-maxage=60, which expires long before the next warm.)
+      if (forceRefresh) {
+        res.setHeader('Cache-Control', 'no-store');
+      } else {
+        setAggregateCacheHeader(res, result, cdnMaxAge, swr);
+      }
       return res.status(200).json(result);
     } finally {
       pendingAggs.delete(currentAggKey);

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -197,7 +197,14 @@ function cacheSet(key: string, data: any, ttlMs: number): void {
   cache.set(key, { data, expires: Date.now() + ttlMs, time: Date.now() });
 }
 
-function setAggregateCacheHeader(res: VercelResponse, data: any, cdnMaxAge: number, swr: number): void {
+function setAggregateCacheHeader(res: VercelResponse, data: any, cdnMaxAge: number, swr: number, noStore = false): void {
+  // Any forceRefresh-flavored URL must never pin a CDN object — the warm URL is predictable
+  // from the public repo, and a 6h object stored on it by an UNAUTHENTICATED probe would be
+  // served back to the next hourly cron warm as a frozen-but-green board.
+  if (noStore) {
+    res.setHeader('Cache-Control', 'no-store');
+    return;
+  }
   const isPartial = data?.partial === true;
   const total = Number(data?.total || 0);
   // A degraded-but-NON-EMPTY board is still useful to show; re-validating it every 30s at the CDN
@@ -238,11 +245,14 @@ function shouldDisableScraperFallback(req: VercelRequest): boolean {
  * (the frozen-board failure mode). Unauthorized force params are silently ignored — the request is
  * served like any other, so probing this surface costs an attacker nothing and gains them nothing.
  */
-function isAuthorizedForceRefresh(req: VercelRequest): boolean {
-  const wantsForce = ['1', 'true', 'yes', 'on'].includes(
+function hasForceRefreshParam(req: VercelRequest): boolean {
+  return ['1', 'true', 'yes', 'on'].includes(
     getSingleQueryValue((req.query as Record<string, string | string[] | undefined>)?.forceRefresh).toLowerCase()
   );
-  return wantsForce && isAuthorizedCronRequest(req);
+}
+
+function isAuthorizedForceRefresh(req: VercelRequest): boolean {
+  return hasForceRefreshParam(req) && isAuthorizedCronRequest(req);
 }
 
 // ── Background provider refresh gate ──
@@ -254,7 +264,7 @@ function isAuthorizedForceRefresh(req: VercelRequest): boolean {
 // hourly per-key cooldown bounds worst case to 24 provider refreshes per board per day.
 const PROVIDER_REFRESH_STALE_MS = 3 * 60 * 60 * 1000;
 const PROVIDER_REFRESH_KEY_COOLDOWN_MS = 60 * 60 * 1000;
-const MAX_PROVIDER_REFRESH_KEYS = 512;
+const MAX_PROVIDER_REFRESH_KEYS = 512; // keyspace is ~270 (9 hubs x 2 dirs x ~15 days): eviction is a guard rail, currently unreachable
 const lastProviderRefreshAt = new Map<string, number>();
 
 export function shouldEnableProviderForBackgroundRefresh(
@@ -1680,7 +1690,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     // Authorized cron warms bypass every serve-from-cache path below: a complete snapshot would
     // otherwise satisfy the warm request, report "ok", and never be refetched — freezing the board
     // for the rest of the day while it self-reports completeness 1.0.
-    const forceRefresh = isAuthorizedForceRefresh(req);
+    const wantsForce = hasForceRefreshParam(req);
+    const forceRefresh = wantsForce && isAuthorizedCronRequest(req);
 
     const cached = forceRefresh ? null : cacheGet(currentAggKey);
     const hasImmediateScheduleRecovery =
@@ -1689,7 +1700,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       shouldAttemptLiveFeedFallback(hub, ts);
     const shouldBypassEmptyPartialCache = cached?.data?.partial === true && Number(cached?.data?.total || 0) === 0 && hasImmediateScheduleRecovery;
     if (cached && !shouldBypassEmptyPartialCache) {
-      setAggregateCacheHeader(res, cached.data, cdnMaxAge, swr);
+      setAggregateCacheHeader(res, cached.data, cdnMaxAge, swr, wantsForce);
       return res.status(200).json({ ...cached.data, cached: true });
     }
 
@@ -1749,7 +1760,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (!forceRefresh && pendingAggs.has(currentAggKey)) {
       const result = await pendingAggs.get(currentAggKey);
       if (result) {
-        setAggregateCacheHeader(res, result, cdnMaxAge, swr);
+        setAggregateCacheHeader(res, result, cdnMaxAge, swr, wantsForce);
         return res.status(200).json({ ...result, cached: true });
       }
     }
@@ -1795,11 +1806,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       // The cron's force URL is its own CDN object (forceRefresh=1 is part of the query string).
       // Never let it pin: a CDN HIT on the warm URL would silently skip the refresh next cycle.
       // (The partial branches above set s-maxage=60, which expires long before the next warm.)
-      if (forceRefresh) {
-        res.setHeader('Cache-Control', 'no-store');
-      } else {
-        setAggregateCacheHeader(res, result, cdnMaxAge, swr);
-      }
+      setAggregateCacheHeader(res, result, cdnMaxAge, swr, wantsForce);
       return res.status(200).json(result);
     } finally {
       // Compare-and-delete (see triggerBackgroundRefresh): never evict an entry that a

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -1,9 +1,9 @@
-import { timingSafeEqual } from 'node:crypto';
 import type { VercelRequest, VercelResponse } from './types.js';
 import { createRateLimiter } from './_rate-limit.js';
 import { loadScheduleSnapshot, saveScheduleSnapshot, isSnapshotCandidateBetter } from './_schedule-snapshots.js';
 import { hydrateQuotaBlock, getMirroredQuotaBlockedUntil, persistQuotaBlock, resetMirroredQuotaBlock, __resetAdbSpendForTests } from './_cost-state.js';
-import { UNITED_HUBS, UNITED_HUB_SET, getHubTerminal } from './_hubs.js';
+import { UNITED_HUB_SET, getHubTerminal } from './_hubs.js';
+import { isAuthorizedCronRequest } from './_cron-auth.js';
 import { fetchViaAeroDataBox } from './_schedule-aerodatabox.js';
 import {
   FR24_SCHEDULE_HEADERS,
@@ -40,7 +40,7 @@ const MAX_COMPLETE_CACHE_SIZE = 128;
 const COMPLETE_CACHE_MAX_AGE = 21600000; // 6 hours
 const BATCH_DELAY = 500; // 500ms pause between parallel batches
 const STALE_GRACE = 120000; // serve stale data for up to 2min past expiry
-const TARGETED_OFFICIAL_RESCUE_HUBS: ReadonlySet<string> = new Set(UNITED_HUBS);
+const TARGETED_OFFICIAL_RESCUE_HUBS: ReadonlySet<string> = UNITED_HUB_SET; // same 9 hubs; alias keeps the call site self-describing
 
 // Busy hubs get more time to fetch all pages (capped at 55s for Vercel's 60s maxDuration)
 const HUB_TIMEOUT_MS: Record<string, number> = { ORD: 55000, EWR: 55000, IAH: 55000, SFO: 55000, LAX: 55000, DEN: 55000, IAD: 55000, NRT: 55000, GUM: 55000 };
@@ -231,13 +231,6 @@ function shouldDisableScraperFallback(req: VercelRequest): boolean {
   return ['0', 'false', 'off', 'no'].includes(queryValue) || ['0', 'false', 'off', 'no'].includes(headerValue);
 }
 
-function timingSafeEqualStr(a: string, b: string): boolean {
-  const ab = new TextEncoder().encode(a);
-  const bb = new TextEncoder().encode(b);
-  if (ab.length !== bb.length) return false;
-  return timingSafeEqual(ab, bb);
-}
-
 /**
  * forceRefresh=1 + the cron secret skips every cached/stale/persistent serve path and runs a full
  * fetch. This is how the warm cron actually REFRESHES a board: without it, the handler serves the
@@ -249,11 +242,7 @@ function isAuthorizedForceRefresh(req: VercelRequest): boolean {
   const wantsForce = ['1', 'true', 'yes', 'on'].includes(
     getSingleQueryValue((req.query as Record<string, string | string[] | undefined>)?.forceRefresh).toLowerCase()
   );
-  if (!wantsForce) return false;
-  const secret = process.env.CRON_SECRET;
-  if (!secret) return false;
-  const auth = getSingleQueryValue(req.headers?.authorization as string | string[] | undefined);
-  return timingSafeEqualStr(auth, `Bearer ${secret}`);
+  return wantsForce && isAuthorizedCronRequest(req);
 }
 
 // ── Background provider refresh gate ──
@@ -274,6 +263,9 @@ export function shouldEnableProviderForBackgroundRefresh(
   allowProviderFallback: boolean,
   nowMs = Date.now()
 ): boolean {
+  // NOTE: this is an ACQUIRE, not a pure check — a true return consumes the key's hourly
+  // cooldown slot. Callers must only invoke it when the refresh will actually be dispatched
+  // (i.e. no in-flight refresh for the key), or the slot is burned for nothing.
   if (!allowProviderFallback || !process.env.AERODATABOX_API_KEY) return false;
   if (dataAgeMs <= PROVIDER_REFRESH_STALE_MS) return false;
   const last = lastProviderRefreshAt.get(aggKey) || 0;
@@ -1162,7 +1154,9 @@ function triggerBackgroundRefresh(
   }).catch(e => {
     console.error(`Background refresh failed for ${refreshHub} [${aggKey}]:`, e.message);
   }).finally(() => {
-    pendingAggs.delete(aggKey);
+    // Compare-and-delete: a forced warm may have overwritten this entry with its own fetch —
+    // an unconditional delete would evict that still-in-flight fetch and break dedupe for it.
+    if (pendingAggs.get(aggKey) === promise) pendingAggs.delete(aggKey);
   });
   pendingAggs.set(aggKey, promise);
   enqueueBackgroundTask(promise);
@@ -1626,7 +1620,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     // all four tiers and fires 2 metered provider calls on a miss, so an open airport parameter is
     // an unmetered spend surface (a crawler iterating IATA codes recreates the quota outage).
     const hub = hubParam.toUpperCase();
-    if (!/^[A-Z]{3,4}$/.test(hub) || !UNITED_HUB_SET.has(hub)) {
+    if (!UNITED_HUB_SET.has(hub)) {
       return res.status(400).json({ error: 'Invalid hub code' });
     }
 
@@ -1704,7 +1698,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, {
         allowTargetedOfficialRescue: false,
         disableOfficialSource: !allowOfficialFallback,
-        disableProviderFallback: !shouldEnableProviderForBackgroundRefresh(
+        disableProviderFallback: pendingAggs.has(currentAggKey) || !shouldEnableProviderForBackgroundRefresh(
           currentAggKey, Date.now() - stale.time, allowProviderFallback
         ),
         disableScraperFallback: true,
@@ -1719,7 +1713,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, {
         allowTargetedOfficialRescue: false,
         disableOfficialSource: !allowOfficialFallback,
-        disableProviderFallback: !shouldEnableProviderForBackgroundRefresh(
+        disableProviderFallback: pendingAggs.has(currentAggKey) || !shouldEnableProviderForBackgroundRefresh(
           currentAggKey, Date.now() - fallbackComplete.time, allowProviderFallback
         ),
         disableScraperFallback: true,
@@ -1738,7 +1732,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, {
           allowTargetedOfficialRescue: allowOfficialFallback && persistentFallback.fallbackScope === 'persistent_partial',
           disableOfficialSource: !allowOfficialFallback,
-          disableProviderFallback: !shouldEnableProviderForBackgroundRefresh(
+          disableProviderFallback: pendingAggs.has(currentAggKey) || !shouldEnableProviderForBackgroundRefresh(
             currentAggKey, Date.now() - persistentFallback.time, allowProviderFallback
           ),
           disableScraperFallback: true,
@@ -1808,7 +1802,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       }
       return res.status(200).json(result);
     } finally {
-      pendingAggs.delete(currentAggKey);
+      // Compare-and-delete (see triggerBackgroundRefresh): never evict an entry that a
+      // concurrent forced warm registered over this one.
+      if (pendingAggs.get(currentAggKey) === aggPromise) pendingAggs.delete(currentAggKey);
     }
   } catch (e) {
     console.error('Schedule API error:', e);

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -22,6 +22,10 @@ type ScheduleFetchOptions = {
   disableOfficialSource?: boolean;
   disableProviderFallback?: boolean;
   disableScraperFallback?: boolean;
+  // Authorized cron warms only: their provider spend is already hard-bounded by the warm ring
+  // (~288 units/day), so the organic daily budget must not starve the one path that keeps boards
+  // from freezing. Never set from user input.
+  providerBudgetExempt?: boolean;
 };
 
 // In-memory LRU cache for FR24 schedule data
@@ -1228,13 +1232,13 @@ async function tryOfficialFallback(
 }
 
 async function tryScheduleProviderFallback(
-  logHub: string, dir: string, ts: number, effectiveDeadline: number
+  logHub: string, dir: string, ts: number, effectiveDeadline: number, budgetExempt = false
 ): Promise<any | null> {
   if (!process.env.AERODATABOX_API_KEY) return null;
   try {
     const remaining = Math.max(0, effectiveDeadline - Date.now() - 1000);
     if (remaining < 2000) return null;
-    const result = await fetchViaAeroDataBox(logHub, dir, ts, Math.min(remaining, 12000));
+    const result = await fetchViaAeroDataBox(logHub, dir, ts, Math.min(remaining, 12000), { bypassDailyBudget: budgetExempt });
     if (result && result.total > 0) {
       result.meta = { ...(result.meta as any), fallbackFrom: 'scraping' };
       return result;
@@ -1251,10 +1255,11 @@ async function tryScheduleRescue(
   ts: number,
   effectiveDeadline: number,
   allowProviderFallback: boolean,
-  allowOfficialFallback: boolean
+  allowOfficialFallback: boolean,
+  budgetExempt = false
 ): Promise<any | null> {
   if (allowProviderFallback) {
-    const providerFallback = await tryScheduleProviderFallback(logHub, dir, ts, effectiveDeadline);
+    const providerFallback = await tryScheduleProviderFallback(logHub, dir, ts, effectiveDeadline, budgetExempt);
     if (providerFallback) return providerFallback;
   }
   if (allowOfficialFallback) {
@@ -1310,7 +1315,9 @@ async function fetchAllPages(
     if (allowProviderFallback && process.env.AERODATABOX_API_KEY) {
       try {
         const providerTimeout = Math.min(Math.floor((effectiveDeadline - Date.now()) * 0.7), 30000);
-        const providerResult = await fetchViaAeroDataBox(logHub, dir, ts, providerTimeout);
+        const providerResult = await fetchViaAeroDataBox(logHub, dir, ts, providerTimeout, {
+          bypassDailyBudget: !!options.providerBudgetExempt,
+        });
         if (providerResult && providerResult.total > 0) {
           // Overlay the free live feed for active flights only when the provider board is partial.
           return await maybeAugmentWithLiveFeedFallback(providerResult, logHub, dir, ts, effectiveDeadline);
@@ -1323,7 +1330,7 @@ async function fetchAllPages(
     // disableOfficialSource (officialFallback=0, e.g. cron) keeps official off so background warming
     // never burns FR24 credits; it then degrades to the free live feed.
     const fallback = await tryScheduleRescue(
-      logHub, dir, ts, effectiveDeadline, false, !options.disableOfficialSource
+      logHub, dir, ts, effectiveDeadline, false, !options.disableOfficialSource, !!options.providerBudgetExempt
     );
     if (fallback) return fallback;
   }
@@ -1384,7 +1391,7 @@ async function fetchAllPages(
   if (!firstPage || firstPage._rateLimited) {
     if (srcPriority === 'scrape' && (allowProviderFallback || allowTargetedOfficialRescue)) {
       console.log(`Scraping failed on first page for ${logHub} ${dir}, trying schedule fallback`);
-      const fallback = await tryScheduleRescue(logHub, dir, ts, effectiveDeadline, allowProviderFallback, allowTargetedOfficialRescue);
+      const fallback = await tryScheduleRescue(logHub, dir, ts, effectiveDeadline, allowProviderFallback, allowTargetedOfficialRescue, !!options.providerBudgetExempt);
       if (fallback) return fallback;
     }
     const failedResult = { flights: [], total: 0, totalFetched: 0, pagesScanned: 0, totalPages: 1, cached: false, partial: true, hub: logHub, dir,
@@ -1570,14 +1577,14 @@ async function fetchAllPages(
   ) {
     attemptedOfficialRescue = true;
     console.log(`Scraping hit repeated FR24 rate limits for ${logHub} ${dir}, trying schedule fallback`);
-    const fallback = await tryScheduleRescue(logHub, dir, ts, effectiveDeadline, allowProviderFallback, allowTargetedOfficialRescue);
+    const fallback = await tryScheduleRescue(logHub, dir, ts, effectiveDeadline, allowProviderFallback, allowTargetedOfficialRescue, !!options.providerBudgetExempt);
     if (fallback) return fallback;
   }
 
   // Scrape-first fallback: if scraping failed completely, try official API (with circuit breaker)
   if (!attemptedOfficialRescue && srcPriority === 'scrape' && (allowProviderFallback || allowTargetedOfficialRescue) && scrapeResult.total === 0 && scrapeResult.partial) {
     console.log(`Scraping returned 0 flights for ${logHub} ${dir}, trying schedule fallback`);
-    const fallback = await tryScheduleRescue(logHub, dir, ts, effectiveDeadline, allowProviderFallback, allowTargetedOfficialRescue);
+    const fallback = await tryScheduleRescue(logHub, dir, ts, effectiveDeadline, allowProviderFallback, allowTargetedOfficialRescue, !!options.providerBudgetExempt);
     if (fallback) return fallback;
   }
 
@@ -1741,7 +1748,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       }
     }
 
-    if (pendingAggs.has(currentAggKey)) {
+    // A force warm must run its own fetch: the in-flight refresh it would join is often
+    // provider-disabled (a user-triggered background refresh below the age gate), which would
+    // silently swallow the cron's refetch for this hour. Concurrent user requests still
+    // piggyback on the forced fetch via the pendingAggs entry it registers below.
+    if (!forceRefresh && pendingAggs.has(currentAggKey)) {
       const result = await pendingAggs.get(currentAggKey);
       if (result) {
         setAggregateCacheHeader(res, result, cdnMaxAge, swr);
@@ -1754,6 +1765,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       disableOfficialSource: !allowOfficialFallback,
       disableProviderFallback: !allowProviderFallback,
       disableScraperFallback: !allowScraperFallback,
+      providerBudgetExempt: forceRefresh,
     }).then(async result => {
       cacheSet(currentAggKey, result, result.partial ? 60000 : ttl);
       saveComplete(currentAggKey, result);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "packageManager": "bun@1.3.14",
   "engines": {
     "node": "24.x"

--- a/sql/009_provider_spend.sql
+++ b/sql/009_provider_spend.sql
@@ -4,23 +4,32 @@
 -- spend under Vercel fan-out. api/_cost-state.ts mirrors this counter and hard-stops provider
 -- calls once the day's units cross AERODATABOX_DAILY_UNIT_BUDGET (default 400). The code degrades
 -- gracefully to per-instance in-memory accounting if this migration is not applied — but the
--- cross-instance ceiling only exists once it is. Apply via the Supabase SQL editor or
--- `supabase db push`.
+-- cross-instance ceiling only exists once it is.
 --
--- Written only by the service-role key (server-side); the anon client has no access.
+-- APPLY MANUALLY via the Supabase dashboard SQL editor (this repo keeps migrations in sql/, not
+-- supabase/migrations/ — `supabase db push` would apply nothing while looking successful).
+-- Verify after applying:  SELECT increment_adb_units(CURRENT_DATE, 0);
+--
+-- Written only by the service-role key (server-side); client keys have no access.
 
-CREATE TABLE schedule_provider_spend (
+CREATE TABLE IF NOT EXISTS schedule_provider_spend (
   day DATE PRIMARY KEY,
-  units INTEGER NOT NULL DEFAULT 0,
+  units INTEGER NOT NULL DEFAULT 0 CHECK (units >= 0),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
--- Server-internal. Enable RLS with no policies so only the service-role key (which bypasses RLS)
--- can read/write; the anon key is denied entirely.
+-- Server-internal. Lock at BOTH layers: RLS with no policies (service-role bypasses), and
+-- explicit privilege revokes so a future debugging session that adds a permissive policy or
+-- disables RLS does not silently hand client keys write access to the spend counter.
 ALTER TABLE schedule_provider_spend ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE schedule_provider_spend FROM PUBLIC;
+REVOKE ALL ON TABLE schedule_provider_spend FROM anon;
+REVOKE ALL ON TABLE schedule_provider_spend FROM authenticated;
 
 -- Atomic increment: read-modify-write from N concurrent lambdas would undercount; the upsert
 -- keeps the counter accurate and returns the new global total so callers can adopt it.
+-- GREATEST(p_units, 0): this is SECURITY DEFINER, so it enforces its own invariants instead of
+-- trusting callers — a negative p_units would silently reopen the spend budget.
 CREATE OR REPLACE FUNCTION increment_adb_units(p_day DATE, p_units INTEGER)
 RETURNS INTEGER
 LANGUAGE SQL
@@ -28,14 +37,18 @@ SECURITY DEFINER
 SET search_path = public
 AS $$
   INSERT INTO schedule_provider_spend (day, units, updated_at)
-  VALUES (p_day, p_units, NOW())
+  VALUES (p_day, GREATEST(p_units, 0), NOW())
   ON CONFLICT (day) DO UPDATE
-    SET units = schedule_provider_spend.units + EXCLUDED.units,
+    SET units = schedule_provider_spend.units + GREATEST(EXCLUDED.units, 0),
         updated_at = NOW()
   RETURNING units;
 $$;
 
--- Only the server may call the increment; deny the public/anon roles.
+-- Only the server may call the increment. Supabase default privileges GRANT EXECUTE on new
+-- public-schema functions to anon AND authenticated — revoking only PUBLIC/anon would leave any
+-- self-minted authenticated JWT able to brick (huge p_units) or uncap (negative p_units, pre-
+-- GREATEST) the budget via POST /rest/v1/rpc/increment_adb_units.
 REVOKE EXECUTE ON FUNCTION increment_adb_units(DATE, INTEGER) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION increment_adb_units(DATE, INTEGER) FROM anon;
+REVOKE EXECUTE ON FUNCTION increment_adb_units(DATE, INTEGER) FROM authenticated;
 GRANT EXECUTE ON FUNCTION increment_adb_units(DATE, INTEGER) TO service_role;

--- a/sql/009_provider_spend.sql
+++ b/sql/009_provider_spend.sql
@@ -1,0 +1,41 @@
+-- Cross-instance daily spend counter for the metered AeroDataBox provider.
+--
+-- The per-IP rate limiter is in-memory per lambda instance, so it cannot bound global provider
+-- spend under Vercel fan-out. api/_cost-state.ts mirrors this counter and hard-stops provider
+-- calls once the day's units cross AERODATABOX_DAILY_UNIT_BUDGET (default 400). The code degrades
+-- gracefully to per-instance in-memory accounting if this migration is not applied — but the
+-- cross-instance ceiling only exists once it is. Apply via the Supabase SQL editor or
+-- `supabase db push`.
+--
+-- Written only by the service-role key (server-side); the anon client has no access.
+
+CREATE TABLE schedule_provider_spend (
+  day DATE PRIMARY KEY,
+  units INTEGER NOT NULL DEFAULT 0,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Server-internal. Enable RLS with no policies so only the service-role key (which bypasses RLS)
+-- can read/write; the anon key is denied entirely.
+ALTER TABLE schedule_provider_spend ENABLE ROW LEVEL SECURITY;
+
+-- Atomic increment: read-modify-write from N concurrent lambdas would undercount; the upsert
+-- keeps the counter accurate and returns the new global total so callers can adopt it.
+CREATE OR REPLACE FUNCTION increment_adb_units(p_day DATE, p_units INTEGER)
+RETURNS INTEGER
+LANGUAGE SQL
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  INSERT INTO schedule_provider_spend (day, units, updated_at)
+  VALUES (p_day, p_units, NOW())
+  ON CONFLICT (day) DO UPDATE
+    SET units = schedule_provider_spend.units + EXCLUDED.units,
+        updated_at = NOW()
+  RETURNING units;
+$$;
+
+-- Only the server may call the increment; deny the public/anon roles.
+REVOKE EXECUTE ON FUNCTION increment_adb_units(DATE, INTEGER) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION increment_adb_units(DATE, INTEGER) FROM anon;
+GRANT EXECUTE ON FUNCTION increment_adb_units(DATE, INTEGER) TO service_role;

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -4035,9 +4035,10 @@ async function loadScheduleData() {
     if (result.partial || result.degraded) {
       const meta = result.meta || {};
       let msg = '';
-      if (result.degraded && meta.dataAge) {
+      if (result.degraded && meta.dataAge != null) {
         // Humanized + honest: "1775m ago while refreshing" hid a 30h-frozen board behind a
-        // reassuring teal banner promising a refresh that never came.
+        // reassuring teal banner promising a refresh that never came. != null (not truthiness):
+        // a just-written snapshot has dataAge 0, which must still render with age context.
         const age = formatDataAge(meta.dataAge);
         msg = result.partial
           ? `Showing cached partial data from ${age} ago.`
@@ -4066,7 +4067,7 @@ async function loadScheduleData() {
         : '';
       // Escalate the banner with data age: teal reads as "all good", which is a lie for a board
       // that is hours old. 1-6h → amber caution; 6h+ (past a full cache lifetime) → red (--ua-red).
-      const ageSeverity = result.degraded && meta.dataAge ? dataAgeSeverity(meta.dataAge) : null;
+      const ageSeverity = result.degraded && meta.dataAge != null ? dataAgeSeverity(meta.dataAge) : null;
       const palette = ageSeverity === 'stale'
         ? { bg: 'rgba(239,68,68,.12)', border: 'rgba(239,68,68,.3)', text: 'var(--ua-red)', icon: '⚠️' }
         : ageSeverity === 'aging'

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -8,6 +8,7 @@ import { bucketInstallsByMonth } from '../lib/starlink-utils.js';
 import { getFlightPopupMetrics } from '../lib/flight-popup.js';
 import { getScheduleFleetFamily } from '../lib/schedule-filters.js';
 import { getStartOfHubDay, getHubDayLabel } from '../lib/hubTz.js';
+import { formatDataAge, dataAgeSeverity } from '../lib/data-age.js';
 
 injectSpeedInsights();
 
@@ -4035,10 +4036,12 @@ async function loadScheduleData() {
       const meta = result.meta || {};
       let msg = '';
       if (result.degraded && meta.dataAge) {
-        const ageMin = Math.round(meta.dataAge / 60);
+        // Humanized + honest: "1775m ago while refreshing" hid a 30h-frozen board behind a
+        // reassuring teal banner promising a refresh that never came.
+        const age = formatDataAge(meta.dataAge);
         msg = result.partial
-          ? `Showing cached partial data from ${ageMin}m ago while refreshing.`
-          : `Showing cached complete data from ${ageMin}m ago while refreshing.`;
+          ? `Showing cached partial data from ${age} ago.`
+          : `Showing cached complete data from ${age} ago.`;
       } else if (meta.liveFeedFallbackAdded) {
         msg = `Added ${meta.liveFeedFallbackAdded} live active flight(s) while the full schedule feed recovers.`;
       } else if (meta.partialReason === 'live_feed_fallback') {
@@ -4061,10 +4064,20 @@ async function loadScheduleData() {
             ? ` ${Math.round(meta.completeness * 100)}% loaded.`
             : ''
         : '';
-      const bgColor = result.degraded ? 'rgba(78,205,196,.12)' : 'rgba(234,179,8,.12)';
-      const borderColor = result.degraded ? 'rgba(78,205,196,.3)' : 'rgba(234,179,8,.3)';
-      const textColor = result.degraded ? '#4ecdc4' : '#eab308';
-      const icon = result.degraded ? '⏳' : '⚠️';
+      // Escalate the banner with data age: teal reads as "all good", which is a lie for a board
+      // that is hours old. 1-6h → amber caution; 6h+ (past a full cache lifetime) → red (--ua-red).
+      const ageSeverity = result.degraded && meta.dataAge ? dataAgeSeverity(meta.dataAge) : null;
+      const palette = ageSeverity === 'stale'
+        ? { bg: 'rgba(239,68,68,.12)', border: 'rgba(239,68,68,.3)', text: '#ef4444', icon: '⚠️' }
+        : ageSeverity === 'aging'
+          ? { bg: 'rgba(234,179,8,.12)', border: 'rgba(234,179,8,.3)', text: '#eab308', icon: '⏳' }
+          : result.degraded
+            ? { bg: 'rgba(78,205,196,.12)', border: 'rgba(78,205,196,.3)', text: '#4ecdc4', icon: '⏳' }
+            : { bg: 'rgba(234,179,8,.12)', border: 'rgba(234,179,8,.3)', text: '#eab308', icon: '⚠️' };
+      const bgColor = palette.bg;
+      const borderColor = palette.border;
+      const textColor = palette.text;
+      const icon = palette.icon;
       loadEl.innerHTML = `<div style="padding:4px 12px;background:${bgColor};border:1px solid ${borderColor};border-radius:4px;font-size:11px;color:${textColor};margin:0">${icon} ${msg}${pct} <button data-action="schedule-retry-cached" style="background:none;border:none;color:var(--ua-accent);cursor:pointer;font-family:var(--font-ui);font-size:11px;text-decoration:underline">↻ Retry</button></div>`;
       loadEl.style.display = 'block';
     } else {

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -4068,7 +4068,7 @@ async function loadScheduleData() {
       // that is hours old. 1-6h → amber caution; 6h+ (past a full cache lifetime) → red (--ua-red).
       const ageSeverity = result.degraded && meta.dataAge ? dataAgeSeverity(meta.dataAge) : null;
       const palette = ageSeverity === 'stale'
-        ? { bg: 'rgba(239,68,68,.12)', border: 'rgba(239,68,68,.3)', text: '#ef4444', icon: '⚠️' }
+        ? { bg: 'rgba(239,68,68,.12)', border: 'rgba(239,68,68,.3)', text: 'var(--ua-red)', icon: '⚠️' }
         : ageSeverity === 'aging'
           ? { bg: 'rgba(234,179,8,.12)', border: 'rgba(234,179,8,.3)', text: '#eab308', icon: '⏳' }
           : result.degraded

--- a/src/lib/data-age.js
+++ b/src/lib/data-age.js
@@ -1,0 +1,27 @@
+// ═══ DATA AGE FORMATTING ═══
+// Humanizes the schedule API's meta.dataAge (seconds) for degraded-board banners.
+// A frozen board once showed "cached data from 1775m ago" — a wall of minutes that
+// reads as a glitch instead of the warning it is. Hours/days keep the age legible.
+
+/**
+ * Human-readable age: "just now", "42m", "5h", "3d".
+ */
+export function formatDataAge(seconds) {
+  const s = Math.max(0, Number(seconds) || 0);
+  if (s < 90) return 'just now';
+  if (s < 5400) return `${Math.round(s / 60)}m`;
+  if (s < 172800) return `${Math.round(s / 3600)}h`;
+  return `${Math.floor(s / 86400)}d`;
+}
+
+/**
+ * Severity bucket for styling: 'recent' (<1h), 'aging' (1-6h), 'stale' (6h+).
+ * 6h matches the server's clean-board TTL — anything older than one full cache
+ * lifetime is no longer "a slightly old board", it is the frozen-board failure mode.
+ */
+export function dataAgeSeverity(seconds) {
+  const s = Math.max(0, Number(seconds) || 0);
+  if (s < 3600) return 'recent';
+  if (s < 21600) return 'aging';
+  return 'stale';
+}

--- a/tests/cost-state-adb.test.js
+++ b/tests/cost-state-adb.test.js
@@ -110,10 +110,9 @@ describe('AeroDataBox daily unit budget (cost-state)', () => {
     expect(getAdbUnitsToday()).toBe(4);
   });
 
-  it('falls back to the 400-unit default when AERODATABOX_DAILY_UNIT_BUDGET is invalid', async () => {
-    // '0' or '-5' honoured literally would brick the provider (always exhausted); 'abc' honoured
-    // as NaN would disable the budget entirely. All three must fall back to the 400 default.
-    for (const bad of ['0', '-5', 'abc']) {
+  it('falls back to the 400-unit default when AERODATABOX_DAILY_UNIT_BUDGET is garbage', async () => {
+    // '-5' honoured literally or 'abc' honoured as NaN would disable the budget entirely.
+    for (const bad of ['-5', 'abc']) {
       __resetAdbSpendForTests();
       process.env.AERODATABOX_DAILY_UNIT_BUDGET = bad;
       await recordAdbUnits(399);
@@ -121,6 +120,13 @@ describe('AeroDataBox daily unit budget (cost-state)', () => {
       await recordAdbUnits(1);
       expect(isAdbBudgetExhausted(), `budget=${bad} at 400 units`).toBe(true);
     }
+  });
+
+  it('honours an explicit budget of 0 as a kill switch — this is metered money', async () => {
+    // An operator setting 0 during a billing incident means STOP ALL SPEND; silently substituting
+    // the 400 default would be fail-open with the owner's wallet.
+    process.env.AERODATABOX_DAILY_UNIT_BUDGET = '0';
+    expect(isAdbBudgetExhausted()).toBe(true);
   });
 
   it('rate-limits hydrate reads to one per 10s: a second hydrate inside the TTL is a no-op', async () => {

--- a/tests/cost-state-adb.test.js
+++ b/tests/cost-state-adb.test.js
@@ -88,6 +88,59 @@ describe('AeroDataBox daily unit budget (cost-state)', () => {
     await hydrateAdbSpend();
     expect(getAdbUnitsToday()).toBe(6);
   });
+
+  it('ignores zero, negative, and NaN unit amounts', async () => {
+    await recordAdbUnits(0);
+    await recordAdbUnits(-5);
+    await recordAdbUnits(NaN);
+    await recordAdbUnits('abc');
+    expect(getAdbUnitsToday()).toBe(0);
+    // Garbage input must not poison the counter for subsequent valid spend either.
+    await recordAdbUnits(2);
+    await recordAdbUnits(-1);
+    expect(getAdbUnitsToday()).toBe(2);
+  });
+
+  it('keeps the locally recorded count when the increment RPC returns an error object', async () => {
+    const rpc = vi.fn(async () => ({ data: null, error: { message: 'x' } }));
+    supabaseMocks.getSupabaseAdmin.mockResolvedValue({ rpc });
+    await recordAdbUnits(4);
+    expect(rpc).toHaveBeenCalled();
+    // The errored RPC's data (null → Number(null) = 0) must never replace local spend.
+    expect(getAdbUnitsToday()).toBe(4);
+  });
+
+  it('falls back to the 400-unit default when AERODATABOX_DAILY_UNIT_BUDGET is invalid', async () => {
+    // '0' or '-5' honoured literally would brick the provider (always exhausted); 'abc' honoured
+    // as NaN would disable the budget entirely. All three must fall back to the 400 default.
+    for (const bad of ['0', '-5', 'abc']) {
+      __resetAdbSpendForTests();
+      process.env.AERODATABOX_DAILY_UNIT_BUDGET = bad;
+      await recordAdbUnits(399);
+      expect(isAdbBudgetExhausted(), `budget=${bad} at 399 units`).toBe(false);
+      await recordAdbUnits(1);
+      expect(isAdbBudgetExhausted(), `budget=${bad} at 400 units`).toBe(true);
+    }
+  });
+
+  it('rate-limits hydrate reads to one per 10s: a second hydrate inside the TTL is a no-op', async () => {
+    let storedUnits = 120;
+    supabaseMocks.getSupabaseAdmin.mockResolvedValue({
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            limit: async () => ({ data: [{ units: storedUnits }], error: null }),
+          }),
+        }),
+      }),
+    });
+    await hydrateAdbSpend();
+    expect(getAdbUnitsToday()).toBe(120);
+    // The store moves, but a hydrate within the 10s TTL must NOT re-read it (hot-path read guard).
+    storedUnits = 500;
+    await hydrateAdbSpend();
+    expect(getAdbUnitsToday()).toBe(120);
+  });
 });
 
 describe('fetchViaAeroDataBox budget enforcement', () => {
@@ -141,6 +194,37 @@ describe('fetchViaAeroDataBox budget enforcement', () => {
     // Spend is still accounted (2 windows × 2 units) so the organic budget sees the true total.
     expect(getAdbUnitsToday()).toBe(404);
   });
+
+  it('bills 2 units per ATTEMPT: 429 retries are metered too (2×429 then 200 per window = 12 units)', { timeout: 20000 }, async () => {
+    // The provider bills every request FIRED, not every success — fetchWindow records spend before
+    // reading the outcome, so a 429 storm drains the budget fast (the intended circuit). Two 429s
+    // then a 200 per window = 3 attempts × 2 units × 2 windows = 12 units for the board, not 4.
+    const attemptsByWindow = new Map();
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const key = String(url);
+      const attempt = (attemptsByWindow.get(key) || 0) + 1;
+      attemptsByWindow.set(key, attempt);
+      if (attempt <= 2) {
+        return {
+          ok: false,
+          status: 429,
+          // fetchWindow honours a positive retry-after (seconds) as the backoff; a tiny fractional
+          // value (10ms) keeps the retries fast. ('0' would NOT be honoured and would fall back to
+          // the slow 1500ms×attempt default.)
+          headers: { get: (name) => (String(name).toLowerCase() === 'retry-after' ? '0.01' : null) },
+          text: async () => '',
+        };
+      }
+      return { ok: true, status: 200, headers: { get: () => null }, json: async () => ({ departures: [] }) };
+    });
+
+    const result = await fetchViaAeroDataBox('ORD', 'departures', Math.floor(Date.now() / 1000), 60000);
+    expect(result).not.toBeNull();
+    // Both windows recovered on attempt 3, so the board itself is complete...
+    expect(result.partial).toBe(false);
+    // ...but every attempt was billed.
+    expect(getAdbUnitsToday()).toBe(12);
+  });
 });
 
 describe('ADB spend day-rollover races', () => {
@@ -165,6 +249,25 @@ describe('ADB spend day-rollover races', () => {
     supabaseMocks.getSupabaseAdmin.mockResolvedValue({ rpc });
     await recordAdbUnits(4);
     // New day starts clean — adopting 350 would block the provider for the whole new day.
+    expect(getAdbUnitsToday()).toBe(0);
+  });
+
+  it('discards a hydrate read that lands after UTC midnight instead of adopting yesterday into the new day', async () => {
+    vi.useFakeTimers({ now: new Date('2026-06-10T23:59:50Z'), toFake: ['Date'] });
+    supabaseMocks.getSupabaseAdmin.mockResolvedValue({
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            limit: async () => {
+              // The read round-trip crosses UTC midnight: 350 is YESTERDAY's running total.
+              vi.setSystemTime(new Date('2026-06-11T00:00:10Z'));
+              return { data: [{ units: 350 }], error: null };
+            },
+          }),
+        }),
+      }),
+    });
+    await hydrateAdbSpend();
     expect(getAdbUnitsToday()).toBe(0);
   });
 });

--- a/tests/cost-state-adb.test.js
+++ b/tests/cost-state-adb.test.js
@@ -173,7 +173,10 @@ describe('fetchViaAeroDataBox budget enforcement', () => {
 
   it('returns null without calling upstream once the daily budget is exhausted', async () => {
     await recordAdbUnits(400);
-    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    // Stubbed (not call-through): a gate regression must fail fast, not via live provider calls.
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false, status: 500, headers: { get: () => null }, json: async () => ({}), text: async () => '',
+    });
     const result = await fetchViaAeroDataBox('ORD', 'departures', Math.floor(Date.now() / 1000), 5000);
     expect(result).toBeNull();
     expect(fetchSpy).not.toHaveBeenCalled();
@@ -193,6 +196,18 @@ describe('fetchViaAeroDataBox budget enforcement', () => {
     expect(result).not.toBeNull();
     // Spend is still accounted (2 windows × 2 units) so the organic budget sees the true total.
     expect(getAdbUnitsToday()).toBe(404);
+  });
+
+  it('bypassDailyBudget still respects the 3x disaster ceiling — a leaked cron secret cannot spend unboundedly', async () => {
+    await recordAdbUnits(1200); // 3 × the 400 default
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false, status: 500, headers: { get: () => null }, json: async () => ({}), text: async () => '',
+    });
+    const result = await fetchViaAeroDataBox('ORD', 'departures', Math.floor(Date.now() / 1000), 5000, {
+      bypassDailyBudget: true,
+    });
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it('bills 2 units per ATTEMPT: 429 retries are metered too (2×429 then 200 per window = 12 units)', { timeout: 20000 }, async () => {

--- a/tests/cost-state-adb.test.js
+++ b/tests/cost-state-adb.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const supabaseMocks = vi.hoisted(() => ({
+  getSupabaseAdmin: vi.fn(async () => null),
+  loadScheduleSnapshot: vi.fn(async () => null),
+  saveScheduleSnapshot: vi.fn(async () => {}),
+}));
+
+vi.mock(process.cwd() + '/api/_schedule-snapshots.ts', () => supabaseMocks);
+
+import {
+  recordAdbUnits,
+  getAdbUnitsToday,
+  isAdbBudgetExhausted,
+  hydrateAdbSpend,
+  __resetAdbSpendForTests,
+} from '../api/_cost-state.js';
+import { fetchViaAeroDataBox } from '../api/_schedule-aerodatabox.js';
+
+describe('AeroDataBox daily unit budget (cost-state)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    __resetAdbSpendForTests();
+    supabaseMocks.getSupabaseAdmin.mockReset();
+    supabaseMocks.getSupabaseAdmin.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete process.env.AERODATABOX_API_KEY;
+    delete process.env.AERODATABOX_DAILY_UNIT_BUDGET;
+    delete process.env.AERODATABOX_INTER_WINDOW_DELAY_MS;
+    __resetAdbSpendForTests();
+  });
+
+  it('accumulates recorded units in memory and trips the breaker at the budget', async () => {
+    expect(getAdbUnitsToday()).toBe(0);
+    expect(isAdbBudgetExhausted()).toBe(false);
+    await recordAdbUnits(2);
+    await recordAdbUnits(2);
+    expect(getAdbUnitsToday()).toBe(4);
+    process.env.AERODATABOX_DAILY_UNIT_BUDGET = '4';
+    expect(isAdbBudgetExhausted()).toBe(true);
+  });
+
+  it('defaults the daily budget to 400 units', async () => {
+    await recordAdbUnits(399);
+    expect(isAdbBudgetExhausted()).toBe(false);
+    await recordAdbUnits(1);
+    expect(isAdbBudgetExhausted()).toBe(true);
+  });
+
+  it('resets the counter on UTC day rollover', async () => {
+    vi.useFakeTimers({ now: new Date('2026-06-10T23:50:00Z'), toFake: ['Date'] });
+    await recordAdbUnits(10);
+    expect(getAdbUnitsToday()).toBe(10);
+    vi.setSystemTime(new Date('2026-06-11T00:10:00Z'));
+    expect(getAdbUnitsToday()).toBe(0);
+    expect(isAdbBudgetExhausted()).toBe(false);
+  });
+
+  it('persists spend through the increment RPC and adopts the cross-instance total', async () => {
+    const rpc = vi.fn(async () => ({ data: 50, error: null }));
+    supabaseMocks.getSupabaseAdmin.mockResolvedValue({ rpc });
+    await recordAdbUnits(4);
+    expect(rpc).toHaveBeenCalledWith('increment_adb_units', expect.objectContaining({ p_units: 4 }));
+    // RPC returned the global running total (other instances spent too) — adopt the higher value.
+    expect(getAdbUnitsToday()).toBe(50);
+  });
+
+  it('hydrates a higher cross-instance count from supabase', async () => {
+    supabaseMocks.getSupabaseAdmin.mockResolvedValue({
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            limit: async () => ({ data: [{ units: 120 }], error: null }),
+          }),
+        }),
+      }),
+    });
+    await hydrateAdbSpend();
+    expect(getAdbUnitsToday()).toBe(120);
+  });
+
+  it('degrades to in-memory accounting when supabase is unavailable', async () => {
+    supabaseMocks.getSupabaseAdmin.mockRejectedValue(new Error('down'));
+    await recordAdbUnits(6);
+    await hydrateAdbSpend();
+    expect(getAdbUnitsToday()).toBe(6);
+  });
+});
+
+describe('fetchViaAeroDataBox budget enforcement', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    __resetAdbSpendForTests();
+    supabaseMocks.getSupabaseAdmin.mockReset();
+    supabaseMocks.getSupabaseAdmin.mockResolvedValue(null);
+    process.env.AERODATABOX_API_KEY = 'test-key';
+    process.env.AERODATABOX_INTER_WINDOW_DELAY_MS = '0';
+  });
+
+  afterEach(() => {
+    delete process.env.AERODATABOX_API_KEY;
+    delete process.env.AERODATABOX_DAILY_UNIT_BUDGET;
+    delete process.env.AERODATABOX_INTER_WINDOW_DELAY_MS;
+    __resetAdbSpendForTests();
+  });
+
+  it('records 2 units per window request (4 per board fetch)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => ({ departures: [] }),
+    });
+    await fetchViaAeroDataBox('ORD', 'departures', Math.floor(Date.now() / 1000), 5000);
+    expect(getAdbUnitsToday()).toBe(4);
+  });
+
+  it('returns null without calling upstream once the daily budget is exhausted', async () => {
+    await recordAdbUnits(400);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const result = await fetchViaAeroDataBox('ORD', 'departures', Math.floor(Date.now() / 1000), 5000);
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/cost-state-adb.test.js
+++ b/tests/cost-state-adb.test.js
@@ -210,6 +210,28 @@ describe('fetchViaAeroDataBox budget enforcement', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it('the 3x ceiling sees CROSS-INSTANCE spend — a cold lambda (in-memory 0) must still refuse', async () => {
+    // Without hydrating, every freshly-spawned instance reads 0 and the "absolute ceiling"
+    // protecting the privileged force path is per-instance theater.
+    supabaseMocks.getSupabaseAdmin.mockResolvedValue({
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            limit: async () => ({ data: [{ units: 1200 }], error: null }),
+          }),
+        }),
+      }),
+    });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false, status: 500, headers: { get: () => null }, json: async () => ({}), text: async () => '',
+    });
+    const result = await fetchViaAeroDataBox('ORD', 'departures', Math.floor(Date.now() / 1000), 5000, {
+      bypassDailyBudget: true,
+    });
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it('bills 2 units per ATTEMPT: 429 retries are metered too (2×429 then 200 per window = 12 units)', { timeout: 20000 }, async () => {
     // The provider bills every request FIRED, not every success — fetchWindow records spend before
     // reading the outcome, so a 429 storm drains the budget fast (the intended circuit). Two 429s

--- a/tests/cost-state-adb.test.js
+++ b/tests/cost-state-adb.test.js
@@ -125,4 +125,46 @@ describe('fetchViaAeroDataBox budget enforcement', () => {
     expect(result).toBeNull();
     expect(fetchSpy).not.toHaveBeenCalled();
   });
+
+  it('bypassDailyBudget (authorized cron warms, ring-bounded at ~288/day) skips the gate but still records spend', async () => {
+    await recordAdbUnits(400);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => ({ departures: [] }),
+    });
+    const result = await fetchViaAeroDataBox('ORD', 'departures', Math.floor(Date.now() / 1000), 5000, {
+      bypassDailyBudget: true,
+    });
+    expect(result).not.toBeNull();
+    // Spend is still accounted (2 windows × 2 units) so the organic budget sees the true total.
+    expect(getAdbUnitsToday()).toBe(404);
+  });
+});
+
+describe('ADB spend day-rollover races', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    __resetAdbSpendForTests();
+    supabaseMocks.getSupabaseAdmin.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    __resetAdbSpendForTests();
+  });
+
+  it('discards an RPC total that lands after UTC midnight instead of adopting yesterday into the new day', async () => {
+    vi.useFakeTimers({ now: new Date('2026-06-10T23:59:50Z'), toFake: ['Date'] });
+    const rpc = vi.fn(async () => {
+      // The RPC round-trip crosses UTC midnight: its return is YESTERDAY's running total.
+      vi.setSystemTime(new Date('2026-06-11T00:00:10Z'));
+      return { data: 350, error: null };
+    });
+    supabaseMocks.getSupabaseAdmin.mockResolvedValue({ rpc });
+    await recordAdbUnits(4);
+    // New day starts clean — adopting 350 would block the provider for the whole new day.
+    expect(getAdbUnitsToday()).toBe(0);
+  });
 });

--- a/tests/data-age.test.js
+++ b/tests/data-age.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { formatDataAge, dataAgeSeverity } from '../src/lib/data-age.js';
+
+describe('formatDataAge', () => {
+  it('reports very recent ages as "just now"', () => {
+    expect(formatDataAge(0)).toBe('just now');
+    expect(formatDataAge(45)).toBe('just now');
+    expect(formatDataAge(89)).toBe('just now');
+  });
+
+  it('reports minute-scale ages in minutes', () => {
+    expect(formatDataAge(300)).toBe('5m');
+    expect(formatDataAge(1775 * 60)).not.toMatch(/^\d{3,}m$/); // never "1775m"
+  });
+
+  it('reports hour-scale ages in hours, not a wall of minutes', () => {
+    expect(formatDataAge(7200)).toBe('2h');
+    expect(formatDataAge(106495)).toBe('30h'); // the live frozen-board age
+  });
+
+  it('reports multi-day ages in days', () => {
+    expect(formatDataAge(86400 * 3)).toBe('3d');
+  });
+});
+
+describe('dataAgeSeverity', () => {
+  it('treats sub-hour data as recent', () => {
+    expect(dataAgeSeverity(300)).toBe('recent');
+    expect(dataAgeSeverity(3599)).toBe('recent');
+  });
+
+  it('treats 1-6h data as aging', () => {
+    expect(dataAgeSeverity(3600)).toBe('aging');
+    expect(dataAgeSeverity(21599)).toBe('aging');
+  });
+
+  it('treats 6h+ data as stale', () => {
+    expect(dataAgeSeverity(21600)).toBe('stale');
+    expect(dataAgeSeverity(106495)).toBe('stale');
+  });
+});

--- a/tests/data-age.test.js
+++ b/tests/data-age.test.js
@@ -21,6 +21,14 @@ describe('formatDataAge', () => {
   it('reports multi-day ages in days', () => {
     expect(formatDataAge(86400 * 3)).toBe('3d');
   });
+
+  it('clamps negative, NaN, and missing ages to "just now"', () => {
+    // meta.dataAge can be garbage (clock skew → negative, absent field → undefined/NaN);
+    // the banner must never render "-5m" or "NaNh".
+    expect(formatDataAge(-5)).toBe('just now');
+    expect(formatDataAge(NaN)).toBe('just now');
+    expect(formatDataAge(undefined)).toBe('just now');
+  });
 });
 
 describe('dataAgeSeverity', () => {
@@ -37,5 +45,12 @@ describe('dataAgeSeverity', () => {
   it('treats 6h+ data as stale', () => {
     expect(dataAgeSeverity(21600)).toBe('stale');
     expect(dataAgeSeverity(106495)).toBe('stale');
+  });
+
+  it('clamps negative, NaN, and missing ages to "recent"', () => {
+    // Same clamping as formatDataAge: garbage age must not style the board as a stale incident.
+    expect(dataAgeSeverity(-5)).toBe('recent');
+    expect(dataAgeSeverity(NaN)).toBe('recent');
+    expect(dataAgeSeverity(undefined)).toBe('recent');
   });
 });

--- a/tests/hubs.test.js
+++ b/tests/hubs.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { UNITED_HUBS, UNITED_HUB_SET, UNITED_HUB_TERMINALS, getHubTerminal } from '../api/_hubs.js';
+
+describe('_hubs shared constants', () => {
+  it('lists exactly the 9 United hubs', () => {
+    expect([...UNITED_HUBS].sort()).toEqual(['DEN', 'EWR', 'GUM', 'IAD', 'IAH', 'LAX', 'NRT', 'ORD', 'SFO']);
+  });
+
+  it('UNITED_HUB_SET matches the hub list and excludes non-hubs', () => {
+    for (const hub of UNITED_HUBS) expect(UNITED_HUB_SET.has(hub)).toBe(true);
+    expect(UNITED_HUB_SET.has('JFK')).toBe(false);
+    expect(UNITED_HUB_SET.has('ATL')).toBe(false);
+  });
+
+  it('has a terminal assignment for every hub', () => {
+    for (const hub of UNITED_HUBS) {
+      expect(UNITED_HUB_TERMINALS[hub]).toBeDefined();
+      expect(UNITED_HUB_TERMINALS[hub].domestic).toBeTruthy();
+      expect(UNITED_HUB_TERMINALS[hub].international).toBeTruthy();
+    }
+  });
+
+  it('getHubTerminal resolves domestic vs international and is case-insensitive', () => {
+    expect(getHubTerminal('IAH', false)).toBe('C');
+    expect(getHubTerminal('IAH', true)).toBe('E');
+    expect(getHubTerminal('iah', true)).toBe('E');
+    expect(getHubTerminal('JFK', false)).toBe('');
+  });
+});

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -1956,6 +1956,51 @@ describe('forceRefresh (cron-authorized cache bypass)', () => {
     expect(res.headers['Cache-Control']).toBe('no-store'); // cron URL must never pin a CDN object
   });
 
+  it('bypasses the persistent-snapshot serve tier (the live 30h-frozen incident path)', async () => {
+    // The frozen-board incident: with cold in-memory caches, a 30h-old COMPLETE persisted snapshot
+    // satisfies every organic request via the persistent serve tier. If the cron's authorized force
+    // request also got that snapshot back, the board would never be refetched — the exact freeze
+    // the warm cron exists to break. The force must skip the snapshot and run a real fetch.
+    scheduleSnapshotMocks.loadScheduleSnapshot.mockResolvedValue({
+      data: { flights: [], total: 412, partial: false, meta: { completeness: 1 } },
+      refreshedAt: Date.now() - 30 * 3600 * 1000,
+    });
+    mockEmptyScrape();
+
+    const res = createRes();
+    await handler({
+      method: 'GET',
+      headers: { authorization: `Bearer ${SECRET}` },
+      query: { ...baseQuery(), forceRefresh: '1' },
+    }, res);
+
+    expect(res.statusCode).toBe(200);
+    // NOT the degraded snapshot: a snapshot serve is stale+degraded with meta.fallbackScope set
+    // and total 412; the forced refetch is a fresh (empty-scrape) board.
+    expect(res.body.cached).toBe(false);
+    expect(res.body.stale).toBeFalsy();
+    expect(res.body.degraded).toBeFalsy();
+    expect(res.body.meta.fallbackScope).toBeUndefined();
+    expect(res.body.total).toBe(0);
+  });
+
+  it("accepts the documented force value variants ('true', 'yes') like '1'", async () => {
+    await prime();
+    for (const value of ['true', 'yes']) {
+      mockEmptyScrape();
+      const res = createRes();
+      await handler({
+        method: 'GET',
+        headers: { authorization: `Bearer ${SECRET}` },
+        query: { ...baseQuery(), forceRefresh: value },
+      }, res);
+      expect(res.statusCode, `forceRefresh=${value}`).toBe(200);
+      // Each variant must trigger a refetch (cached:false), not serve the fresh cache entry the
+      // previous request just repopulated.
+      expect(res.body.cached, `forceRefresh=${value}`).toBe(false);
+    }
+  });
+
   it('ignores forceRefresh with a wrong secret', async () => {
     await prime();
     const res = createRes();

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -15,6 +15,7 @@ vi.mock('@vercel/functions', () => vercelFunctionMocks);
 import handler, { shouldAttemptOfficialFallback, recordFallback, resetFallbackBreaker, __resetScheduleCachesForTests, shouldEnableProviderForBackgroundRefresh } from '../api/schedule.js';
 import { getStartOfDayForHub } from '../api/irops.js';
 import { __resetRateLimitersForTests } from '../api/_rate-limit.js';
+import { recordAdbUnits } from '../api/_cost-state.js';
 import { getStartOfHubDay } from '../src/lib/hubTz.js';
 
 function formatForFR24Test(date) {
@@ -1976,6 +1977,32 @@ describe('forceRefresh (cron-authorized cache bypass)', () => {
       query: { ...baseQuery(), forceRefresh: '1' },
     }, res);
     expect(res.body.cached).toBe(true);
+  });
+
+  it('keeps the provider available to authorized force warms after the organic budget is exhausted', async () => {
+    process.env.AERODATABOX_API_KEY = 'test-key';
+    process.env.SCHEDULE_SOURCE_PRIORITY = 'provider';
+    await recordAdbUnits(400);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => ({ departures: [], result: { response: { airport: { pluginData: {} } } } }),
+    });
+
+    // Organic cache-miss traffic: the budget gate blocks the provider (spend cap working).
+    await handler({ method: 'GET', headers: { origin: 'http://localhost:3000' }, query: baseQuery() }, createRes());
+    expect(fetchSpy.mock.calls.filter(([url]) => /aerodatabox|aedbx/i.test(String(url))).length).toBe(0);
+
+    // The cron's authorized force warm is ring-bounded (~288 units/day) upstream — the organic
+    // cap must not starve the very refresh path that keeps boards from freezing.
+    fetchSpy.mockClear();
+    await handler({
+      method: 'GET',
+      headers: { authorization: `Bearer ${SECRET}` },
+      query: { ...baseQuery(), forceRefresh: '1' },
+    }, createRes());
+    expect(fetchSpy.mock.calls.filter(([url]) => /aerodatabox|aedbx/i.test(String(url))).length).toBeGreaterThan(0);
   });
 });
 

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -2016,6 +2016,22 @@ describe('forceRefresh (cron-authorized cache bypass)', () => {
     expect(res.body.cached).toBe(true);
   });
 
+  it('responds no-store to ANY forceRefresh request, even unauthorized', async () => {
+    // The warm URL is fully predictable from the public repo. If an unauthenticated GET of it
+    // produced a normal cacheable response, the CDN would pin a 6h object on the cron's own URL
+    // key and the next hourly warm could be served that frozen object as a green "ok" —
+    // unauthenticated re-freezing of the exact boards the force path exists to refresh.
+    await prime();
+    const res = createRes();
+    await handler({
+      method: 'GET',
+      headers: { authorization: 'Bearer wrong-secret' },
+      query: { ...baseQuery(), forceRefresh: '1' },
+    }, res);
+    expect(res.body.cached).toBe(true); // still served normally (no oracle)...
+    expect(res.headers['Cache-Control']).toBe('no-store'); // ...but never CDN-pinned
+  });
+
   it('ignores forceRefresh when CRON_SECRET is not configured', async () => {
     await prime();
     delete process.env.CRON_SECRET;

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -12,9 +12,10 @@ const vercelFunctionMocks = vi.hoisted(() => ({
 vi.mock(process.cwd() + '/api/_schedule-snapshots.ts', () => scheduleSnapshotMocks);
 vi.mock('@vercel/functions', () => vercelFunctionMocks);
 
-import handler, { shouldAttemptOfficialFallback, recordFallback, resetFallbackBreaker, __resetScheduleCachesForTests } from '../api/schedule.js';
+import handler, { shouldAttemptOfficialFallback, recordFallback, resetFallbackBreaker, __resetScheduleCachesForTests, shouldEnableProviderForBackgroundRefresh } from '../api/schedule.js';
 import { getStartOfDayForHub } from '../api/irops.js';
 import { __resetRateLimitersForTests } from '../api/_rate-limit.js';
+import { getStartOfHubDay } from '../src/lib/hubTz.js';
 
 function formatForFR24Test(date) {
   return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
@@ -651,7 +652,9 @@ describe('schedule API', () => {
       };
     });
 
-    const ts1 = Math.floor(Date.now() / 1000) - 42000;
+    // Two days back: snapped day is never "today", keeping the today-only live-feed rescue out of
+    // this test's fetch counts regardless of wall-clock time.
+    const ts1 = Math.floor(Date.now() / 1000) - 172800;
     const req1 = {
       method: 'GET',
       headers: { origin: 'http://localhost:3000' },
@@ -1225,7 +1228,9 @@ describe('schedule API', () => {
       };
     });
 
-    const ts = Math.floor(Date.now() / 1000) - 28800;
+    // Two days back: a snapped "today" board would legitimately attempt the live-feed rescue for
+    // an empty result, which is out of scope for this test.
+    const ts = Math.floor(Date.now() / 1000) - 172800;
     const req = {
       method: 'GET',
       headers: { origin: 'http://localhost:3000' },
@@ -1323,7 +1328,10 @@ describe('schedule API', () => {
   });
 
   it('returns persisted exact snapshot on cold start while refreshing in the background', async () => {
-    const ts = Math.floor(Date.now() / 1000) - 46800;
+    // Two days back: the snapped day is never "today", so the empty-board live-feed rescue
+    // (a today-only path) cannot add clock-dependent fetches to this test.
+    const ts = Math.floor(Date.now() / 1000) - 172800;
+    const tsSnapped = getStartOfHubDay('ORD', 0, new Date(ts * 1000));
     scheduleSnapshotMocks.loadScheduleSnapshot.mockResolvedValue({
       data: {
         flights: [{
@@ -1374,7 +1382,7 @@ describe('schedule API', () => {
     expect(res.body.total).toBe(1);
     expect(res.body.degraded).toBe(true);
     expect(res.body.meta.fallbackScope).toBe('persistent');
-    expect(scheduleSnapshotMocks.loadScheduleSnapshot).toHaveBeenCalledWith(`agg:ORD:departures:${ts}`);
+    expect(scheduleSnapshotMocks.loadScheduleSnapshot).toHaveBeenCalledWith(`agg:ORD:departures:${tsSnapped}`);
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(vercelFunctionMocks.waitUntil).toHaveBeenCalledTimes(1);
   });
@@ -1469,6 +1477,8 @@ describe('schedule API', () => {
     });
 
     const ts = Math.floor(Date.now() / 1000) - 50400;
+    // The handler snaps any intra-day timestamp to the hub-local day start before keying.
+    const tsSnapped = getStartOfHubDay('EWR', 0, new Date(ts * 1000));
     const req = {
       method: 'GET',
       headers: { origin: 'http://localhost:3000' },
@@ -1481,10 +1491,10 @@ describe('schedule API', () => {
     expect(res.statusCode).toBe(200);
     expect(res.body.partial).toBe(false);
     expect(scheduleSnapshotMocks.saveScheduleSnapshot).toHaveBeenCalledWith(expect.objectContaining({
-      cacheKey: `agg:EWR:departures:${ts}`,
+      cacheKey: `agg:EWR:departures:${tsSnapped}`,
       hub: 'EWR',
       dir: 'departures',
-      ts,
+      ts: tsSnapped,
       data: expect.objectContaining({
         partial: false,
         total: 1
@@ -1832,5 +1842,219 @@ describe('schedule API', () => {
     for (const call of fetchSpy.mock.calls) {
       expect(String(call[0])).not.toContain('fr24api.flightradar24.com');
     }
+  });
+});
+
+// Empty-but-valid FR24 scrape payload: the no-env default path completes with a total-0 complete
+// board, which is enough to populate the in-memory agg cache for cache-key assertions.
+function mockEmptyScrape() {
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    json: async () => ({ result: { response: { airport: { pluginData: {} } } } }),
+  });
+}
+
+function resetScheduleTestState() {
+  vi.restoreAllMocks();
+  __resetRateLimitersForTests();
+  __resetScheduleCachesForTests();
+  process.env.AERODATABOX_INTER_WINDOW_DELAY_MS = '0';
+  scheduleSnapshotMocks.loadScheduleSnapshot.mockReset();
+  scheduleSnapshotMocks.saveScheduleSnapshot.mockReset();
+  scheduleSnapshotMocks.loadScheduleSnapshot.mockResolvedValue(null);
+  scheduleSnapshotMocks.saveScheduleSnapshot.mockResolvedValue(undefined);
+  vercelFunctionMocks.waitUntil.mockReset();
+}
+
+function cleanupScheduleTestEnv() {
+  delete process.env.FR24_API_TOKEN;
+  delete process.env.AERODATABOX_API_KEY;
+  delete process.env.AERODATABOX_BASE_URL;
+  delete process.env.AERODATABOX_INTER_WINDOW_DELAY_MS;
+  delete process.env.SCHEDULE_SOURCE_PRIORITY;
+  delete process.env.CRON_SECRET;
+  resetFallbackBreaker();
+}
+
+describe('hub allowlist + timestamp snapping (quota-burn surface)', () => {
+  beforeEach(resetScheduleTestState);
+  afterEach(cleanupScheduleTestEnv);
+
+  it('rejects non-United-hub codes with 400 before any upstream call', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    for (const hub of ['JFK', 'ATL', 'LHR', 'ZZZ']) {
+      const res = createRes();
+      await handler({
+        method: 'GET',
+        headers: { origin: 'http://localhost:3000' },
+        query: { hub, dir: 'departures', timestamp: String(Math.floor(Date.now() / 1000)) },
+      }, res);
+      expect(res.statusCode, hub).toBe(400);
+    }
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('serves lowercase hub + intra-day timestamp from the same cache entry as the canonical request', async () => {
+    mockEmptyScrape();
+    const dayStart = getStartOfHubDay('ORD', 0);
+
+    const res1 = createRes();
+    await handler({
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'ORD', dir: 'departures', timestamp: String(dayStart) },
+    }, res1);
+    expect(res1.statusCode).toBe(200);
+    expect(res1.body.cached).toBe(false);
+
+    // 'ord' two hours into the same hub-local day must hit the SAME board, not mint a new
+    // cache key (every distinct key = 2 paid provider calls once the provider path is on).
+    const res2 = createRes();
+    await handler({
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'ord', dir: 'departures', timestamp: String(dayStart + 7200) },
+    }, res2);
+    expect(res2.statusCode).toBe(200);
+    expect(res2.body.cached).toBe(true);
+  });
+});
+
+describe('forceRefresh (cron-authorized cache bypass)', () => {
+  const SECRET = 'test-cron-secret-1234';
+
+  beforeEach(() => {
+    resetScheduleTestState();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(cleanupScheduleTestEnv);
+
+  function baseQuery() {
+    return { hub: 'ORD', dir: 'departures', timestamp: String(getStartOfHubDay('ORD', 0)) };
+  }
+
+  async function prime() {
+    mockEmptyScrape();
+    const res = createRes();
+    await handler({ method: 'GET', headers: { origin: 'http://localhost:3000' }, query: baseQuery() }, res);
+    expect(res.body.cached).toBe(false);
+  }
+
+  it('bypasses the fresh cache and responds no-store when authorized with CRON_SECRET', async () => {
+    await prime();
+    const res = createRes();
+    await handler({
+      method: 'GET',
+      headers: { authorization: `Bearer ${SECRET}` },
+      query: { ...baseQuery(), forceRefresh: '1' },
+    }, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.cached).toBe(false);                  // refetched, not served frozen
+    expect(res.headers['Cache-Control']).toBe('no-store'); // cron URL must never pin a CDN object
+  });
+
+  it('ignores forceRefresh with a wrong secret', async () => {
+    await prime();
+    const res = createRes();
+    await handler({
+      method: 'GET',
+      headers: { authorization: 'Bearer wrong-secret' },
+      query: { ...baseQuery(), forceRefresh: '1' },
+    }, res);
+    expect(res.body.cached).toBe(true);
+  });
+
+  it('ignores forceRefresh when CRON_SECRET is not configured', async () => {
+    await prime();
+    delete process.env.CRON_SECRET;
+    const res = createRes();
+    await handler({
+      method: 'GET',
+      headers: { authorization: 'Bearer anything' },
+      query: { ...baseQuery(), forceRefresh: '1' },
+    }, res);
+    expect(res.body.cached).toBe(true);
+  });
+});
+
+describe('background provider refresh age gate', () => {
+  beforeEach(resetScheduleTestState);
+  afterEach(cleanupScheduleTestEnv);
+
+  it('stays off without a provider key, fresh data, or provider fallback disabled', () => {
+    delete process.env.AERODATABOX_API_KEY;
+    expect(shouldEnableProviderForBackgroundRefresh('agg:ORD:departures:1', 30 * 3600 * 1000, true)).toBe(false);
+    process.env.AERODATABOX_API_KEY = 'test-key';
+    expect(shouldEnableProviderForBackgroundRefresh('agg:ORD:departures:1', 1 * 3600 * 1000, true)).toBe(false);
+    expect(shouldEnableProviderForBackgroundRefresh('agg:ORD:departures:1', 30 * 3600 * 1000, false)).toBe(false);
+  });
+
+  it('allows one provider refresh per agg key per hour once data is older than 3h', () => {
+    process.env.AERODATABOX_API_KEY = 'test-key';
+    expect(shouldEnableProviderForBackgroundRefresh('agg:ORD:departures:2', 4 * 3600 * 1000, true)).toBe(true);
+    // Same key again immediately: cooldown holds (user traffic must not stampede the quota).
+    expect(shouldEnableProviderForBackgroundRefresh('agg:ORD:departures:2', 4 * 3600 * 1000, true)).toBe(false);
+    // A different board is independent.
+    expect(shouldEnableProviderForBackgroundRefresh('agg:DEN:departures:2', 4 * 3600 * 1000, true)).toBe(true);
+  });
+
+  it('enables the provider on background refresh of a 30h-old persistent snapshot', async () => {
+    process.env.AERODATABOX_API_KEY = 'test-key';
+    process.env.SCHEDULE_SOURCE_PRIORITY = 'provider';
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => ({ departures: [], result: { response: { airport: { pluginData: {} } } } }),
+    });
+    scheduleSnapshotMocks.loadScheduleSnapshot.mockResolvedValue({
+      data: { flights: [], total: 412, partial: false, meta: { completeness: 1 } },
+      refreshedAt: Date.now() - 30 * 3600 * 1000,
+    });
+
+    const res = createRes();
+    await handler({
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'ORD', dir: 'departures', timestamp: String(getStartOfHubDay('ORD', 0)) },
+    }, res);
+    expect(res.body.stale).toBe(true);
+    expect(res.body.meta.fallbackScope).toBe('persistent');
+
+    // The background refresh (captured by waitUntil) must hit the paid provider: a 30h-old board
+    // is exactly the frozen state the refresh exists to fix.
+    expect(vercelFunctionMocks.waitUntil).toHaveBeenCalled();
+    await Promise.all(vercelFunctionMocks.waitUntil.mock.calls.map(c => c[0]));
+    const aeroCalls = fetchSpy.mock.calls.filter(([url]) => /aerodatabox|aedbx/i.test(String(url)));
+    expect(aeroCalls.length).toBeGreaterThan(0);
+  });
+
+  it('keeps the provider off on background refresh of a young snapshot', async () => {
+    process.env.AERODATABOX_API_KEY = 'test-key';
+    process.env.SCHEDULE_SOURCE_PRIORITY = 'provider';
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => ({ departures: [], result: { response: { airport: { pluginData: {} } } } }),
+    });
+    scheduleSnapshotMocks.loadScheduleSnapshot.mockResolvedValue({
+      data: { flights: [], total: 412, partial: false, meta: { completeness: 1 } },
+      refreshedAt: Date.now() - 10 * 60 * 1000,
+    });
+
+    const res = createRes();
+    await handler({
+      method: 'GET',
+      headers: { origin: 'http://localhost:3000' },
+      query: { hub: 'ORD', dir: 'departures', timestamp: String(getStartOfHubDay('ORD', 0)) },
+    }, res);
+    expect(res.body.stale).toBe(true);
+
+    await Promise.all(vercelFunctionMocks.waitUntil.mock.calls.map(c => c[0]));
+    const aeroCalls = fetchSpy.mock.calls.filter(([url]) => /aerodatabox|aedbx/i.test(String(url)));
+    expect(aeroCalls.length).toBe(0);
   });
 });

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -1884,7 +1884,11 @@ describe('hub allowlist + timestamp snapping (quota-burn surface)', () => {
   afterEach(cleanupScheduleTestEnv);
 
   it('rejects non-United-hub codes with 400 before any upstream call', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    // Stubbed (not call-through): on regression the handler would otherwise fire real FR24
+    // requests with 45s+ timeouts before the not-called assertion fails.
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false, status: 500, headers: { get: () => null }, json: async () => ({}), text: async () => '',
+    });
     for (const hub of ['JFK', 'ATL', 'LHR', 'ZZZ']) {
       const res = createRes();
       await handler({

--- a/tests/warm-config.test.js
+++ b/tests/warm-config.test.js
@@ -13,4 +13,11 @@ describe('vercel.json warm-schedules cron config', () => {
     expect(cron, 'warm-schedules cron entry missing from vercel.json').toBeTruthy();
     expect(cron.schedule).toBe('0 * * * *');
   });
+
+  it('SLOT_MS in warm-schedules.ts matches the hourly cron (the other side of the lockstep)', () => {
+    // Without this, changing SLOT_MS back to 2h while vercel.json stays hourly would pass the
+    // test above and silently double-stride the warm ring in production.
+    const src = readFileSync(new URL('../api/cron/warm-schedules.ts', import.meta.url), 'utf8');
+    expect(src).toMatch(/const SLOT_MS = 60 \* 60 \* 1000/);
+  });
 });

--- a/tests/warm-config.test.js
+++ b/tests/warm-config.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('vercel.json warm-schedules cron config', () => {
+  it("fires hourly ('0 * * * *'), in lockstep with SLOT_MS in api/cron/warm-schedules.ts", () => {
+    // Documented footgun: buildWarmPlan strides the warm ring once per SLOT_MS (hard-coded to
+    // 60 min in api/cron/warm-schedules.ts). The cron interval in vercel.json MUST match it.
+    // If the cron schedule changes without SLOT_MS (or vice versa), the ring is either skipped
+    // (slots fire but the stride doesn't advance — windows never get warmed) or strided multiple
+    // steps per fire (windows silently skipped while quota is still burned). Update both together.
+    const config = JSON.parse(readFileSync(new URL('../vercel.json', import.meta.url), 'utf8'));
+    const cron = (config.crons || []).find((c) => c.path === '/api/cron/warm-schedules');
+    expect(cron, 'warm-schedules cron entry missing from vercel.json').toBeTruthy();
+    expect(cron.schedule).toBe('0 * * * *');
+  });
+});

--- a/tests/warm-schedules.test.js
+++ b/tests/warm-schedules.test.js
@@ -1,10 +1,13 @@
-import { describe, it, expect } from 'vitest';
-import { buildScheduleWarmUrl, buildWarmPlan } from '../api/cron/warm-schedules.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import handler, { buildScheduleWarmUrl, buildWarmPlan } from '../api/cron/warm-schedules.js';
+import { getStartOfHubDay } from '../src/lib/hubTz.js';
 
 describe('warm-schedules buildWarmPlan', () => {
   const HUBS = ['ORD', 'DEN', 'IAH', 'EWR', 'SFO', 'IAD', 'LAX', 'NRT', 'GUM'];
-  const TOTAL_TASKS = 9 * 4; // 9 hubs × 4 window tasks (today+tomorrow × 2 dirs); yesterday is on-demand
-  const SLOT_MS = 2 * 60 * 60 * 1000; // must match the cron interval / SLOT_MS in warm-schedules.ts
+  const UNIQUE_WINDOWS = 9 * 4;       // 9 hubs × (today+tomorrow) × 2 dirs; yesterday is on-demand
+  const TODAY_ROUNDS = 3;             // each today window is warmed 3×/day (~every 8h)
+  const RING_SIZE = 9 * 2 * TODAY_ROUNDS + 9 * 2; // 54 today slots + 18 tomorrow slots = 72
+  const SLOT_MS = 60 * 60 * 1000;     // must match the cron interval / SLOT_MS in warm-schedules.ts (hourly)
 
   it('returns an array of warm tasks', () => {
     const plan = buildWarmPlan();
@@ -15,7 +18,7 @@ describe('warm-schedules buildWarmPlan', () => {
   it('each task has required fields and never warms yesterday', () => {
     // Sweep a full rotation so we assert across every window the plan can emit, not just one slot.
     const start = new Date('2026-04-03T00:00:00Z').getTime();
-    for (let i = 0; i < TOTAL_TASKS + 4; i++) {
+    for (let i = 0; i < RING_SIZE + 4; i++) {
       const plan = buildWarmPlan(start + i * SLOT_MS);
       for (const task of plan) {
         expect(HUBS).toContain(task.hub);
@@ -26,49 +29,57 @@ describe('warm-schedules buildWarmPlan', () => {
     }
   });
 
-  it('returns different tasks for different 2-hour slots', () => {
+  it('returns different tasks for different hourly slots', () => {
     const t1 = new Date('2026-04-03T00:00:00Z').getTime();
-    const t2 = new Date('2026-04-03T02:00:00Z').getTime();
-
-    const plan1 = buildWarmPlan(t1);
-    const plan2 = buildWarmPlan(t2);
-
-    // Adjacent cron fires (2h apart) should advance to a different starting position
-    const keys1 = plan1.map(t => `${t.hub}-${t.dir}-${t.label}`);
-    const keys2 = plan2.map(t => `${t.hub}-${t.dir}-${t.label}`);
+    const t2 = new Date('2026-04-03T01:00:00Z').getTime();
+    const keys1 = buildWarmPlan(t1).map(t => `${t.hub}-${t.dir}-${t.label}`);
+    const keys2 = buildWarmPlan(t2).map(t => `${t.hub}-${t.dir}-${t.label}`);
     expect(keys1).not.toEqual(keys2);
   });
 
   it('returns consistent results for the same timestamp', () => {
     const t = new Date('2026-04-03T12:00:00Z').getTime();
-    const plan1 = buildWarmPlan(t);
-    const plan2 = buildWarmPlan(t);
-    expect(plan1).toEqual(plan2);
+    expect(buildWarmPlan(t)).toEqual(buildWarmPlan(t));
   });
 
-  it('cycles through all tasks over enough cron intervals with no gaps', () => {
-    const allKeys = new Set();
-    const start = new Date('2026-04-03T00:00:00Z').getTime();
+  it('limits plan size to WARM_TASKS_PER_RUN (default 3)', () => {
+    // 3 tasks × 24 hourly fires = 72 slots/day = one full ring: today boards 3×/day, tomorrow 1×/day,
+    // ≈ 72 fresh boards × 4 units = 288 AeroDataBox units/day — the metered-plan budget.
+    expect(buildWarmPlan().length).toBe(3);
+  });
 
-    // Run enough 2h cron fires to cover all windows (sequential stride => full coverage)
-    for (let i = 0; i < TOTAL_TASKS + 4; i++) {
-      const plan = buildWarmPlan(start + i * SLOT_MS);
-      for (const task of plan) {
-        allKeys.add(`${task.hub}-${task.dir}-${task.label}`);
+  it('covers every window over a day, warming today 3× and tomorrow 1×', () => {
+    const counts = new Map();
+    const start = new Date('2026-04-03T00:00:00Z').getTime();
+    // 24 hourly fires × 3 tasks = 72 slots = exactly one full ring.
+    for (let i = 0; i < 24; i++) {
+      for (const task of buildWarmPlan(start + i * SLOT_MS)) {
+        const key = `${task.hub}-${task.dir}-${task.label}`;
+        counts.set(key, (counts.get(key) || 0) + 1);
       }
     }
-
-    // Should eventually cover every today/tomorrow hub/dir combination
-    expect(allKeys.size).toBe(TOTAL_TASKS);
+    expect(counts.size).toBe(UNIQUE_WINDOWS);
+    for (const [key, n] of counts) {
+      expect(n, key).toBe(key.endsWith('today') ? TODAY_ROUNDS : 1);
+    }
   });
 
-  it('limits plan size to WARM_TASKS_PER_RUN (default 2)', () => {
-    const plan = buildWarmPlan();
-    // Default is 2 tasks per run to bound metered AeroDataBox spend
-    expect(plan.length).toBe(2);
+  it('spreads the repeats of a given today-window across the day instead of bunching them', () => {
+    const start = new Date('2026-04-03T00:00:00Z').getTime();
+    const fires = [];
+    for (let i = 0; i < 24; i++) {
+      for (const task of buildWarmPlan(start + i * SLOT_MS)) {
+        if (task.hub === 'ORD' && task.dir === 'departures' && task.label === 'today') fires.push(i);
+      }
+    }
+    expect(fires.length).toBe(3);
+    // Consecutive warms of the same board should be roughly a round apart (≥4h), not back-to-back.
+    for (let i = 1; i < fires.length; i++) {
+      expect(fires[i] - fires[i - 1]).toBeGreaterThanOrEqual(4);
+    }
   });
 
-  it('warms via the provider (AeroDataBox) while keeping paid FR24 + dead scrape off', () => {
+  it('warms via the provider with a forced refresh while keeping paid FR24 + dead scrape off', () => {
     const url = buildScheduleWarmUrl('ORD', 'departures', 1778907600);
     expect(url).toContain('/api/schedule?');
     expect(url).toContain('hub=ORD');
@@ -79,5 +90,116 @@ describe('warm-schedules buildWarmPlan', () => {
     // ... but never burns FR24 official credits, and skips the Cloudflare-dead scrape.
     expect(url).toContain('officialFallback=0');
     expect(url).toContain('scraperFallback=0');
+    // The whole point of the warm is a FRESH board: bypass the frozen-snapshot serve paths.
+    expect(url).toContain('forceRefresh=1');
+  });
+});
+
+describe('warm-schedules handler', () => {
+  const SECRET = 'test-cron-secret-1234';
+
+  function createRes() {
+    return {
+      statusCode: 200,
+      body: null,
+      status(code) { this.statusCode = code; return this; },
+      json(payload) { this.body = payload; return this; },
+    };
+  }
+
+  function createReq() {
+    return { method: 'GET', headers: { authorization: `Bearer ${SECRET}` } };
+  }
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.CRON_SECRET = SECRET;
+    process.env.SCHEDULE_WARM_DELAY_MS = '0';
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete process.env.CRON_SECRET;
+    delete process.env.SCHEDULE_WARM_DELAY_MS;
+  });
+
+  function mockFetchOk(schedulePayload) {
+    return vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => (String(url).includes('/api/schedule') ? schedulePayload : { ok: true }),
+    }));
+  }
+
+  it('sends forceRefresh + cron authorization on every schedule warm request', async () => {
+    const fetchSpy = mockFetchOk({ cached: false, stale: false, partial: false, total: 100, meta: {} });
+    await handler(createReq(), createRes());
+    const scheduleCalls = fetchSpy.mock.calls.filter(([url]) => String(url).includes('/api/schedule'));
+    expect(scheduleCalls.length).toBeGreaterThan(0);
+    for (const [url, opts] of scheduleCalls) {
+      expect(String(url)).toContain('forceRefresh=1');
+      expect(opts.headers['Authorization']).toBe(`Bearer ${SECRET}`);
+    }
+  });
+
+  it('warms hub-correct day keys (getStartOfHubDay) at every hour, even pre-6AM hub-local', async () => {
+    // Sweep the clock across the day: pre-6AM hub-local (e.g. 3:30 AM Chicago) is the window where
+    // the old getStartOfDayForHub rollback warmed YESTERDAY's key and the slot's quota was spent on
+    // a mislabeled board (~25% of slots).
+    for (let h = 0; h < 24; h += 3) {
+      vi.useFakeTimers({ now: new Date(Date.UTC(2026, 5, 10, h, 30)), toFake: ['Date'] });
+      const fetchSpy = mockFetchOk({ cached: false, stale: false, partial: false, total: 100, meta: {} });
+      await handler(createReq(), createRes());
+      const scheduleCalls = fetchSpy.mock.calls.filter(([url]) => String(url).includes('/api/schedule'));
+      expect(scheduleCalls.length).toBeGreaterThan(0);
+      for (const [url] of scheduleCalls) {
+        const u = new URL(String(url));
+        const hub = u.searchParams.get('hub');
+        const ts = Number(u.searchParams.get('timestamp'));
+        expect([getStartOfHubDay(hub, 0), getStartOfHubDay(hub, 1)], `${h}:30Z ${hub} ts ${ts}`).toContain(ts);
+      }
+      vi.restoreAllMocks();
+      vi.useRealTimers();
+    }
+  });
+
+  it('counts a stale-served board as a FAILED warm (the frozen-board signature)', async () => {
+    mockFetchOk({ cached: true, stale: true, degraded: true, partial: false, total: 628, meta: { dataAge: 106495 } });
+    const res = createRes();
+    await handler(createReq(), res);
+    // All schedule tasks served frozen snapshots → none warmed; only starlink succeeded.
+    expect(res.body.failed).toBeGreaterThanOrEqual(3);
+    expect(res.body.warmed).toBe(1);
+    const scheduleResults = Object.entries(res.body.results).filter(([k]) => k !== 'starlink-data');
+    for (const [, r] of scheduleResults) expect(r.status).toBe('stale_served');
+  });
+
+  it('counts a fresh complete board as warmed', async () => {
+    mockFetchOk({ cached: false, stale: false, partial: false, total: 312, meta: { completeness: 1 } });
+    const res = createRes();
+    await handler(createReq(), res);
+    expect(res.body.failed).toBe(0);
+    expect(res.body.warmed).toBe(4); // 3 schedule tasks + starlink
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('returns 503 when every warm task fails so cron monitoring turns red', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 500,
+      headers: { get: () => null },
+      json: async () => ({}),
+    });
+    const res = createRes();
+    await handler(createReq(), res);
+    expect(res.body.warmed).toBe(0);
+    expect(res.statusCode).toBe(503);
+  });
+
+  it('rejects requests without the cron secret', async () => {
+    const res = createRes();
+    await handler({ method: 'GET', headers: {} }, res);
+    expect(res.statusCode).toBe(401);
   });
 });

--- a/tests/warm-schedules.test.js
+++ b/tests/warm-schedules.test.js
@@ -207,4 +207,77 @@ describe('warm-schedules handler', () => {
     await handler({ method: 'GET', headers: {} }, res);
     expect(res.statusCode).toBe(401);
   });
+
+  it('counts a partial non-empty board as degraded_partial — a FAILED warm', async () => {
+    mockFetchOk({ cached: false, stale: false, partial: true, total: 50, meta: { completeness: 0.5 } });
+    const res = createRes();
+    await handler(createReq(), res);
+    const scheduleResults = Object.entries(res.body.results).filter(([k]) => k !== 'starlink-data');
+    expect(scheduleResults.length).toBe(3);
+    for (const [key, r] of scheduleResults) expect(r.status, key).toBe('degraded_partial');
+    // A half-board did not warm anything: the schedule counters must reflect total failure even
+    // though the starlink ping succeeded, and the run must go red for cron monitoring.
+    expect(res.body.scheduleWarmed).toBe(0);
+    expect(res.body.scheduleFailed).toBe(3);
+    expect(res.body.failed).toBe(3);
+    expect(res.statusCode).toBe(503);
+  });
+
+  it('counts a partial EMPTY board as degraded_empty — a FAILED warm', async () => {
+    mockFetchOk({ cached: false, stale: false, partial: true, total: 0, meta: { completeness: 0 } });
+    const res = createRes();
+    await handler(createReq(), res);
+    const scheduleResults = Object.entries(res.body.results).filter(([k]) => k !== 'starlink-data');
+    expect(scheduleResults.length).toBe(3);
+    for (const [key, r] of scheduleResults) expect(r.status, key).toBe('degraded_empty');
+    expect(res.body.scheduleWarmed).toBe(0);
+    expect(res.body.scheduleFailed).toBe(3);
+    expect(res.statusCode).toBe(503);
+  });
+
+  it("marks a schedule warm whose fetch throws as status 'error' (a FAILED warm)", async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      if (String(url).includes('/api/schedule')) throw new Error('socket hang up');
+      return { ok: true, status: 200, headers: { get: () => null }, json: async () => ({ ok: true }) };
+    });
+    const res = createRes();
+    await handler(createReq(), res);
+    const scheduleResults = Object.entries(res.body.results).filter(([k]) => k !== 'starlink-data');
+    expect(scheduleResults.length).toBe(3);
+    for (const [key, r] of scheduleResults) {
+      expect(r.status, key).toBe('error');
+      expect(r.message, key).toBe('socket hang up');
+    }
+    expect(res.body.scheduleWarmed).toBe(0);
+    expect(res.body.scheduleFailed).toBe(3);
+    // Starlink still warmed (its fetch resolves), but that must not mask the schedule incident.
+    expect(res.statusCode).toBe(503);
+  });
+
+  it('returns 200 on a MIXED run where at least one board actually warmed', async () => {
+    // 503 is reserved for "warmed NOTHING": one genuinely fresh board out of three is a partial
+    // success, and flapping the cron red on every transient stale-serve would bury real incidents.
+    let scheduleCalls = 0;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const isSchedule = String(url).includes('/api/schedule');
+      if (!isSchedule) {
+        return { ok: true, status: 200, headers: { get: () => null }, json: async () => ({ ok: true }) };
+      }
+      scheduleCalls++;
+      const fresh = scheduleCalls === 1;
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        json: async () => fresh
+          ? { cached: false, stale: false, partial: false, total: 280, meta: { completeness: 1 } }
+          : { cached: true, stale: true, degraded: true, partial: false, total: 600, meta: { dataAge: 106495 } },
+      };
+    });
+    const res = createRes();
+    await handler(createReq(), res);
+    expect(res.body.scheduleWarmed).toBe(1);
+    expect(res.body.scheduleFailed).toBe(2);
+    expect(res.statusCode).toBe(200);
+  });
 });

--- a/tests/warm-schedules.test.js
+++ b/tests/warm-schedules.test.js
@@ -173,6 +173,11 @@ describe('warm-schedules handler', () => {
     expect(res.body.warmed).toBe(1);
     const scheduleResults = Object.entries(res.body.results).filter(([k]) => k !== 'starlink-data');
     for (const [, r] of scheduleResults) expect(r.status).toBe('stale_served');
+    // The Starlink ping has nothing to do with AeroDataBox and is built to never fail — its
+    // success must not turn an every-board-frozen run into a green 200 (that 200-while-frozen
+    // masking is the exact incident this commit exists to surface).
+    expect(res.body.scheduleWarmed).toBe(0);
+    expect(res.statusCode).toBe(503);
   });
 
   it('counts a fresh complete board as warmed', async () => {

--- a/tests/warm-schedules.test.js
+++ b/tests/warm-schedules.test.js
@@ -3,6 +3,11 @@ import handler, { buildScheduleWarmUrl, buildWarmPlan } from '../api/cron/warm-s
 import { getStartOfHubDay } from '../src/lib/hubTz.js';
 
 describe('warm-schedules buildWarmPlan', () => {
+  // The production code reads this env per call; pin it so an ambient export in a dev/CI shell
+  // can't skew every count-based assertion in this file.
+  beforeEach(() => { process.env.SCHEDULE_WARM_TASKS_PER_RUN = '3'; });
+  afterEach(() => { delete process.env.SCHEDULE_WARM_TASKS_PER_RUN; });
+
   const HUBS = ['ORD', 'DEN', 'IAH', 'EWR', 'SFO', 'IAD', 'LAX', 'NRT', 'GUM'];
   const UNIQUE_WINDOWS = 9 * 4;       // 9 hubs × (today+tomorrow) × 2 dirs; yesterday is on-demand
   const TODAY_ROUNDS = 3;             // each today window is warmed 3×/day (~every 8h)
@@ -115,12 +120,14 @@ describe('warm-schedules handler', () => {
     vi.restoreAllMocks();
     process.env.CRON_SECRET = SECRET;
     process.env.SCHEDULE_WARM_DELAY_MS = '0';
+    process.env.SCHEDULE_WARM_TASKS_PER_RUN = '3'; // pin the per-call env read (see plan describe)
   });
 
   afterEach(() => {
     vi.useRealTimers();
     delete process.env.CRON_SECRET;
     delete process.env.SCHEDULE_WARM_DELAY_MS;
+    delete process.env.SCHEDULE_WARM_TASKS_PER_RUN;
   });
 
   function mockFetchOk(schedulePayload) {
@@ -153,11 +160,17 @@ describe('warm-schedules handler', () => {
       await handler(createReq(), createRes());
       const scheduleCalls = fetchSpy.mock.calls.filter(([url]) => String(url).includes('/api/schedule'));
       expect(scheduleCalls.length).toBeGreaterThan(0);
+      // Exact per-task assertion (not "either day"): a bug that swaps the today/tomorrow
+      // dayOffset mapping must fail here, not just the yesterday-rollback regression.
+      const plan = buildWarmPlan(Date.now());
       for (const [url] of scheduleCalls) {
         const u = new URL(String(url));
         const hub = u.searchParams.get('hub');
+        const dir = u.searchParams.get('dir');
         const ts = Number(u.searchParams.get('timestamp'));
-        expect([getStartOfHubDay(hub, 0), getStartOfHubDay(hub, 1)], `${h}:30Z ${hub} ts ${ts}`).toContain(ts);
+        const task = plan.find(t => t.hub === hub && t.dir === dir);
+        expect(task, `${h}:30Z no plan task for ${hub} ${dir}`).toBeTruthy();
+        expect(ts, `${h}:30Z ${hub} ${dir} (${task.label})`).toBe(getStartOfHubDay(task.hub, task.dayOffset));
       }
       vi.restoreAllMocks();
       vi.useRealTimers();
@@ -205,6 +218,15 @@ describe('warm-schedules handler', () => {
   it('rejects requests without the cron secret', async () => {
     const res = createRes();
     await handler({ method: 'GET', headers: {} }, res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('fails CLOSED when CRON_SECRET is unset — "Bearer undefined" must not authenticate', async () => {
+    // A plain `auth !== `Bearer ${process.env.CRON_SECRET}`` check with the env var missing
+    // compares against the literal string "Bearer undefined" — a guessable constant.
+    delete process.env.CRON_SECRET;
+    const res = createRes();
+    await handler({ method: 'GET', headers: { authorization: 'Bearer undefined' } }, res);
     expect(res.statusCode).toBe(401);
   });
 

--- a/tests/warm-schedules.test.js
+++ b/tests/warm-schedules.test.js
@@ -202,6 +202,35 @@ describe('warm-schedules handler', () => {
     expect(res.statusCode).toBe(200);
   });
 
+  it('counts a CDN HIT or cache-served warm as NOT refreshed — a warm that did not refetch warmed nothing', async () => {
+    // Tripwire for CDN pinning of the warm URL: a HIT means the stored body (possibly a frozen
+    // board recorded as cached:false hours ago) came back without the lambda running at all.
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => ({
+      ok: true,
+      status: 200,
+      headers: { get: (h) => (h === 'x-vercel-cache' && String(url).includes('/api/schedule') ? 'HIT' : null) },
+      json: async () => (String(url).includes('/api/schedule')
+        ? { cached: false, stale: false, partial: false, total: 300, meta: { completeness: 1 } }
+        : { ok: true }),
+    }));
+    const res = createRes();
+    await handler(createReq(), res);
+    expect(res.body.scheduleWarmed).toBe(0);
+    expect(res.statusCode).toBe(503);
+    const scheduleResults = Object.entries(res.body.results).filter(([k]) => k !== 'starlink-data');
+    for (const [, r] of scheduleResults) expect(r.status).toBe('not_refreshed');
+  });
+
+  it('counts a cache-served body (cached:true, e.g. force silently ignored) as NOT refreshed', async () => {
+    // If CRON_SECRET is missing from the schedule lambda's env, forceRefresh is silently ignored
+    // and the warm gets the cached board back — that must not report a green ok.
+    mockFetchOk({ cached: true, stale: false, partial: false, total: 300, meta: { completeness: 1 } });
+    const res = createRes();
+    await handler(createReq(), res);
+    expect(res.body.scheduleWarmed).toBe(0);
+    expect(res.statusCode).toBe(503);
+  });
+
   it('returns 503 when every warm task fails so cron monitoring turns red', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: false,

--- a/vercel.json
+++ b/vercel.json
@@ -34,7 +34,7 @@
         "api/cron/refresh-metar.ts": { "maxDuration": 30 }
     },
     "crons": [
-        { "path": "/api/cron/warm-schedules", "schedule": "0 */2 * * *" },
+        { "path": "/api/cron/warm-schedules", "schedule": "0 * * * *" },
         { "path": "/api/cron/sync-starlink", "schedule": "0 */4 * * *" },
         { "path": "/api/cron/refresh-tsa", "schedule": "*/5 * * * *" },
         { "path": "/api/cron/refresh-metar", "schedule": "*/5 * * * *" }


### PR DESCRIPTION
## Summary

Fixes the two top findings of the June 9 production audit — boards frozen all day in prod, and an unmetered paid-API spend surface — as one PR because the first fix re-opens the spend path the second one bounds.

**Unfreeze the boards (audit #1 — live incident)**
- All three cache-fallback serve paths hardcoded `disableProviderFallback:true`, and a complete snapshot could never be replaced — each board was fetched from AeroDataBox at most once and then served stale all day at completeness 1.0 (live-proven: ORD 30h stale, 628/628 flights "scheduled" after a full operating day; IROPS `operated:0` on 7/9 hubs). The warm cron received the frozen snapshot back and logged "ok".
- The warm cron now sends `forceRefresh=1` + `Authorization: Bearer CRON_SECRET`; `/api/schedule` skips every cached/stale/persistent serve tier for authorized force requests and actually refetches.
- Background refreshes age-gate the provider: data >3h old may refresh via AeroDataBox, once per board per hour per instance.
- Warm ring rebalanced: hourly cron × 3 tasks = today boards 3×/day (~every 8h), tomorrow boards 1×/day ≈ 288 units/day — the metered-plan budget. Day keys use the DST-safe `getStartOfHubDay` (pre-6AM slots no longer warm mislabeled yesterday keys).
- Warm honesty: `stale_served` / `not_refreshed` (CDN HIT or cached body) / `degraded_*` all count as FAILED; a run that warms zero schedule boards returns **503** so Vercel cron monitoring goes red (the always-green Starlink ping is counted separately and can no longer mask it).
- Dashboard: degraded banner shows humanized age ("30h", not "1775m"), escalates teal→amber→red past 1h/6h, drops the false "while refreshing" copy (tokens per DESIGN.md).

**Close the spend surface (audit #2)**
- Hub allowlist (9 United hubs, shared `api/_hubs.ts` — de-duplicates `UNITED_HUB_TERMINALS` across three modules) and timestamps snapped losslessly to the hub-local day start: cache-key cardinality drops from ~1.2M/hub/dir to ≤15 day keys. Previously one IP at the allowed rate could drain the monthly quota in <2h.
- Cross-instance daily unit budget (default 400; `AERODATABOX_DAILY_UNIT_BUDGET`, `0` honored as kill switch) enforced inside `fetchViaAeroDataBox`, persisted via atomic Supabase RPC. Cron warms bypass the organic budget (ring-bounded) but keep a hydrated 3× absolute ceiling.

**Security hardening (from review + adversarial passes)**
- `api/_cron-auth.ts`: timing-safe Bearer compare that **fails closed** when `CRON_SECRET` is unset ("Bearer undefined" previously authenticated). Used by warm-schedules and the force gate. (TODOS #6 partial — reuse for refresh-tsa/sync-starlink/news-notify.)
- Any `forceRefresh`-flavored request responds `Cache-Control: no-store` regardless of auth — an unauthenticated probe of the predictable warm URL could otherwise pin a 6h CDN object on the cron's own URL key and re-freeze boards behind a green cron.
- `sql/009`: RPC EXECUTE revoked from `authenticated` (Supabase default privileges would let any self-minted JWT brick/uncap the budget), table CRUD revoked from client roles, `GREATEST(p_units, 0)` + `CHECK (units >= 0)`, re-runnable (`IF NOT EXISTS`).

**Concurrency/correctness (from review)**
- `pendingAggs` compare-and-delete (a forced warm's in-flight fetch could be evicted by an orphaned entry's `finally`, breaking dedupe and double-billing).
- Provider cooldown no longer consumed when an in-flight refresh makes the trigger a no-op.
- Spend RPC registered with `waitUntil`; day-rollover guards stop yesterday's total from blocking a fresh day.

## ⚠️ Deploy steps (merge = instant prod deploy)

1. **Before (or immediately after) merge:** apply `sql/009_provider_spend.sql` via the Supabase dashboard SQL editor (NOT `supabase db push` — this repo keeps migrations in `sql/`). Verify: `SELECT increment_adb_units(CURRENT_DATE, 0);`. The code degrades gracefully without it (and logs a distinct one-time error), but the cross-instance spend ceiling only exists once applied.
2. Confirm `CRON_SECRET` is set in the Vercel env — cron auth now fails closed, and warms without it will (correctly) report `not_refreshed` + 503.
3. The hourly warm cron (`vercel.json`) takes effect on deploy; expect ~288 AeroDataBox units/day steady-state (~8.6k/mo).
4. After the first few cron fires, check logs for `Cron warm-schedules:` lines — fresh boards should show `cached:false` with est-units >0, and `/api/irops` hub metrics should repopulate within a day.

## Test Coverage

Tests: 604 → 665 (+61 new, 4 new test files), TDD throughout (every behavior change red-first). AI-assessed path coverage after generation ≈87% (68% pre-generation, 25 gaps → remaining gaps are E2E-only: dashboard banner rendering ×4, live Supabase RPC ×1, plus minor force-tier branches). Money-pipeline firsts: the AeroDataBox fetch path, cost-state accounting, and warm handler now have direct test coverage (previously zero).

## Pre-Landing Review

6 specialists (checklist, testing, maintainability, security, performance, data-migration force-included) + red team: 23 findings → 1 CRITICAL (sql/009 `authenticated` EXECUTE gap) + 22 informational; all actionable items fixed in `d05d6e8`/`e90f0f8`, each behavior change pinned by a test. Quality score 7.0/10 pre-fix.

Accepted residuals (documented, not fixed): check-then-spend overshoot window (~12 units/concurrent fetch inside a 10s hydrate window — soft ceiling by design); nested-`waitUntil` semantics on background-refresh spend writes (in-memory accounting unaffected; cross-instance counter may undercount, self-corrects on next RPC adopt); CDN objects for non-canonical timestamps (no paid spend, lambda-only); 6h TTL constant appears in three layers with cross-referencing comments.

## Adversarial Review

Claude adversarial (fresh context): found the unauthenticated CDN-pinning hole (fixed, `8dd33f4`) and the budget-0 kill-switch inversion (fixed). Codex passes skipped — CLI auth expired (`codex login` to restore cross-model coverage). Earlier in this branch: a 19-agent adversarial workflow reviewed the original implementation (4 confirmed findings, fixed in `b10bcdf`).

## Scope Drift

Scope Check: CLEAN — intent was audit fixes #1 + #2 as approved; every changed file is named in the approved fix specs or a verified review finding on those files.

## Plan Completion

No plan file detected (spec = audit items #1/#2, approved in conversation). One external-state item the diff cannot prove: **sql/009 applied in Supabase** — see Deploy steps.

## Eval Results

No prompt-related files changed — evals skipped.

## TODOS

No items fully completed. TODOS #6 (CRON_SECRET timing-safe compare) annotated as partial: warm-schedules + the force gate shipped via `api/_cron-auth.ts`; refresh-tsa/sync-starlink/news-notify remain.

## Documentation

**README.md** (commit 54fa882): warm cron cadence corrected to hourly; schedule cache claim updated (6h edge for complete boards / 60s partial); AeroDataBox added to Data Sources; schedule/warm-schedules tree descriptions updated.

Documentation debt flagged (not blocking): no env-var reference doc (`AERODATABOX_DAILY_UNIT_BUDGET`, `SCHEDULE_WARM_TASKS_PER_RUN` live only in CHANGELOG); no Supabase-migration how-to; architecture diagram still labels `/api/schedule` as "FR24 schedule proxy".

## Test plan

- [x] Full vitest suite passes: 665 tests, 47 files (`bun run test`)
- [x] `tsc --noEmit` clean
- [x] Production build passes (`bun run build`)
- [ ] Post-merge: apply sql/009, watch the first hourly warm logs, confirm `/api/schedule?hub=ORD...` serves `stale:false` with fresh `dataAge` through the day

🤖 Generated with [Claude Code](https://claude.com/claude-code)
