### PR TITLE
feat(starlink): Install Pace — 12-week rollout-trend panel

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -537,11 +537,28 @@ tbody td{padding:5px 8px;white-space:nowrap}
 .sl-swatch-line{background:var(--ua-amber);height:2px;width:14px}
 .sl-chart-footnote{font-family:var(--font-mono);font-size:8px;color:var(--ua-dim);margin-top:8px}
 .sl-chart-footnote:empty{display:none}
+.sl-trend{background:linear-gradient(180deg,var(--ua-panel) 0%,rgba(17,26,39,.6) 100%);border:1px solid var(--ua-border);border-left:3px solid var(--ua-amber);border-radius:0 6px 6px 0;padding:16px 20px;margin-bottom:14px}
+.sl-trend-label{font-family:var(--font-mono);font-size:10px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;color:var(--ua-amber);margin-bottom:2px}
+.sl-trend-sub{font-family:var(--font-mono);font-size:9px;color:var(--ua-dim);margin-bottom:12px;text-transform:uppercase;letter-spacing:.5px}
+.sl-trend-bars{display:flex;align-items:flex-end;gap:4px;height:52px;margin-bottom:12px}
+.sl-trend-bar{flex:1;height:100%;display:flex;align-items:flex-end;background:var(--ua-border-subtle);border-radius:2px;overflow:hidden}
+.sl-trend-bar-fill{width:100%;background:var(--ua-amber);border-radius:2px 2px 0 0;transition:height .5s ease}
+.sl-trend-bar-capped{background:repeating-linear-gradient(45deg,var(--ua-amber),var(--ua-amber) 3px,rgba(196,163,90,.4) 3px,rgba(196,163,90,.4) 6px)}
+.sl-trend-stats{display:grid;grid-template-columns:repeat(3,1fr);gap:10px}
+.sl-trend-stat{background:var(--ua-panel-elevated);border:1px solid var(--ua-border);border-radius:4px;padding:8px 10px}
+.sl-trend-stat-featured{border-left:3px solid var(--ua-amber)}
+.sl-trend-stat-k{font-family:var(--font-mono);font-size:8px;text-transform:uppercase;letter-spacing:.5px;color:var(--ua-dim)}
+.sl-trend-stat-v{font-family:var(--font-mono);font-size:18px;font-weight:700;line-height:1.1;margin-top:2px;color:var(--ua-text)}
+.sl-trend-stat-featured .sl-trend-stat-v{color:var(--ua-amber)}
+.sl-trend-stat-note{font-family:var(--font-mono);font-size:8px;color:var(--ua-dim);margin-top:2px}
+.sl-trend-foot{font-family:var(--font-mono);font-size:8px;color:var(--ua-dim);margin-top:8px}
+.sl-trend-foot:empty{display:none}
 @media (max-width:600px){
   .sl-hero{grid-template-columns:1fr;gap:14px}
   .sl-hero-chips{flex-direction:row;align-items:flex-start;flex-wrap:wrap}
   .sl-meta-grid{grid-template-columns:repeat(2,1fr)}
   .sl-bar-row{grid-template-columns:56px 1fr 90px}
+  .sl-trend-stats{grid-template-columns:1fr}
 }
 
 /* Special Aircraft Badge & Tracker */

--- a/public/index.html
+++ b/public/index.html
@@ -612,6 +612,29 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
       <div class="sl-hero-label">Industry · Starlink Coverage</div>
       <div class="sl-bars" id="sl-industry-bars"></div>
     </div>
+    <div class="sl-trend" id="sl-trend" style="display:none">
+      <div class="sl-trend-label">Install Pace</div>
+      <div class="sl-trend-sub" id="sl-trend-sub">Weekly equipped · trailing 12 weeks</div>
+      <div class="sl-trend-bars" id="sl-trend-bars" role="img" aria-label="Weekly Starlink installs, trailing 12 weeks"></div>
+      <div class="sl-trend-stats">
+        <div class="sl-trend-stat">
+          <div class="sl-trend-stat-k">This Week</div>
+          <div class="sl-trend-stat-v" id="sl-trend-thisweek">—</div>
+          <div class="sl-trend-stat-note">in progress</div>
+        </div>
+        <div class="sl-trend-stat">
+          <div class="sl-trend-stat-k">Avg / Wk</div>
+          <div class="sl-trend-stat-v" id="sl-trend-pace">—</div>
+          <div class="sl-trend-stat-note" id="sl-trend-pace-note">8-wk trailing</div>
+        </div>
+        <div class="sl-trend-stat sl-trend-stat-featured">
+          <div class="sl-trend-stat-k">Express ETA</div>
+          <div class="sl-trend-stat-v" id="sl-trend-eta">—</div>
+          <div class="sl-trend-stat-note" id="sl-trend-eta-note">at current pace</div>
+        </div>
+      </div>
+      <div class="sl-trend-foot" id="sl-trend-foot"></div>
+    </div>
     <div class="sl-chart-card" id="sl-chart-card" style="display:none">
       <div class="sl-chart-label">Installation Velocity</div>
       <div class="sl-chart-sub" id="sl-chart-sub">Aircraft equipped per month</div>

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -4,7 +4,7 @@ import { formatDelayExplainFAAStatus, getScheduleRiskContext } from '../lib/dela
 import { getMetarStationForIata, INTL_AIRPORTS } from '../lib/airport-metadata.js';
 import { chunkMetarStationIds, normalizeMetarPayload } from '../lib/metar.js';
 import { categorizeFleetStatus, FLEET_HEALTH_CATEGORIES, FLEET_FAMILIES, normalizeWifi, WIFI_DISPLAY, sortFleetData, filterFleetData, parseFleetDeepLink, TAB_MAP, VALID_FLEET_VIEWS } from '../lib/fleet-utils.js';
-import { bucketInstallsByMonth } from '../lib/starlink-utils.js';
+import { bucketInstallsByMonth, computeInstallPace } from '../lib/starlink-utils.js';
 import { getFlightPopupMetrics } from '../lib/flight-popup.js';
 import { getScheduleFleetFamily } from '../lib/schedule-filters.js';
 import { getStartOfHubDay, getHubDayLabel } from '../lib/hubTz.js';
@@ -1125,7 +1125,7 @@ async function refreshFlights() {
     [updateMarkers, updateStats, updateHubStats, updateTicker].forEach(fn => { try { fn(); } catch(e) { console.error(fn.name + ':', e); } });
     try { if (document.getElementById('tab-myflight')?.classList.contains('active')) renderMyFlights(); } catch(e) { console.error('renderMyFlights:', e); }
     try { if (document.getElementById('tab-fleet')?.classList.contains('active')) updateLiveFleetPanel(); } catch(e) { console.error('updateLiveFleetPanel:', e); }
-    try { if (document.getElementById('tab-starlink')?.classList.contains('active') && slInitialized) { renderSlHero(); renderSlTable(); } } catch(e) { console.error('renderStarlinkTab:', e); }
+    try { if (document.getElementById('tab-starlink')?.classList.contains('active') && slInitialized) { renderSlHero(); renderSlTrend(); renderSlTable(); } } catch(e) { console.error('renderStarlinkTab:', e); }
     try { if (document.getElementById('tab-analytics')?.classList.contains('active')) updateAnalytics(); } catch(e) { console.error('updateAnalytics:', e); }
     // Handle deep link: ?flight=UA1234 on first load (also supports ?q= for SearchAction compatibility)
     if (!deepLinkHandled) {
@@ -2569,8 +2569,79 @@ function initStarlinkTab() {
     });
   }
   renderSlHero();
+  renderSlTrend();
   renderSlChart();
   renderSlTable();
+}
+
+// ═══ INSTALL PACE ═══
+// Compact rolling 12-week sparkline + 3-up readout (this week / 8-wk avg / Express ETA), built from
+// CSS divs (no chart library). Pace math + backfill clamp live in computeInstallPace (starlink-utils).
+// HONESTY: dateFound is a DETECTION date — ~121 tails share one backfill date — so this shows ROLLING
+// WEEKLY ADDS over a 12-week window (never an all-time cumulative cliff), clamps backfill spikes, and
+// frames the ETA as Express-fleet "at current pace …", never a commitment.
+function renderSlTrend() {
+  const card = document.getElementById('sl-trend');
+  if (!card) return;
+
+  const fs = STARLINK_FLEET_STATS;
+  // Express remaining drives the ETA. Mainline (much of which is widebody/retiring that may never get
+  // Starlink) is deliberately NOT used as the ETA denominator — see spec.
+  const expressRemaining = (fs && fs.expressTotal && fs.express != null)
+    ? Math.max(0, fs.expressTotal - fs.express) : null;
+  const pace = computeInstallPace(STARLINK_DB, new Date(),
+    expressRemaining != null ? { remaining: expressRemaining } : {});
+
+  // Degraded mode (static fallback carries no dateFound): hide the whole panel, same guard the
+  // rollout bars use — never render an empty/garbage panel.
+  if (pace.dated === 0) { card.style.display = 'none'; return; }
+  card.style.display = '';
+
+  // Sparkline: one vertical bar per ISO week (amber fill on a --ua-border-subtle track). Backfill
+  // weeks get a striped fill (texture, not color alone) + a tooltip note.
+  const barsEl = document.getElementById('sl-trend-bars');
+  barsEl.innerHTML = pace.weeks.map(w => {
+    const pct = w.barValue > 0 ? Math.max(3, Math.round((w.barValue / pace.peak) * 100)) : 0;
+    const tip = 'Week of ' + w.label + ' · ' + w.count + ' equipped' + (w.capped ? ' (backfill batch)' : '');
+    return '<div class="sl-trend-bar" title="' + escapeHtml(tip) + '">' +
+      '<div class="sl-trend-bar-fill' + (w.capped ? ' sl-trend-bar-capped' : '') + '" style="height:' + pct + '%"></div>' +
+      '</div>';
+  }).join('');
+
+  // Window subtitle: first → last week of the displayed range.
+  const subEl = document.getElementById('sl-trend-sub');
+  if (subEl && pace.weeks.length) {
+    subEl.textContent = 'Weekly equipped · ' + pace.weeks[0].label + ' – ' + pace.weeks[pace.weeks.length - 1].label;
+  }
+
+  // 3-up readout — counts/derived numbers are our own data, safe as textContent.
+  document.getElementById('sl-trend-thisweek').textContent = pace.thisWeek;
+  const paceStr = pace.pace >= 10 ? String(Math.round(pace.pace)) : String(Math.round(pace.pace * 10) / 10);
+  document.getElementById('sl-trend-pace').textContent = pace.pace > 0 ? '~' + paceStr : '—';
+  const paceNote = document.getElementById('sl-trend-pace-note');
+  if (paceNote) paceNote.textContent = pace.paceWeeks > 0 ? pace.paceWeeks + '-wk trailing' : 'no complete weeks';
+
+  // Featured amber ETA — Express-fleet, "at current pace", never a commitment. Drops to em-dash when
+  // pace or the Express denominator is unavailable.
+  const etaEl = document.getElementById('sl-trend-eta');
+  const etaNote = document.getElementById('sl-trend-eta-note');
+  if (pace.etaDate) {
+    const MON = ['JAN','FEB','MAR','APR','MAY','JUN','JUL','AUG','SEP','OCT','NOV','DEC'];
+    etaEl.textContent = '~' + MON[pace.etaDate.getUTCMonth()] + " '" + String(pace.etaDate.getUTCFullYear()).slice(2);
+    if (etaNote) etaNote.textContent = 'Express · at current pace';
+  } else {
+    etaEl.textContent = '—';
+    if (etaNote) etaNote.textContent = expressRemaining == null ? 'Express fleet n/a' : 'pace too low';
+  }
+
+  // Footnote: surface any backfill-clamped weeks so the spike never reads as a real surge.
+  const footEl = document.getElementById('sl-trend-foot');
+  if (footEl) {
+    const capped = pace.weeks.filter(w => w.capped);
+    footEl.textContent = capped.length
+      ? '* ' + capped.map(w => 'Week of ' + w.label + ' (' + w.count + ') is a backfill detection batch — bar clamped').join(' · ')
+      : '';
+  }
 }
 
 // ═══ INSTALLATION VELOCITY CHART ═══

--- a/src/lib/starlink-utils.js
+++ b/src/lib/starlink-utils.js
@@ -71,3 +71,103 @@ export function bucketInstallsByMonth(aircraft, nowDate = new Date()) {
 
   return { months, undated, total: aircraft.length };
 }
+
+const WEEK_MS = 7 * 86400000;
+const WEEK_LABEL_MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+// Monday-anchored ISO-week start (UTC midnight) for a millisecond timestamp.
+function isoWeekStartUTC(ms) {
+  const d = new Date(ms);
+  const dayOfWeek = (d.getUTCDay() + 6) % 7; // 0 = Mon … 6 = Sun
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()) - dayOfWeek * 86400000;
+}
+
+// 'MMM D' label for a week-start timestamp (UTC), e.g. 'Jun 9'.
+function weekStartLabel(ms) {
+  const d = new Date(ms);
+  return WEEK_LABEL_MONTHS[d.getUTCMonth()] + ' ' + d.getUTCDate();
+}
+
+/**
+ * Compute the rolling 12-week install-pace series for the STARLINK tab.
+ *
+ * IMPORTANT — data caveat baked into this function: `dateFound` is a *detection* date, not an
+ * install date. A large share of the fleet shares one upstream backfill date (e.g. ~121 tails on
+ * 2025-12-03), so any week can be a detection spike rather than a real install surge. We therefore:
+ *   - only ever look at the trailing 12-week window (never an all-time cumulative line);
+ *   - clamp the *bar height* of any week exceeding ~3× the trailing median to a ceiling and flag it
+ *     `capped` (a backfill batch), while preserving the true `count` for the tooltip;
+ *   - compute pace from the trailing COMPLETE weeks only (the current week is partial — detection
+ *     systematically under-reads it — so it is excluded from both pace and the average framing), and
+ *     clamp backfill weeks before averaging so one batch can't inflate the pace.
+ *
+ * @param {Array<{dateFound?: string}>} aircraft - entries from /api/starlink-data (STARLINK_DB)
+ * @param {Date} [nowDate] - "today"; the window ends at this (partial) ISO week
+ * @param {{remaining?: number, weeksWindow?: number, paceWindow?: number}} [opts]
+ *        remaining: aircraft still to equip (e.g. Express remaining) → drives etaWeeks/etaDate
+ * @returns {{
+ *   weeks: Array<{start: number, label: string, count: number, barValue: number, capped: boolean}>,
+ *   peak: number, thisWeek: number, pace: number, paceWeeks: number, dated: number,
+ *   remaining: (number|null), etaWeeks: (number|null), etaDate: (Date|null)
+ * }}
+ */
+export function computeInstallPace(aircraft, nowDate = new Date(), opts = {}) {
+  const weeksWindow = opts.weeksWindow || 12;
+  const paceWindow = opts.paceWindow || 8;
+  const empty = {
+    weeks: [], peak: 1, thisWeek: 0, pace: 0, paceWeeks: 0, dated: 0,
+    remaining: null, etaWeeks: null, etaDate: null,
+  };
+  if (!Array.isArray(aircraft) || aircraft.length === 0) return empty;
+
+  const currentWeekStart = isoWeekStartUTC(nowDate.getTime());
+
+  // Tally every dated aircraft into its ISO week (whole fleet — `dated` drives the degraded guard).
+  const counts = new Map(); // weekStart(ms) -> count
+  let dated = 0;
+  for (const a of aircraft) {
+    const raw = typeof a?.dateFound === 'string' ? a.dateFound.slice(0, 10) : '';
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(raw)) continue;
+    const t = Date.parse(raw);
+    if (isNaN(t)) continue;
+    dated++;
+    const ws = isoWeekStartUTC(t);
+    counts.set(ws, (counts.get(ws) || 0) + 1);
+  }
+  if (dated === 0) return empty;
+
+  // Window anchors: oldest → current (partial) week.
+  const starts = [];
+  for (let i = weeksWindow - 1; i >= 0; i--) starts.push(currentWeekStart - i * WEEK_MS);
+  const rawCounts = starts.map(s => counts.get(s) || 0);
+
+  // Backfill clamp ceiling = 3× the median of the non-zero COMPLETE weeks (exclude current partial).
+  const completeNonZero = rawCounts.slice(0, weeksWindow - 1).filter(c => c > 0).sort((a, b) => a - b);
+  const median = completeNonZero.length
+    ? completeNonZero[Math.floor((completeNonZero.length - 1) / 2)]
+    : 0;
+  const clampCeil = median > 0 ? median * 3 : Infinity;
+
+  const weeks = starts.map((s, i) => {
+    const count = rawCounts[i];
+    const capped = count > clampCeil;
+    return { start: s, label: weekStartLabel(s), count, barValue: capped ? clampCeil : count, capped };
+  });
+  const peak = Math.max(1, ...weeks.map(w => w.barValue));
+
+  // Pace: mean of the trailing `paceWindow` COMPLETE weeks, backfill-clamped.
+  const completeCounts = rawCounts.slice(0, weeksWindow - 1);
+  const trailing = completeCounts.slice(-paceWindow);
+  const trailingClamped = trailing.map(c => (clampCeil !== Infinity && c > clampCeil) ? clampCeil : c);
+  const paceWeeks = trailing.length;
+  const pace = paceWeeks ? trailingClamped.reduce((a, b) => a + b, 0) / paceWeeks : 0;
+
+  let remaining = null, etaWeeks = null, etaDate = null;
+  if (typeof opts.remaining === 'number' && opts.remaining > 0 && pace > 0) {
+    remaining = opts.remaining;
+    etaWeeks = Math.ceil(opts.remaining / pace);
+    etaDate = new Date(currentWeekStart + etaWeeks * WEEK_MS);
+  }
+
+  return { weeks, peak, thisWeek: rawCounts[weeksWindow - 1], pace, paceWeeks, dated, remaining, etaWeeks, etaDate };
+}

--- a/tests/starlink-utils.test.js
+++ b/tests/starlink-utils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { bucketInstallsByMonth } from '../src/lib/starlink-utils.js';
+import { bucketInstallsByMonth, computeInstallPace } from '../src/lib/starlink-utils.js';
 
 // Helper to build aircraft entries the way /api/starlink-data shapes them
 const ac = (dateFound, fleet = 'Express') => ({ tail: 'N1', fleet, type: 'ERJ-175', operator: 'SkyWest dba UAX', dateFound, wifi: 'Starlink' });
@@ -77,5 +77,80 @@ describe('bucketInstallsByMonth', () => {
 
     // continuous axis: Mar 2025 → May 2026 = 15 months
     expect(months).toHaveLength(15);
+  });
+});
+
+// dateFound-only aircraft entry (the only field computeInstallPace reads)
+const acw = (dateFound) => ({ tail: 'N1', fleet: 'Express', dateFound });
+
+describe('computeInstallPace', () => {
+  // Anchored so the current (partial) ISO week starts Mon 2026-05-25; `now` is the Wed of that week.
+  const NOW = new Date('2026-05-27T12:00:00Z');
+  // Helper: push n aircraft detected on a given date.
+  const build = (entries) => entries.flatMap(([date, n]) => Array.from({ length: n }, () => acw(date)));
+
+  it('returns exactly 12 trailing ISO weeks, zero-filled, with the current week last', () => {
+    const r = computeInstallPace([acw('2026-05-25')], NOW);
+    expect(r.weeks).toHaveLength(12);
+    expect(r.weeks[11].count).toBe(1);          // current partial week (Mon 2026-05-25)
+    expect(r.weeks[11].label).toBe('May 25');   // 'MMM D' label for the week start
+    expect(r.weeks[0].count).toBe(0);           // 11 weeks ago — zero-filled, not omitted
+    expect(r.thisWeek).toBe(1);
+  });
+
+  it('paces off the trailing 8 COMPLETE weeks and excludes the partial current week', () => {
+    const aircraft = build([
+      ['2026-03-30', 2], ['2026-04-06', 4], ['2026-04-20', 6], ['2026-04-27', 2],
+      ['2026-05-04', 4], ['2026-05-18', 6],   // trailing complete weeks (two weeks left at 0)
+      ['2026-05-25', 1],                       // current partial week — excluded from pace
+    ]);
+    const r = computeInstallPace(aircraft, NOW);
+    expect(r.thisWeek).toBe(1);
+    expect(r.paceWeeks).toBe(8);
+    expect(r.pace).toBe(3);                     // (2+4+0+6+2+4+0+6)/8, current week not counted
+    expect(r.peak).toBe(6);
+  });
+
+  it('clamps a backfill detection spike for the bar + pace but preserves the true count', () => {
+    const aircraft = build([
+      ['2026-03-30', 3], ['2026-04-06', 3], ['2026-04-13', 3], ['2026-04-20', 150], // backfill batch
+      ['2026-04-27', 3], ['2026-05-04', 3], ['2026-05-11', 3], ['2026-05-18', 3],
+    ]);
+    const r = computeInstallPace(aircraft, NOW);
+    const spike = r.weeks.find(w => w.count === 150);
+    expect(spike.capped).toBe(true);
+    expect(spike.barValue).toBe(9);             // clamped to 3× the trailing median (3) for bar height
+    expect(spike.count).toBe(150);              // true count survives for the tooltip
+    expect(r.pace).toBeCloseTo(3.75);           // clamped in the average too — one batch can't inflate pace
+  });
+
+  it('derives an Express-fleet ETA from remaining / pace', () => {
+    const aircraft = build([
+      ['2026-03-30', 2], ['2026-04-06', 4], ['2026-04-20', 6], ['2026-04-27', 2],
+      ['2026-05-04', 4], ['2026-05-18', 6], ['2026-05-25', 1],
+    ]);
+    const r = computeInstallPace(aircraft, NOW, { remaining: 30 });
+    expect(r.pace).toBe(3);
+    expect(r.remaining).toBe(30);
+    expect(r.etaWeeks).toBe(10);                // ceil(30 / 3)
+    expect(r.etaDate.toISOString().slice(0, 10)).toBe('2026-08-03'); // 10 weeks past Mon 2026-05-25
+  });
+
+  it('omits the ETA when no remaining is supplied or pace is zero', () => {
+    const aircraft = build([['2026-03-30', 2], ['2026-05-25', 1]]);
+    expect(computeInstallPace(aircraft, NOW).etaDate).toBeNull();              // no remaining
+    expect(computeInstallPace([acw('2026-05-25')], NOW, { remaining: 30 }).etaDate).toBeNull(); // pace 0
+  });
+
+  it('reports dated=0 and empty weeks in degraded mode (no parseable dateFound)', () => {
+    const r = computeInstallPace([acw(''), acw(undefined), acw('not-a-date')], NOW);
+    expect(r.dated).toBe(0);
+    expect(r.weeks).toEqual([]);
+    expect(r.pace).toBe(0);
+  });
+
+  it('returns the empty shape for empty/invalid input', () => {
+    expect(computeInstallPace([], NOW).dated).toBe(0);
+    expect(computeInstallPace(null, NOW).weeks).toEqual([]);
   });
 });


### PR DESCRIPTION
## What

Adds a compact **INSTALL PACE** panel to the STARLINK tab, between the rollout hero (`.sl-hero`) and the filter bar (`#sl-filters`). NOC-Console styling throughout (JetBrains Mono, existing `--ua-amber` / `--ua-border-subtle` tokens, amber-left feature border).

Three parts:
1. Section label **INSTALL PACE** (Section-Label style).
2. A **12-bar weekly-adds sparkline** built from CSS divs (no chart library) — one bar per ISO week, amber fill on a `--ua-border-subtle` track, reusing the hero rollout-bar visual language. Each bar has a `title` tooltip "Week of MMM D · N equipped".
3. A **3-up readout**: `This week N` (point-in-time, partial), `Avg/wk ~X` (8-wk trailing), and a featured amber **Express ETA**.

New `renderSlTrend()` sits beside `renderSlHero()`, called from `initStarlinkTab()` (after the hero) and from the periodic re-render hook. Pace math lives in a new pure `computeInstallPace()` in `src/lib/starlink-utils.js`, unit-tested in `tests/starlink-utils.test.js`.

## Why / honesty (this is the important part)

`dateFound` is a **detection** date, not an install date — ~121/400 tails share one upstream backfill date (2025-12-03). So:

- **No all-time cumulative-from-zero line** (it would show a false ~30% cliff). This panel shows **rolling weekly adds over the recent 12-week window only**.
- Any week exceeding **~3× the trailing median** is **clamped to the bar ceiling** with a striped fill (texture, not color alone) + a "backfill batch" tooltip/footnote. The **true count is preserved** for the tooltip — it just can't dominate the bar scale or the average.
- **Pace = mean of the trailing 8 COMPLETE weeks.** The partial current week is excluded from both the average and the "This week" framing, because detection systematically under-reads the current week.
- **ETA is reframed off the Express fleet** (`Express remaining / pace`), labelled **"at current pace …"** — never "100% of 1782" (mainline is only ~6% and much of 1782 is widebody/retiring that may never get Starlink). It drops to an em-dash when pace is zero or the Express denominator is unavailable — never a commitment.
- Mild overlap with the hero "+N NEW THIS WEEK" chip is intentional: the chip stays the point-in-time number; this panel adds temporal history + ETA.

## Degraded tier

The static `/api/starlink-data` fallback carries no `dateFound`. `renderSlTrend()` hides the whole panel (`display:none`) when no aircraft have a parseable `dateFound`, mirroring the existing rollout-bars / velocity-chart guard. The markup ships `style="display:none"` so nothing flashes pre-JS.

## Scope

Frontend + one pure util only. No new serverless function, no API/CORS changes, no new fonts/colors/libraries. ~17 lines of scoped CSS reusing existing tokens. The existing monthly Installation Velocity chart is untouched.

## Caveats / risks

- The Express ETA depends on `STARLINK_FLEET_STATS.expressTotal`/`express`; if those are absent the ETA box shows `—` with an "Express fleet n/a" note (panel still renders the sparkline + this-week/avg).
- The 3× trailing-median clamp is a heuristic; in an unusually spiky-but-real period it could clamp a genuine surge. It is conservative by design (honesty over flattery) and the true count remains in the tooltip + footnote.
- ISO weeks are Monday-anchored in UTC; week labels are "MMM D" of the UTC week start.

## Test evidence

- `bun run typecheck` (`tsc --noEmit`) — **pass, clean**.
- `bun run test` (vitest, the repo's canonical command) — **pass: 50 files / 710 tests**, including 7 new `computeInstallPace` cases (12-week zero-fill, pace excludes partial week, backfill clamp preserves true count, Express ETA from remaining/pace, ETA omitted when no remaining/zero pace, degraded `dated=0`, empty input).
- `bun run build:dashboard` (vite bundle of `src/dashboard/main.js`) — **pass, built clean**.

**⚠️ merge = deploy to prod — review before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)