### PR TITLE
v1.5.18 feat: warm-cron Discord alerting + post-deploy smoke check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,12 @@ AERODATABOX_API_KEY=
 # Vercel Cron Secret (required for cron job auth)
 CRON_SECRET=
 
+# Operational alerting (optional): Discord webhook URL. When set, the hourly warm-schedules cron
+# POSTs a compact alert when the schedule pipeline is degraded (total warm failure, frozen/stale-
+# served boards, 0-flight boards, AeroDataBox spend >= 80% of the daily budget, or starlink down).
+# Leave unset to disable alerting entirely. For Slack, api/_alert.ts would need `text` not `content`.
+ALERT_WEBHOOK_URL=
+
 # Supabase (waitlist / email capture)
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -1,0 +1,34 @@
+# Post-deploy smoke check: merge to main = instant Vercel production deploy (no preview deploys),
+# so this is the only automated signal that a deploy broke the site (the b280fd7 ESM-crash class).
+# Waits for Vercel to build, then curls the three load-bearing URLs with retries.
+name: Post-deploy smoke
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for Vercel production deploy
+        run: sleep 150
+      - name: Smoke-check production
+        run: |
+          check () {
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 "$1")
+            echo "$1 -> $code"
+            [ "$code" = "200" ]
+          }
+          for attempt in 1 2 3; do
+            ok=true
+            check "https://theblueboard.co/" || ok=false
+            check "https://theblueboard.co/api/starlink-data" || ok=false
+            # Any intra-day timestamp snaps server-side to the hub-local day start (v1.5.16+).
+            check "https://theblueboard.co/api/schedule?hub=ORD&dir=departures&timestamp=$(date +%s)" || ok=false
+            if $ok; then echo "smoke OK"; exit 0; fi
+            echo "attempt $attempt failed; retrying in 60s"
+            sleep 60
+          done
+          echo "PRODUCTION SMOKE FAILED after 3 attempts — consider 'vercel rollback'"
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.18] - 2026-06-10
+
+### Added
+- Operational alerting (supersedes PR #168): when `ALERT_WEBHOOK_URL` is set, the hourly warm cron posts a Discord alert on the signatures that mean the live site is degraded right now — total warm failure, frozen/stale-served boards (the warm didn't actually refetch), 0-flight boards, AeroDataBox spend ≥80% of the daily budget, or the Starlink feed down. Throttled to one alert per 5 minutes; alerting failures never affect the cron itself.
+- Post-deploy smoke check (`.github/workflows/post-deploy-smoke.yml`): every push to main waits for the Vercel deploy and curls the homepage, the Starlink API, and a live schedule board with retries — the first automated signal for the merge-equals-deploy pipeline (previously a broken deploy was only discovered by visiting the site).
+
 ## [1.5.16] - 2026-06-10
 
 ### Fixed

--- a/api/_alert.ts
+++ b/api/_alert.ts
@@ -1,0 +1,47 @@
+// Lightweight, env-gated operational alerting. (Ported from PR #168, which this supersedes.)
+//
+// POSTs a compact message to a Discord webhook configured via ALERT_WEBHOOK_URL.
+// - No-ops when ALERT_WEBHOOK_URL is unset, so callers can invoke it unconditionally.
+// - Best-effort: never throws into the caller, uses a short timeout, and swallows its own errors.
+// - Throttled per-instance to avoid spamming on every cron tick. (The throttle is module-level
+//   state and therefore per-lambda; on serverless this is "good enough" for an hourly cron that
+//   normally runs on a single warm instance — it is a noise guard, not a hard global limit.)
+//
+// Discord webhooks accept a JSON body with a `content` field; we also include `username` for a
+// friendly sender name. (For Slack, swap `content` -> `text`.)
+// Audit P1: "No alerting/monitoring on the schedule/credit subsystem."
+
+let lastAlertAt = 0;
+const MIN_ALERT_INTERVAL_MS = 5 * 60 * 1000;
+
+export async function sendAlert(title: string, lines: string[] = []): Promise<void> {
+  const url = process.env.ALERT_WEBHOOK_URL;
+  if (!url) return;
+
+  const now = Date.now();
+  if (now - lastAlertAt < MIN_ALERT_INTERVAL_MS) return;
+  lastAlertAt = now;
+
+  // Discord hard-caps message content at 2000 chars; stay well under.
+  const content = [`**${title}**`, ...lines].join('\n').slice(0, 1900);
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+    await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content, username: 'Blue Board' }),
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+  } catch (e: any) {
+    // Never let alerting failures affect the caller's control flow.
+    console.error('Alert webhook failed:', e?.message || e);
+  }
+}
+
+/** Test helper: clear the per-instance throttle. Production never calls it. */
+export function __resetAlertThrottleForTests(): void {
+  lastAlertAt = 0;
+}

--- a/api/cron/warm-schedules.ts
+++ b/api/cron/warm-schedules.ts
@@ -11,6 +11,8 @@
 import type { VercelRequest, VercelResponse } from '../types.js';
 import { UNITED_HUBS } from '../_hubs.js';
 import { isAuthorizedCronRequest } from '../_cron-auth.js';
+import { sendAlert } from '../_alert.js';
+import { hydrateAdbSpend, getAdbUnitsToday, getAdbDailyUnitBudget } from '../_cost-state.js';
 import { getStartOfHubDay } from '../../src/lib/hubTz.js';
 
 const HUBS = UNITED_HUBS;
@@ -221,6 +223,44 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     `Cron warm-schedules: ${warmed} warmed, ${failed} failed, ~${estUnits} AeroDataBox units (${freshBoards} fresh boards)`,
     { warmPlan, results }
   );
+
+  // Operational alerting (env-gated; no-op without ALERT_WEBHOOK_URL). The hourly warm cron is
+  // the natural heartbeat for the schedule pipeline: alert on the signatures that mean the live
+  // site is degraded RIGHT NOW or money is about to run out, not on every transient blip.
+  // (Audit P1: no-alerting-blind-pipeline; supersedes PR #168, whose `failed > warmed` condition
+  // predates the schedule/starlink counter split and the stale_served/not_refreshed statuses.)
+  try {
+    const scheduleEntries = Object.entries(results).filter(([k]) => k !== 'starlink-data');
+    const byStatus = (...statuses: string[]) =>
+      scheduleEntries.filter(([, r]) => statuses.includes(r?.status)).map(([k]) => k);
+    const frozen = byStatus('stale_served', 'not_refreshed'); // the frozen-board signature
+    const emptyBoards = byStatus('degraded_empty');
+    const erroredKeys = scheduleEntries
+      .filter(([, r]) => r?.status === 'error' || String(r?.status || '').startsWith('http_'))
+      .map(([k]) => k);
+    const starlinkStatus = results['starlink-data']?.status;
+
+    await hydrateAdbSpend();
+    const unitsToday = getAdbUnitsToday();
+    const budget = getAdbDailyUnitBudget();
+    const budgetHot = budget > 0 && unitsToday >= budget * 0.8;
+
+    const totalFailure = scheduleWarmed === 0 && scheduleFailed > 0;
+    if (totalFailure || frozen.length > 0 || emptyBoards.length > 0 || budgetHot || (starlinkStatus && starlinkStatus !== 'ok')) {
+      await sendAlert('⚠️ Blue Board schedule pipeline degraded', [
+        `warmed=${scheduleWarmed} failed=${scheduleFailed} (plan size ${warmPlan.length}, ~${estUnits} units this run)`,
+        frozen.length ? `frozen/stale-served boards (warm did NOT refetch): ${frozen.join(', ')}` : '',
+        emptyBoards.length ? `0-flight boards: ${emptyBoards.join(', ')}` : '',
+        erroredKeys.length ? `errors/http: ${erroredKeys.join(', ')}` : '',
+        budgetHot ? `AeroDataBox budget: ${unitsToday}/${budget} units today (≥80%)` : '',
+        starlinkStatus && starlinkStatus !== 'ok' ? `starlink: ${starlinkStatus}` : '',
+      ].filter(Boolean));
+    }
+  } catch (e: any) {
+    // Alerting must never break the cron itself.
+    console.error('warm-schedules alerting block failed:', e?.message || e);
+  }
+
   // A run that warmed NO schedule board is an incident, not a success — return 5xx so Vercel's
   // built-in cron monitoring (and any uptime check on this path) goes red instead of logging a
   // quiet 200. Gated on the schedule counters only; see the counter comment above.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.5.16",
+  "version": "1.5.18",
   "packageManager": "bun@1.3.14",
   "engines": {
     "node": "24.x"

--- a/tests/alert.test.js
+++ b/tests/alert.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { sendAlert, __resetAlertThrottleForTests } from '../api/_alert.js';
+
+describe('sendAlert', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    __resetAlertThrottleForTests();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete process.env.ALERT_WEBHOOK_URL;
+    __resetAlertThrottleForTests();
+  });
+
+  it('no-ops when ALERT_WEBHOOK_URL is unset', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    await sendAlert('title', ['line']);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('POSTs a Discord-shaped payload when configured', async () => {
+    process.env.ALERT_WEBHOOK_URL = 'https://discord.test/webhook';
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true });
+    await sendAlert('⚠️ degraded', ['warmed=0 failed=3']);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchSpy.mock.calls[0];
+    expect(String(url)).toBe('https://discord.test/webhook');
+    const body = JSON.parse(opts.body);
+    expect(body.content).toContain('degraded');
+    expect(body.content).toContain('warmed=0 failed=3');
+  });
+
+  it('throttles to one alert per 5 minutes per instance', async () => {
+    process.env.ALERT_WEBHOOK_URL = 'https://discord.test/webhook';
+    vi.useFakeTimers({ now: new Date('2026-06-10T12:00:00Z'), toFake: ['Date'] });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true });
+    await sendAlert('first', []);
+    await sendAlert('suppressed', []);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    vi.setSystemTime(new Date('2026-06-10T12:06:00Z'));
+    await sendAlert('second', []);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('never throws into the caller when the webhook fails', async () => {
+    process.env.ALERT_WEBHOOK_URL = 'https://discord.test/webhook';
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('down'));
+    await expect(sendAlert('title', [])).resolves.toBeUndefined();
+  });
+});

--- a/tests/warm-schedules.test.js
+++ b/tests/warm-schedules.test.js
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import handler, { buildScheduleWarmUrl, buildWarmPlan } from '../api/cron/warm-schedules.js';
+import { __resetAlertThrottleForTests } from '../api/_alert.js';
+import { recordAdbUnits, __resetAdbSpendForTests } from '../api/_cost-state.js';
 import { getStartOfHubDay } from '../src/lib/hubTz.js';
 
 describe('warm-schedules buildWarmPlan', () => {
@@ -121,6 +123,8 @@ describe('warm-schedules handler', () => {
     process.env.CRON_SECRET = SECRET;
     process.env.SCHEDULE_WARM_DELAY_MS = '0';
     process.env.SCHEDULE_WARM_TASKS_PER_RUN = '3'; // pin the per-call env read (see plan describe)
+    __resetAlertThrottleForTests();
+    __resetAdbSpendForTests();
   });
 
   afterEach(() => {
@@ -128,6 +132,9 @@ describe('warm-schedules handler', () => {
     delete process.env.CRON_SECRET;
     delete process.env.SCHEDULE_WARM_DELAY_MS;
     delete process.env.SCHEDULE_WARM_TASKS_PER_RUN;
+    delete process.env.ALERT_WEBHOOK_URL;
+    __resetAlertThrottleForTests();
+    __resetAdbSpendForTests();
   });
 
   function mockFetchOk(schedulePayload) {
@@ -248,6 +255,34 @@ describe('warm-schedules handler', () => {
     const res = createRes();
     await handler({ method: 'GET', headers: {} }, res);
     expect(res.statusCode).toBe(401);
+  });
+
+  it('alerts the webhook when every schedule warm is frozen (stale_served)', async () => {
+    process.env.ALERT_WEBHOOK_URL = 'https://discord.test/webhook';
+    const fetchSpy = mockFetchOk({ cached: true, stale: true, degraded: true, partial: false, total: 628, meta: { dataAge: 106495 } });
+    await handler(createReq(), createRes());
+    const alertCalls = fetchSpy.mock.calls.filter(([url]) => String(url).includes('discord.test'));
+    expect(alertCalls.length).toBe(1);
+    const body = JSON.parse(alertCalls[0][1].body);
+    expect(body.content).toMatch(/stale|frozen/i);
+  });
+
+  it('does not alert on a fully healthy run', async () => {
+    process.env.ALERT_WEBHOOK_URL = 'https://discord.test/webhook';
+    const fetchSpy = mockFetchOk({ cached: false, stale: false, partial: false, total: 312, meta: { completeness: 1 } });
+    await handler(createReq(), createRes());
+    const alertCalls = fetchSpy.mock.calls.filter(([url]) => String(url).includes('discord.test'));
+    expect(alertCalls.length).toBe(0);
+  });
+
+  it('alerts when daily AeroDataBox spend crosses 80% of the budget, even on a healthy run', async () => {
+    process.env.ALERT_WEBHOOK_URL = 'https://discord.test/webhook';
+    await recordAdbUnits(340); // 85% of the 400 default
+    const fetchSpy = mockFetchOk({ cached: false, stale: false, partial: false, total: 312, meta: { completeness: 1 } });
+    await handler(createReq(), createRes());
+    const alertCalls = fetchSpy.mock.calls.filter(([url]) => String(url).includes('discord.test'));
+    expect(alertCalls.length).toBe(1);
+    expect(JSON.parse(alertCalls[0][1].body).content).toMatch(/budget|units/i);
   });
 
   it('fails CLOSED when CRON_SECRET is unset — "Bearer undefined" must not authenticate', async () => {


### PR DESCRIPTION
## Summary

Audit item 3: alerting + deploy safety. Supersedes #168 (its `api/_alert.ts` is ported as-is, credited; its `failed > warmed` trigger predates the v1.5.16 counter split and stale-detection, so the wiring is new).

**Alerting** — when `ALERT_WEBHOOK_URL` is set (Discord webhook), the hourly warm cron posts one compact alert when any of these fire:
- total schedule-warm failure (the 503 case)
- frozen boards: `stale_served` / `not_refreshed` warms (the exact signature of the incident class v1.5.16 fixed)
- `degraded_empty` (0-flight) boards
- AeroDataBox spend ≥80% of the daily budget (hydrated cross-instance count — early warning before the breaker trips)
- Starlink feed down

Throttled to one alert per 5 min per instance; the alerting block can never break the cron (try/catch). The always-green Starlink ping cannot mask schedule alerts — counters are split.

**Deploy safety** — `.github/workflows/post-deploy-smoke.yml`: every push to main waits ~2.5min for the Vercel deploy, then curls `/`, `/api/starlink-data`, and a live ORD schedule board (3 attempts, 60s apart). First automated signal for the merge-equals-deploy pipeline; failure shows a red X + suggests `vercel rollback`.

Branch protection on `main` (requiring the `test` check, blocking force-pushes) is being applied as a repo setting alongside this PR — not a file change.

## Actions for you
- Set `ALERT_WEBHOOK_URL` in Vercel env (Discord → channel → Integrations → Webhooks → copy URL). Without it, alerting silently no-ops.
- Merge order: #195 first, then this (trivial CHANGELOG/version conflict otherwise — happy to rebase).

## Test Coverage
672 tests / 48 files: `tests/alert.test.js` (no-op without env, Discord payload shape, 5-min throttle via fake timers, webhook failure never throws) + 3 warm-cron wiring tests (alerts on all-frozen run, silent on healthy run, budget ≥80% alerts even when warms succeed).

## Test plan
- [x] `bun run test` 672/672 · `tsc --noEmit` clean
- [ ] Post-merge: set `ALERT_WEBHOOK_URL`, then `curl -H "Authorization: Bearer $CRON_SECRET" https://theblueboard.co/api/cron/warm-schedules` and confirm a Discord message arrives if anything is degraded (or temporarily set the budget env low to force one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
