### PR TITLE
feat(starlink): likelihood-forecast badge for unknown-tail My Flight lookups

### DIFF
--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -1565,6 +1565,28 @@ function fetchStarlinkPredictions() {
 }
 
 function applyStarlinkPrediction(el, data) {
+  // Two distinct badge surfaces share this renderer. Only the NEW forecast badge
+  // (data-mode="forecast", driven by predict-flight's statistical base-rate) gets
+  // the "likely ~N%" label + low-data gating. The pre-existing deterministic
+  // check-flight badge (tail already resolved) must render exactly as it did on
+  // main — otherwise a verified-95% confirmation (n_observations≈1) would be
+  // demoted to a muted "· low data" with a self-contradictory tooltip.
+  const forecast = el.getAttribute('data-mode') === 'forecast';
+
+  if (!forecast) {
+    // ---- Legacy check-flight badge — byte-identical to main ----
+    const lpct = Math.round(data.probability * 100);
+    if (lpct < 5) { el.style.display = 'none'; return; }
+    const lcolor = lpct >= 75 ? 'var(--ua-green)' : lpct >= 40 ? 'var(--ua-yellow)' : 'var(--ua-muted)';
+    const lbg = lpct >= 75 ? 'rgba(34,197,94,.2)' : lpct >= 40 ? 'rgba(234,179,8,.15)' : 'rgba(100,116,139,.15)';
+    el.style.background = lbg;
+    el.style.color = lcolor;
+    el.textContent = '⚡ Starlink ~' + lpct + '%';
+    el.title = 'Confidence: ' + (data.confidence || 'unknown') + ' (' + (data.n_observations || 0) + ' observations)';
+    return;
+  }
+
+  // ---- Forecast badge — statistical route base-rate from predict-flight ----
   const pct = Math.round((data.probability || 0) * 100);
   // A near-zero base rate is noise, not a signal — hide rather than show "~2%".
   if (pct < 5) { el.style.display = 'none'; return; }

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -1528,19 +1528,29 @@ function fetchStarlinkPredictions() {
   // en-CA emits YYYY-MM-DD in the user's local timezone, which matches the
   // operational date of the displayed flights. Plain toISOString() is UTC and
   // would query tomorrow's date for west-of-UTC users after local afternoon.
+  // (Only the legacy tail-known check-flight path is date-scoped.)
   const today = new Date().toLocaleDateString('en-CA');
   document.querySelectorAll('.starlink-predict').forEach(el => {
     const flight = el.getAttribute('data-flight');
     if (!flight || flight === 'N/A') { el.style.display = 'none'; return; }
 
-    const cacheKey = flight + '|' + today;
+    // Forecast badges fire where no tail is resolvable, so the right signal is the
+    // statistical route base-rate from predict-flight's flight_history model. That
+    // model is date-agnostic → drop the date param and cache by flight-number only.
+    // Tail-known badges keep their existing date-scoped check-flight path.
+    const forecast = el.getAttribute('data-mode') === 'forecast';
+    const cacheKey = forecast ? 'forecast|' + flight : flight + '|' + today;
     const cached = starlinkPredictionCache.get(cacheKey);
     if (cached) {
       applyStarlinkPrediction(el, cached);
       return;
     }
 
-    fetch('/api/check-flight?flight_number=' + encodeURIComponent(flight) + '&date=' + today)
+    const url = forecast
+      ? '/api/predict-flight?flight_number=' + encodeURIComponent(flight)
+      : '/api/check-flight?flight_number=' + encodeURIComponent(flight) + '&date=' + today;
+
+    fetch(url)
       .then(r => r.ok ? r.json() : null)
       .then(data => {
         if (!data || data.probability === undefined) {
@@ -1555,15 +1565,33 @@ function fetchStarlinkPredictions() {
 }
 
 function applyStarlinkPrediction(el, data) {
-  const pct = Math.round(data.probability * 100);
+  const pct = Math.round((data.probability || 0) * 100);
+  // A near-zero base rate is noise, not a signal — hide rather than show "~2%".
   if (pct < 5) { el.style.display = 'none'; return; }
 
-  const color = pct >= 75 ? 'var(--ua-green)' : pct >= 40 ? 'var(--ua-yellow)' : 'var(--ua-muted)';
-  const bgColor = pct >= 75 ? 'rgba(34,197,94,.2)' : pct >= 40 ? 'rgba(234,179,8,.15)' : 'rgba(100,116,139,.15)';
+  const n = data.n_observations || 0;
+  const confidence = data.confidence || 'unknown';
+  // Sample-size gating: a high % off <3 flights (or an explicitly low-confidence
+  // model) shouldn't masquerade as a confident green badge. Demote to the muted
+  // treatment and carry the caveat in TEXT + SHAPE (dashed underline), never colour
+  // alone — per DESIGN.md "status never conveyed by color alone".
+  const lowData = n < 3 || confidence === 'low';
+
+  let color, bgColor;
+  if (lowData) {
+    color = 'var(--ua-muted)';
+    bgColor = 'rgba(100,116,139,.15)';
+  } else {
+    color = pct >= 75 ? 'var(--ua-green)' : pct >= 40 ? 'var(--ua-yellow)' : 'var(--ua-muted)';
+    bgColor = pct >= 75 ? 'rgba(34,197,94,.2)' : pct >= 40 ? 'rgba(234,179,8,.15)' : 'rgba(100,116,139,.15)';
+  }
   el.style.background = bgColor;
   el.style.color = color;
-  el.textContent = '⚡ Starlink ~' + pct + '%';
-  el.title = 'Confidence: ' + (data.confidence || 'unknown') + ' (' + (data.n_observations || 0) + ' observations)';
+  el.style.borderBottom = lowData ? '1px dashed currentColor' : '';
+  el.textContent = '⚡ Starlink likely ~' + pct + '%' + (lowData ? ' · low data' : '');
+  // Read as a statistical estimate, NOT a united.com verification for this date.
+  el.title = 'Statistical estimate from ' + n + ' past flights · ' + confidence
+    + ' confidence · not a guarantee for this date’s aircraft.';
 }
 
 // ═══ STATS ═══
@@ -5582,7 +5610,15 @@ function buildMyFlightCard(watched, td) {
       <div><span class="mf-label">Config</span><div class="mf-value">${escapeHtml(seatStr)}${isStar ? ' <span class="starlink-badge">⚡ Starlink Confirmed</span>' : ` <span class="starlink-badge starlink-predict" data-flight="${escapeHtml(flightNum)}" style="background:rgba(100,116,139,.15);color:var(--ua-muted)">⚡ Checking…</span>`}</div></div>
     </div>`;
   } else if (td && td.aircraft) {
-    equipHtml = `<div><span class="mf-label">Aircraft</span><div class="mf-value">${escapeHtml(td.aircraft)}</div></div>`;
+    // No resolvable tail here (e.g. future-dated lookups): we know the route but not
+    // the metal, so STARLINK_TAILS can't confirm and a route base-rate is the right
+    // signal. Surface a statistical forecast badge instead of leaving Starlink blank.
+    // data-mode="forecast" routes it to the date-agnostic predict-flight model in
+    // fetchStarlinkPredictions(); it hides itself if the model has no useful estimate.
+    const forecastBadge = (flightNum && flightNum !== 'N/A')
+      ? ` <span class="starlink-badge starlink-predict" data-flight="${escapeHtml(flightNum)}" data-mode="forecast" style="background:rgba(100,116,139,.15);color:var(--ua-muted)">⚡ Checking…</span>`
+      : '';
+    equipHtml = `<div><span class="mf-label">Aircraft</span><div class="mf-value">${escapeHtml(td.aircraft)}${forecastBadge}</div></div>`;
   }
 
   // Inbound aircraft tracking + journey chain


### PR DESCRIPTION
## What

Wires the deployed-but-unused `api/predict-flight` proxy (upstream's real `flight_history_smoothed` model → `{probability, confidence, n_observations, method}`) into a **new forecast-badge path** — and ONLY into the case it's statistically correct for.

**Key insight:** the existing `.starlink-predict` badges (map popup; My Flight equipment block) fire when the **airframe is already resolved** — there a route base-rate is the *wrong* signal because we already know the metal. predict-flight's correct home is the **opposite** case: a flight number looked up with **no resolvable tail** (e.g. future-dated My Flight lookups) where BB currently shows a plain aircraft type and nothing for Starlink. This PR fills that blank only.

## How — two-source resolver

- **Tail resolvable** → deterministic behavior unchanged. `STARLINK_TAILS` membership → "⚡ STARLINK CONFIRMED". The existing tail-known `.starlink-predict` badges (map popup line ~1283; My Flight `reg && FLEET_BY_REG[reg]` branch) stay on their current `/api/check-flight` path. **No predict-flight wired here.**
- **No tail resolvable** → the My Flight equipment block's `else if (td && td.aircraft)` branch (plain aircraft type, no reg) now emits `<span class="starlink-badge starlink-predict" data-flight="…" data-mode="forecast">⚡ Checking…</span>` instead of leaving Starlink blank.
- **`fetchStarlinkPredictions()`** routes `data-mode="forecast"` badges to `/api/predict-flight?flight_number=<f>` — **date param dropped** (the model is date-agnostic; cached by flight-number only). Tail-known badges keep their date-scoped check-flight path untouched.
- **`applyStarlinkPrediction()`**: hides when `pct < 5`; low-data gating (`n_observations < 3` OR `confidence === 'low'`) demotes to a muted treatment carried by **text** (`· low data`) + **shape** (dashed underline), never colour alone (DESIGN.md); label `⚡ Starlink likely ~N%`; tooltip reads as a statistical estimate ("Statistical estimate from N past flights · {confidence} confidence · not a guarantee for this date's aircraft."), not a united.com verification.

Reuses the existing `.starlink-badge` component and the green≥75 / yellow≥40 / muted thresholds. **No new colors, fonts, endpoints, or routes** (`api/predict-flight.ts` is unmodified; already routed in `vercel.json`).

## Scope boundaries honored

- `api/predict-flight.ts` **not modified**.
- The separate `api/check-flight.ts` schema-drift bug is **out of scope** — existing tail-known badges are left on that path as-is.
- Forecast badge added **only** in the My Flight equipment block (not the map popup, per spec).

## Caveats / risks

- `applyStarlinkPrediction()` is shared by both paths, so the new label/tooltip/low-data treatment now also applies to the legacy tail-known check-flight badges (label "⚡ Starlink ~N%" → "⚡ Starlink likely ~N%", richer tooltip). This is intentional per spec ("near drop-in; Add: …") and is an improvement, but it is a visible change to that existing surface.
- The fully-unknown equipment case (no `reg` AND no `td.aircraft`) is intentionally left blank — no aircraft context to attach a lone badge to.
- predict-flight's upstream is "dead-but-deployed"; on a 502/empty response the badge fetch returns null and the badge `display:none`s itself (degraded-tier graceful hide). No live end-to-end probability verification was possible in this environment.
- No new unit test added: this is a frontend-only change in `src/dashboard/main.js` (a browser bundle with no existing unit-test harness for these functions); `api/predict-flight.ts` is unchanged and its existing suite still passes. Coverage relies on typecheck + `build:dashboard` (catches JS errors) + the full vitest suite.

## Test evidence

- `bun run typecheck` (`tsc --noEmit`) — **PASS** (exit 0)
- `bun run test` (`vitest run`) — **PASS** — 50 files, 703 tests, incl. unchanged `predict-flight.test.js`
- `bun run build:dashboard` (`vite build`) — **PASS** — bundled `public/js/dashboard.js` 233 kB

**⚠️ merge = deploy to prod — review before merging**

🤖 Generated with [Claude Code](https://claude.com/claude-code)