### PR TITLE
feat(starlink): industry Starlink-coverage strip (UA vs HA vs AS)

### DIFF
--- a/api/fleet-summary.ts
+++ b/api/fleet-summary.ts
@@ -1,0 +1,84 @@
+// Thin proxy for the upstream industry fleet-summary endpoint.
+// Wraps unitedstarlinktracker.com/api/fleet-summary and serves its
+// { airlines: [{ code, name, installed, total, percentage }], generatedAt }
+// payload to the dashboard's "Starlink coverage by airline" strip.
+//
+// Cloned from api/check-flight.ts minus the flight-number normalization: this
+// endpoint takes no parameters. GET-only, origin-locked to theblueboard.co /
+// localhost, IP rate-limited, ~4s upstream abort, and a single shared 5-minute
+// positive cache that matches upstream's max-age=300. On any failure it returns
+// 502 — the client treats a non-200 as "no data" and simply hides the strip.
+
+import type { VercelRequest, VercelResponse } from './types.js';
+import { createRateLimiter } from './_rate-limit.js';
+
+const UPSTREAM_URL = 'https://unitedstarlinktracker.com/api/fleet-summary';
+const isRateLimited = createRateLimiter('fleet-summary', 20);
+
+// Single-key positive cache: the upstream payload is identical for every caller,
+// so one shared 5-minute entry (matching upstream's max-age=300) is enough.
+let cache: { data: unknown; ts: number } | null = null;
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+// Negative cache: short-circuit subsequent requests for NEGATIVE_TTL ms after an
+// upstream connection failure so we don't burn function-seconds on a dead host.
+const NEGATIVE_TTL = 60 * 1000;
+let upstreamUnhealthyUntil = 0;
+
+// Test-only: reset module-level state. Imported by tests/fleet-summary.test.js.
+export function _resetCacheForTest(): void {
+  cache = null;
+  upstreamUnhealthyUntil = 0;
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const origin = req.headers.origin as string | undefined;
+  if (origin && origin !== 'https://theblueboard.co' && !/^http:\/\/localhost(:\d+)?$/.test(origin)) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  res.setHeader('Access-Control-Allow-Origin', origin || 'https://theblueboard.co');
+
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    if (isRateLimited(req)) {
+      return res.status(429).json({ error: 'Too many requests' });
+    }
+
+    if (cache && Date.now() - cache.ts < CACHE_TTL) {
+      res.setHeader('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=60');
+      return res.status(200).json(cache.data);
+    }
+
+    if (Date.now() < upstreamUnhealthyUntil) {
+      return res.status(502).json({ error: 'Fleet summary service unavailable' });
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 4000);
+
+    const resp = await fetch(UPSTREAM_URL, {
+      signal: controller.signal,
+      headers: { 'User-Agent': 'BlueBoard-FleetSummary/1.0' },
+    });
+    clearTimeout(timeout);
+
+    if (!resp.ok) {
+      return res.status(resp.status).json({ error: `Upstream returned ${resp.status}` });
+    }
+
+    const data = await resp.json();
+
+    upstreamUnhealthyUntil = 0;
+    cache = { data, ts: Date.now() };
+
+    res.setHeader('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=60');
+    return res.status(200).json(data);
+  } catch (err: any) {
+    upstreamUnhealthyUntil = Date.now() + NEGATIVE_TTL;
+    console.error('Fleet-summary error:', err);
+    return res.status(502).json({ error: 'Fleet summary service unavailable' });
+  }
+}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -470,6 +470,11 @@ tbody td{padding:5px 8px;white-space:nowrap}
 .sl-bar-fill{height:100%;border-radius:3px;width:0;transition:width .5s ease}
 .sl-bar-fill-express{background:var(--ua-green)}
 .sl-bar-fill-mainline{background:var(--ua-accent)}
+/* Industry coverage strip: United is the amber home team, competitors muted. */
+.sl-bar-fill-ua{background:var(--ua-amber)}
+.sl-bar-fill-muted{background:var(--ua-dim)}
+.sl-bar-label-ua{color:var(--ua-amber);font-weight:600}
+.sl-industry{margin-bottom:14px}
 .sl-bar-val{color:var(--ua-text);text-align:right;white-space:nowrap}
 .sl-hero-chips{display:flex;flex-direction:column;gap:8px;align-items:flex-end}
 .sl-chip{display:inline-flex;align-items:center;gap:6px;font-family:var(--font-mono);font-size:10px;padding:4px 10px;border-radius:3px;white-space:nowrap}

--- a/public/index.html
+++ b/public/index.html
@@ -606,6 +606,10 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
       </div>
       <div class="sl-hero-chips" id="sl-hero-chips"></div>
     </div>
+    <div class="sl-industry" id="sl-industry" style="display:none">
+      <div class="sl-hero-label">Industry · Starlink Coverage</div>
+      <div class="sl-bars" id="sl-industry-bars"></div>
+    </div>
     <div class="sl-chart-card" id="sl-chart-card" style="display:none">
       <div class="sl-chart-label">Installation Velocity</div>
       <div class="sl-chart-sub" id="sl-chart-sub">Aircraft equipped per month</div>

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -55,6 +55,7 @@ let STARLINK_TAILS = new Set();
 let STARLINK_FLIGHTS_BY_TAIL = {};  // upcoming flights keyed by tail number
 let STARLINK_FLEET_STATS = null;    // { mainline, express, total }
 let STARLINK_LAST_UPDATED = null;   // ISO timestamp from upstream
+let STARLINK_INDUSTRY = null;       // [{ code, name, installed, total, percentage }] from /api/fleet-summary
 let pendingFleetDeepLinkFilter = null;
 
 // Build registration lookup
@@ -62,10 +63,13 @@ const FLEET_BY_REG = {};
 
 async function loadFleetData() {
   try {
-    // Fetch fleet + Starlink data in parallel (saves one network round trip)
-    const [fleetRes, starlinkResult] = await Promise.all([
+    // Fetch fleet + Starlink data + industry coverage in parallel (saves round trips).
+    // The industry fetch is non-blocking: any failure resolves to null and the
+    // "Starlink coverage by airline" strip simply doesn't render.
+    const [fleetRes, starlinkResult, industryResult] = await Promise.all([
       fetch('/data/fleet.json'),
-      fetch('/api/starlink-data').then(r => r.ok ? r.json() : null).catch(() => null)
+      fetch('/api/starlink-data').then(r => r.ok ? r.json() : null).catch(() => null),
+      fetch('/api/fleet-summary').then(r => r.ok ? r.json() : null).catch(() => null)
     ]);
     if (!fleetRes.ok) throw new Error('Fleet data load failed');
     FLEET_DB = await fleetRes.json();
@@ -87,6 +91,11 @@ async function loadFleetData() {
         STARLINK_DB = await starlinkRes.json();
       }
     }
+
+    // Industry coverage strip data (optional). renderSlIndustry() re-validates
+    // each row before painting, so we only need the array-or-null here.
+    STARLINK_INDUSTRY = (industryResult && Array.isArray(industryResult.airlines) && industryResult.airlines.length > 0)
+      ? industryResult.airlines : null;
   } catch (err) {
     console.error('Fleet data load error:', err);
     FLEET_DB = [];
@@ -2668,6 +2677,50 @@ function renderSlHero() {
     const ago = Math.round((Date.now() - new Date(STARLINK_LAST_UPDATED).getTime()) / 60000);
     document.getElementById('sl-updated').textContent = ago < 60 ? ('Updated ' + ago + 'm ago') : ago < 1440 ? ('Updated ' + Math.round(ago/60) + 'h ago') : ('Updated ' + Math.round(ago/1440) + 'd ago');
   }
+
+  renderSlIndustry();
+}
+
+// Industry strip: one thin coverage bar per carrier (UA vs competitors), sorted
+// descending. Reuses the hero's .sl-bar-* classes. United is the amber "home
+// team"; competitors are muted. Coverage = installed / tracked-fleet from upstream
+// (NOT full mainline). Hidden entirely unless every row has a finite percentage,
+// mirroring the degraded-tier guards elsewhere on this tab.
+function renderSlIndustry() {
+  const wrap = document.getElementById('sl-industry');
+  if (!wrap) return;
+  const barsEl = document.getElementById('sl-industry-bars');
+
+  const rows = STARLINK_INDUSTRY;
+  const finitePct = (r) => {
+    if (!r || r.percentage == null || r.percentage === '') return false;
+    const p = typeof r.percentage === 'string' ? parseFloat(r.percentage) : r.percentage;
+    return typeof p === 'number' && Number.isFinite(p);
+  };
+  if (!Array.isArray(rows) || rows.length === 0 || !rows.every(finitePct)) {
+    wrap.style.display = 'none';
+    if (barsEl) barsEl.innerHTML = '';
+    return;
+  }
+
+  const sorted = rows.slice().sort((a, b) => Number(b.percentage) - Number(a.percentage));
+  barsEl.innerHTML = sorted.map((r) => {
+    const code = escapeHtml(String(r.code || '').toUpperCase());
+    const isUA = String(r.code || '').toUpperCase() === 'UA';
+    const pctNum = Number(r.percentage);
+    const pct = Math.round(pctNum);
+    const width = Math.max(0, Math.min(100, pctNum));
+    const installed = Number.isFinite(Number(r.installed)) ? Number(r.installed) : '—';
+    const total = Number.isFinite(Number(r.total)) ? Number(r.total) : '—';
+    const fillCls = isUA ? 'sl-bar-fill-ua' : 'sl-bar-fill-muted';
+    const labelCls = isUA ? 'sl-bar-label sl-bar-label-ua' : 'sl-bar-label';
+    return '<div class="sl-bar-row">' +
+      '<span class="' + labelCls + '">' + code + '</span>' +
+      '<div class="sl-bar-track"><div class="sl-bar-fill ' + fillCls + '" style="width:' + width + '%"></div></div>' +
+      '<span class="sl-bar-val">' + installed + ' / ' + total + ' · ' + pct + '%</span>' +
+      '</div>';
+  }).join('');
+  wrap.style.display = '';
 }
 
 // The aircraft table. Every row toggles an inline expansion (one at a time).

--- a/tests/fleet-summary.test.js
+++ b/tests/fleet-summary.test.js
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import handler, { _resetCacheForTest } from '../api/fleet-summary.js';
+
+function createRes() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: null,
+    setHeader(name, value) { this.headers[name] = value; },
+    status(code) { this.statusCode = code; return this; },
+    json(payload) { this.body = payload; return this; },
+  };
+}
+
+function makeReq(overrides = {}) {
+  return {
+    method: 'GET',
+    headers: {},
+    query: {},
+    ...overrides,
+  };
+}
+
+const SAMPLE = {
+  airlines: [
+    { code: 'UA', name: 'United Airlines', installed: 400, total: 1782, percentage: 22.4 },
+    { code: 'HA', name: 'Hawaiian Airlines', installed: 42, total: 61, percentage: 68.9 },
+    { code: 'AS', name: 'Alaska Airlines', installed: 97, total: 346, percentage: 28 },
+  ],
+  generatedAt: '2026-06-14T00:00:00.000Z',
+};
+
+describe('fleet-summary API', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    _resetCacheForTest();
+  });
+
+  it('rejects non-GET requests', async () => {
+    const res = createRes();
+    await handler(makeReq({ method: 'POST' }), res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it('rejects a disallowed cross-origin request', async () => {
+    const res = createRes();
+    await handler(makeReq({ headers: { origin: 'https://evil.example' } }), res);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('allows the production origin and proxies the upstream payload through unchanged', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => SAMPLE,
+    });
+    const res = createRes();
+    await handler(makeReq({ headers: { origin: 'https://theblueboard.co' } }), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(SAMPLE);
+    expect(res.headers['Access-Control-Allow-Origin']).toBe('https://theblueboard.co');
+  });
+
+  it('allows a localhost origin', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, json: async () => SAMPLE });
+    const res = createRes();
+    await handler(makeReq({ headers: { origin: 'http://localhost:4321' } }), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['Access-Control-Allow-Origin']).toBe('http://localhost:4321');
+  });
+
+  it('sets the 5-minute cache-control header on success', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, json: async () => SAMPLE });
+    const res = createRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['Cache-Control']).toBe('public, s-maxage=300, stale-while-revalidate=60');
+  });
+
+  it('sends the correct User-Agent and hits the documented upstream URL', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, json: async () => SAMPLE });
+    const res = createRes();
+    await handler(makeReq(), res);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://unitedstarlinktracker.com/api/fleet-summary',
+      expect.objectContaining({ headers: { 'User-Agent': 'BlueBoard-FleetSummary/1.0' } })
+    );
+  });
+
+  it('serves a second request from cache without re-fetching upstream', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, json: async () => SAMPLE });
+    await handler(makeReq(), createRes());
+    const res2 = createRes();
+    await handler(makeReq(), res2);
+    expect(res2.statusCode).toBe(200);
+    expect(res2.body).toEqual(SAMPLE);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards upstream non-2xx status codes', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 503 });
+    const res = createRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(503);
+    expect(res.body.error).toMatch(/503/);
+  });
+
+  it('returns 502 on upstream connection failure (degraded — strip hides client-side)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+    const res = createRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(502);
+    expect(res.body.error).toMatch(/unavailable/);
+  });
+
+  it('short-circuits to 502 without re-fetching inside the negative-cache window', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+    await handler(makeReq(), createRes());
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    const res2 = createRes();
+    await handler(makeReq(), res2);
+    expect(res2.statusCode).toBe(502);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('probes upstream again once the negative-cache window expires', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch')
+        .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+        .mockResolvedValue({ ok: true, json: async () => SAMPLE });
+
+      await handler(makeReq(), createRes());
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(61 * 1000);
+
+      const resOk = createRes();
+      await handler(makeReq(), resOk);
+      expect(resOk.statusCode).toBe(200);
+      expect(resOk.body).toEqual(SAMPLE);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -28,6 +28,7 @@
         "api/starlink-data.ts": { "maxDuration": 20 },
         "api/predict-flight.ts": { "maxDuration": 15 },
         "api/check-flight.ts": { "maxDuration": 15 },
+        "api/fleet-summary.ts": { "maxDuration": 10 },
         "api/news-notify.ts": { "maxDuration": 15 },
         "api/tsa.ts": { "maxDuration": 30 },
         "api/cron/refresh-tsa.ts": { "maxDuration": 30 },


### PR DESCRIPTION
## What

Adds a compact horizontal **"Starlink coverage by airline"** strip to the STARLINK tab — three thin progress bars (UA / HA / AS), sorted descending by coverage %, placed **below `.sl-hero` and above `.sl-filters`**. Section label: `INDUSTRY · STARLINK COVERAGE`.

- **United is the amber home team** (`--ua-amber`); competitors muted (`--ua-dim`). Each row: carrier code + `installed / total · pct%`, JetBrains Mono.
- Reuses the existing hero bar classes (`.sl-bar-row` / `.sl-bar-track` / `.sl-bar-fill` / `.sl-bar-label` / `.sl-bar-val`). The fill-color classes were semantic (`-express`/`-mainline`), so I added two minimal variants — `.sl-bar-fill-ua` (amber) and `.sl-bar-fill-muted` — rather than reusing the wrong colors. The UA label also gets weight + amber so the home team isn't signalled by color alone (DESIGN.md rule).

## Why

United currently trails on coverage of the tracked fleet (live: UA 400/1782 ≈ 22%, HA 42/61 ≈ 69%, AS 97/346 ≈ 28%). The underdog framing is the point. Read-only, at-a-glance industry context next to United's own rollout band.

## How

- **`api/fleet-summary.ts`** — new thin proxy of `unitedstarlinktracker.com/api/fleet-summary`, cloned from the `check-flight` skeleton minus flight-number normalization. GET-only, origin-locked to `theblueboard.co`/localhost, IP rate-limited, ~4s `AbortController`, shared **5-min positive cache** (matches upstream `max-age=300`) + 60s negative cache. Route added to `vercel.json` (`maxDuration: 10`). On any failure → 502.
- **`loadFleetData()`** fetches `/api/fleet-summary` inside its existing `Promise.all`, **non-blocking** — `.catch(() => null)` so a failure never breaks the tab and the strip just doesn't render.
- **`renderSlIndustry()`** (called at the end of `renderSlHero()`) reads a new `STARLINK_INDUSTRY` global. Defensive render rule: only paints when `Array.isArray(airlines) && length > 0 && every row has a finite numeric percentage`; sorts desc; marks `code === "UA"` amber. Otherwise `display:none`.

## Honest caveats / risks

- **Metric is labelled "Starlink coverage" deliberately** — it's coverage of upstream's *tracked* fleet, **not** full mainline. Numbers move with upstream's denominator.
- No separate timestamp on the strip — it inherits the tab's existing freshness line.
- Degraded tier (`/api/starlink-data` static fallback) is unaffected: the strip hides gracefully whenever `/api/fleet-summary` returns non-200 or a malformed payload.
- `innerHTML` is built from numeric-coerced fields (`Number`/`Math`) plus the carrier `code` passed through `escapeHtml` — same safe pattern as the existing hero render.

## Strict scope (what this deliberately does NOT do)

One read-only 3-bar strip. **No** new tab, **no** drill-down, **no** competitor fleet tables or maps.

## Test evidence

- `bun run typecheck` (`tsc --noEmit`) — **pass, clean**
- `bun run test` (vitest) — **pass, 714/714 across 51 files** (incl. new `tests/fleet-summary.test.js`, 11 cases: origin lock, cache reuse, negative-cache short-circuit + expiry, degraded 502, header/UA assertions)
- `bun run build:dashboard` — **pass** (bundled `public/js/dashboard.js`, 233.7 kB)

**⚠️ merge = deploy to prod — review before merging**

🤖 Generated with [Claude Code](https://claude.com/claude-code)