### PR TITLE
feat(starlink): verification ledger panel + render-time integrity tripwire

### DIFF
--- a/api/starlink-mismatches.ts
+++ b/api/starlink-mismatches.ts
@@ -1,0 +1,161 @@
+// Proxy endpoint for the unitedstarlinktracker.com verification ledger.
+//
+// Upstream /api/mismatches tracks community-spreadsheet Starlink claims that
+// official united.com verification OVERRULED. These tails are ALREADY EXCLUDED
+// from the ~400 served by /api/data, so this endpoint is a data-integrity record
+// of "claims we (and upstream) deliberately do NOT serve" — not a correction to
+// the main fleet count.
+//
+// Upstream sends `Cache-Control: no-store`, so we keep a long in-memory cache
+// (45 min) to avoid hammering it every time a visitor opens the STARLINK tab.
+// Mirrors the api/check-flight.ts skeleton: GET-only, origin-locked, IP rate
+// limited, ~4s AbortController, negative cache on connection failure.
+
+import type { VercelRequest, VercelResponse } from './types.js';
+import { createRateLimiter } from './_rate-limit.js';
+import { normalizeType, normalizeOperator } from './_starlink-normalize.js';
+
+const UPSTREAM_URL = 'https://unitedstarlinktracker.com/api/mismatches';
+const isRateLimited = createRateLimiter('starlink-mismatches', 20);
+
+const CACHE_TTL = 45 * 60 * 1000; // 45 min — upstream is no-store; the ledger changes slowly.
+const NEGATIVE_TTL = 60 * 1000;   // short-circuit window after a connection failure.
+
+interface DisputedRow {
+  tail: string;        // normalised (trimmed + upper-cased) registration
+  aircraft: string;    // normalizeType()
+  operator: string;    // normalizeOperator()
+  verifiedAs: string;  // what official verification found instead (e.g. "Viasat", "Thales")
+  verifiedAt: string;  // ISO 8601 or ''
+  dateFound: string;   // original community sighting date (YYYY-MM-DD) or ''
+}
+
+interface VerifySummary {
+  verifiedStarlink: number;
+  disputed: number;
+  unverified: number;
+  totalPlanes: number;
+  generatedAt: string; // ISO 8601
+}
+
+interface AdaptedResponse {
+  summary: VerifySummary;
+  disputed: DisputedRow[];
+}
+
+let cache: { data: AdaptedResponse; ts: number } | null = null;
+let upstreamUnhealthyUntil = 0;
+
+// Test-only: reset module-level state. Imported by tests/starlink-mismatches.test.js.
+export function _resetCacheForTest(): void {
+  cache = null;
+  upstreamUnhealthyUntil = 0;
+}
+
+function num(v: unknown): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function str(v: unknown): string {
+  return v == null ? '' : String(v).trim();
+}
+
+// Accept an upstream epoch (seconds or ms) or an ISO/date string; emit an ISO string or ''.
+function toIso(v: unknown): string {
+  if (v == null || v === '') return '';
+  if (typeof v === 'number' && Number.isFinite(v) && v > 0) {
+    const sec = v > 1e12 ? Math.round(v / 1000) : Math.round(v);
+    return new Date(sec * 1000).toISOString();
+  }
+  const ms = Date.parse(String(v));
+  return Number.isFinite(ms) ? new Date(ms).toISOString() : '';
+}
+
+// Adapt the (loosely documented) upstream payload into our stable contract. Tolerant of missing
+// fields and of several plausible key spellings: every field defaults rather than throws, so a
+// shape drift degrades to an empty/partial ledger (hidden panel) instead of a 502.
+function adapt(u: any): AdaptedResponse {
+  const rawList: any[] =
+    Array.isArray(u?.disputed) ? u.disputed
+    : Array.isArray(u?.mismatches) ? u.mismatches
+    : Array.isArray(u?.planes) ? u.planes
+    : Array.isArray(u) ? u
+    : [];
+
+  const disputed: DisputedRow[] = rawList
+    .map((r) => ({
+      tail: str(r?.tail ?? r?.TailNumber ?? r?.tail_number).toUpperCase(),
+      aircraft: normalizeType(r?.aircraft ?? r?.Aircraft ?? r?.aircraft_type),
+      operator: normalizeOperator(r?.operator ?? r?.OperatedBy ?? r?.operated_by),
+      verifiedAs: str(r?.verifiedAs ?? r?.verified_as ?? r?.VerifiedAs) || 'Not Starlink',
+      verifiedAt: toIso(r?.verifiedAt ?? r?.verified_at ?? r?.VerifiedAt),
+      dateFound: str(r?.dateFound ?? r?.DateFound ?? r?.date_found),
+    }))
+    .filter((d) => d.tail);
+
+  const s = u?.summary ?? u?.stats ?? {};
+  const summary: VerifySummary = {
+    verifiedStarlink: num(s?.verifiedStarlink ?? s?.verified_starlink ?? s?.verified),
+    disputed: num(s?.disputed ?? s?.disputed_count) || disputed.length,
+    unverified: num(s?.unverified ?? s?.unverified_count),
+    totalPlanes: num(s?.totalPlanes ?? s?.total_planes ?? s?.total),
+    generatedAt: toIso(s?.generatedAt ?? s?.generated_at ?? u?.generatedAt) || new Date().toISOString(),
+  };
+
+  return { summary, disputed };
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const origin = req.headers.origin as string | undefined;
+  if (origin && origin !== 'https://theblueboard.co' && !/^http:\/\/localhost(:\d+)?$/.test(origin)) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  res.setHeader('Access-Control-Allow-Origin', origin || 'https://theblueboard.co');
+
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    // Rate limit before the cache lookup so the endpoint's per-IP cost is bounded even on hits.
+    if (isRateLimited(req)) {
+      return res.status(429).json({ error: 'Too many requests' });
+    }
+
+    if (cache && Date.now() - cache.ts < CACHE_TTL) {
+      res.setHeader('Cache-Control', 'public, s-maxage=2700, stale-while-revalidate=600');
+      return res.status(200).json(cache.data);
+    }
+
+    // Don't re-attempt a known-dead host inside the negative-cache window.
+    if (Date.now() < upstreamUnhealthyUntil) {
+      return res.status(502).json({ error: 'Mismatch service unavailable' });
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 4000);
+
+    const resp = await fetch(UPSTREAM_URL, {
+      signal: controller.signal,
+      headers: { 'User-Agent': 'BlueBoard-StarlinkMismatches/1.0' },
+    });
+    clearTimeout(timeout);
+
+    if (!resp.ok) {
+      return res.status(resp.status).json({ error: `Upstream returned ${resp.status}` });
+    }
+
+    const adapted = adapt(await resp.json());
+
+    upstreamUnhealthyUntil = 0;
+    cache = { data: adapted, ts: Date.now() };
+
+    res.setHeader('Cache-Control', 'public, s-maxage=2700, stale-while-revalidate=600');
+    return res.status(200).json(adapted);
+  } catch (err: any) {
+    upstreamUnhealthyUntil = Date.now() + NEGATIVE_TTL;
+    console.error('Starlink-mismatches error:', err);
+    return res.status(502).json({ error: 'Mismatch service unavailable' });
+  }
+}

--- a/api/starlink-mismatches.ts
+++ b/api/starlink-mismatches.ts
@@ -97,7 +97,7 @@ function adapt(u: any): AdaptedResponse {
   const s = u?.summary ?? u?.stats ?? {};
   const summary: VerifySummary = {
     verifiedStarlink: num(s?.verifiedStarlink ?? s?.verified_starlink ?? s?.verified),
-    disputed: num(s?.disputed ?? s?.disputed_count) || disputed.length,
+    disputed: num(s?.disputed ?? s?.disputed_count ?? s?.mismatches_count) || disputed.length,
     unverified: num(s?.unverified ?? s?.unverified_count),
     totalPlanes: num(s?.totalPlanes ?? s?.total_planes ?? s?.total),
     generatedAt: toIso(s?.generatedAt ?? s?.generated_at ?? u?.generatedAt) || new Date().toISOString(),

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -553,12 +553,46 @@ tbody td{padding:5px 8px;white-space:nowrap}
 .sl-trend-stat-note{font-family:var(--font-mono);font-size:8px;color:var(--ua-dim);margin-top:2px}
 .sl-trend-foot{font-family:var(--font-mono);font-size:8px;color:var(--ua-dim);margin-top:8px}
 .sl-trend-foot:empty{display:none}
+/* ═══ VERIFICATION LEDGER ═══ */
+.sl-hero-verify-sub{font-family:var(--font-mono);font-size:9px;color:var(--ua-dim);letter-spacing:.3px;margin-top:5px}
+.sl-verify{margin-top:14px;background:linear-gradient(180deg,var(--ua-panel) 0%,rgba(17,26,39,.6) 100%);border:1px solid var(--ua-border);border-left:3px solid var(--ua-amber);border-radius:0 6px 6px 0;padding:16px 20px}
+.sl-verify-head{display:flex;justify-content:space-between;align-items:center;gap:16px;flex-wrap:wrap;margin-bottom:12px}
+.sl-verify-label{margin-bottom:0}
+.sl-verify-strip{display:flex;gap:10px;flex-wrap:wrap}
+.sl-verify-stat{background:var(--ua-panel-elevated);border:1px solid var(--ua-border);border-radius:4px;padding:6px 12px;text-align:center;min-width:74px}
+.sl-verify-stat-v{font-family:var(--font-mono);font-size:18px;font-weight:700;line-height:1;color:var(--ua-text)}
+.sl-verify-stat-ok{color:var(--ua-green)}
+.sl-verify-stat-bad{color:var(--ua-amber)}
+.sl-verify-stat-k{font-family:var(--font-mono);font-size:8px;text-transform:uppercase;letter-spacing:.5px;color:var(--ua-dim);margin-top:3px}
+.sl-verify-alert{display:flex;flex-direction:column;gap:4px;background:rgba(239,68,68,.1);border:1px solid rgba(239,68,68,.4);border-left:3px solid var(--ua-red);border-radius:0 4px 4px 0;padding:10px 12px;margin-bottom:12px}
+.sl-verify-alert-badge{font-family:var(--font-mono);font-size:10px;font-weight:700;letter-spacing:.5px;text-transform:uppercase;color:var(--ua-red)}
+.sl-verify-alert-text{font-family:var(--font-mono);font-size:11px;color:var(--ua-text);line-height:1.5}
+.sl-verify-details{border-top:1px solid var(--ua-border-subtle);padding-top:8px}
+.sl-verify-summary{font-family:var(--font-mono);font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.5px;color:var(--ua-text);cursor:pointer;padding:4px 0;list-style:none}
+.sl-verify-summary::-webkit-details-marker{display:none}
+.sl-verify-summary::before{content:'\25B8 ';color:var(--ua-amber)}
+.sl-verify-details[open] .sl-verify-summary::before{content:'\25BE '}
+.sl-verify-summary-hint{color:var(--ua-dim);font-weight:400;text-transform:none;letter-spacing:0}
+.sl-verify-note{font-family:var(--font-ui);font-size:11px;line-height:1.6;color:var(--ua-muted);margin:8px 0 12px;max-width:680px}
+.sl-verify-note strong{color:var(--ua-text)}
+.sl-verify-table{width:100%;border-collapse:collapse}
+.sl-verify-table th{font-family:var(--font-mono);font-size:9px;font-weight:600;text-transform:uppercase;letter-spacing:.5px;color:var(--ua-dim);text-align:left;padding:6px 10px;border-bottom:1px solid var(--ua-border)}
+.sl-verify-table td{font-family:var(--font-mono);font-size:11px;color:var(--ua-text);padding:7px 10px;border-bottom:1px solid var(--ua-border-subtle);vertical-align:middle}
+.sl-verify-badge{display:inline-block;font-family:var(--font-mono);font-size:8px;font-weight:700;text-transform:uppercase;letter-spacing:.5px;padding:1px 5px;border-radius:3px;background:rgba(239,68,68,.12);color:var(--ua-red);border:1px solid rgba(239,68,68,.3);margin-right:6px;vertical-align:middle}
+.sl-verify-transition{color:var(--ua-muted)}
+.sl-verify-arrow{color:var(--ua-dim)}
+.sl-verify-when{color:var(--ua-muted);font-size:10px}
+.sl-verify-empty{text-align:center;color:var(--ua-muted);padding:18px;font-size:11px}
+.sl-verify-dot{display:inline-flex;align-items:center;justify-content:center;width:13px;height:13px;border-radius:50%;background:var(--ua-red);color:#fff;font-family:var(--font-mono);font-size:9px;font-weight:700;line-height:1;vertical-align:middle;margin-left:6px}
 @media (max-width:600px){
   .sl-hero{grid-template-columns:1fr;gap:14px}
   .sl-hero-chips{flex-direction:row;align-items:flex-start;flex-wrap:wrap}
   .sl-meta-grid{grid-template-columns:repeat(2,1fr)}
   .sl-bar-row{grid-template-columns:56px 1fr 90px}
   .sl-trend-stats{grid-template-columns:1fr}
+  .sl-verify-head{flex-direction:column;align-items:flex-start;gap:10px}
+  .sl-verify-strip{width:100%}
+  .sl-verify-stat{flex:1}
 }
 
 /* Special Aircraft Badge & Tracker */

--- a/public/index.html
+++ b/public/index.html
@@ -601,6 +601,7 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
       <div class="sl-hero-left">
         <div class="sl-hero-num" id="sl-hero-count">—</div>
         <div class="sl-hero-sub">Aircraft Equipped</div>
+        <div class="sl-hero-verify-sub" id="sl-hero-verify-sub" style="display:none"></div>
       </div>
       <div class="sl-bars" id="sl-bars">
         <div class="sl-bar-row"><span class="sl-bar-label">Express</span><div class="sl-bar-track"><div class="sl-bar-fill sl-bar-fill-express" id="sl-bar-express"></div></div><span class="sl-bar-val" id="sl-bar-express-val"></span></div>
@@ -667,6 +668,32 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
         <tbody id="sl-tbody"><tr><td colspan="6" class="fleet-loading-text">Loading Starlink fleet…</td></tr></tbody>
       </table>
     </div>
+    <section id="sl-verification" class="sl-verify" aria-label="Starlink verification ledger" style="display:none">
+      <div class="sl-verify-head">
+        <div class="sl-hero-label sl-verify-label">Verification Ledger</div>
+        <div class="sl-verify-strip">
+          <div class="sl-verify-stat"><div class="sl-verify-stat-v sl-verify-stat-ok" id="sl-verify-verified">—</div><div class="sl-verify-stat-k">Verified Starlink</div></div>
+          <div class="sl-verify-stat"><div class="sl-verify-stat-v sl-verify-stat-bad" id="sl-verify-disputed">—</div><div class="sl-verify-stat-k">Disputed</div></div>
+          <div class="sl-verify-stat"><div class="sl-verify-stat-v" id="sl-verify-unverified">—</div><div class="sl-verify-stat-k">Unverified</div></div>
+        </div>
+      </div>
+      <div class="sl-verify-alert" id="sl-verify-alert" role="alert" style="display:none"></div>
+      <details class="sl-verify-details" open>
+        <summary class="sl-verify-summary">Disputed claims <span class="sl-verify-summary-hint">— overruled by official verification</span></summary>
+        <p class="sl-verify-note">These tails were claimed as Starlink in the community spreadsheet, but official united.com verification overruled the claim. Upstream <strong>already excludes</strong> them from the served fleet, so The Blue Board's equipped count is not affected. Verified equipment may be Viasat or Thales.</p>
+        <div class="fleet-table-wrap sl-verify-table-wrap">
+          <table class="sl-verify-table" aria-label="Disputed Starlink claims">
+            <thead><tr>
+              <th scope="col">Tail</th>
+              <th scope="col">Airframe</th>
+              <th scope="col">Verification</th>
+              <th scope="col">Verified</th>
+            </tr></thead>
+            <tbody id="sl-verify-tbody"></tbody>
+          </table>
+        </div>
+      </details>
+    </section>
     <div class="fleet-starlink-source" id="sl-source">Starlink data via <a href="https://unitedstarlinktracker.com" target="_blank" rel="noopener noreferrer" class="fleet-source-link">unitedstarlinktracker.com</a> · <span id="sl-updated" class="fleet-starlink-updated">live</span> · <span id="sl-count">—</span> aircraft</div>
   </div>
 </div>

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -1125,7 +1125,7 @@ async function refreshFlights() {
     [updateMarkers, updateStats, updateHubStats, updateTicker].forEach(fn => { try { fn(); } catch(e) { console.error(fn.name + ':', e); } });
     try { if (document.getElementById('tab-myflight')?.classList.contains('active')) renderMyFlights(); } catch(e) { console.error('renderMyFlights:', e); }
     try { if (document.getElementById('tab-fleet')?.classList.contains('active')) updateLiveFleetPanel(); } catch(e) { console.error('updateLiveFleetPanel:', e); }
-    try { if (document.getElementById('tab-starlink')?.classList.contains('active') && slInitialized) { renderSlHero(); renderSlTrend(); renderSlTable(); } } catch(e) { console.error('renderStarlinkTab:', e); }
+    try { if (document.getElementById('tab-starlink')?.classList.contains('active') && slInitialized) { renderSlHero(); renderSlTrend(); renderSlTable(); renderSlVerification(); } } catch(e) { console.error('renderStarlinkTab:', e); }
     try { if (document.getElementById('tab-analytics')?.classList.contains('active')) updateAnalytics(); } catch(e) { console.error('updateAnalytics:', e); }
     // Handle deep link: ?flight=UA1234 on first load (also supports ?q= for SearchAction compatibility)
     if (!deepLinkHandled) {
@@ -2547,6 +2547,12 @@ let slSortKey = 'tail', slSortAsc = true;
 let slInitialized = false;
 let slExpandedTail = null;   // tail of the one currently-expanded row (null = none)
 let slShowNewOnly = false;   // "★ New this week" quick filter
+// Verification Ledger: community-spreadsheet Starlink claims that official united.com verification
+// OVERRULED. Upstream already excludes these from the served fleet, so a disputed tail should never
+// appear in STARLINK_TAILS — see getServedConflictTails() for the render-time integrity tripwire.
+let STARLINK_DISPUTED = [];         // [{ tail, aircraft, operator, verifiedAs, verifiedAt, dateFound }]
+let STARLINK_VERIFY_SUMMARY = null; // { verifiedStarlink, disputed, unverified, totalPlanes, generatedAt }
+let slMismatchesFetched = false;    // one-shot fetch guard (the ledger changes slowly)
 
 // A plane counts as "newly equipped" if upstream first recorded its Starlink (DateFound) within the
 // last 7 days. Computed against the live clock so the badge ages out on its own.
@@ -2622,6 +2628,128 @@ function initStarlinkTab() {
   renderSlTrend();
   renderSlChart();
   renderSlTable();
+  fetchStarlinkMismatches(); // lazy/non-blocking; resolves into renderSlVerification()
+  renderSlVerification();    // reflect any already-loaded ledger on an idempotent re-open
+}
+
+// ═══ VERIFICATION LEDGER ═══
+// Fetches the disputed-claims ledger from /api/starlink-mismatches. Mirrors fetchStarlinkPredictions:
+// lazy, non-blocking, and a failure or empty list simply hides the panel — it never blocks the tab.
+function fetchStarlinkMismatches() {
+  if (slMismatchesFetched) return;
+  slMismatchesFetched = true;
+  fetch('/api/starlink-mismatches')
+    .then(r => r.ok ? r.json() : null)
+    .then(data => {
+      if (data && Array.isArray(data.disputed)) {
+        STARLINK_DISPUTED = data.disputed;
+        STARLINK_VERIFY_SUMMARY = data.summary || null;
+      } else {
+        STARLINK_DISPUTED = [];
+        STARLINK_VERIFY_SUMMARY = null;
+        slMismatchesFetched = false; // allow a retry on the next tab open
+      }
+      renderSlVerification();
+      renderSlTable(); // re-render rows so an integrity conflict can flag the offending tail
+    })
+    .catch(() => {
+      STARLINK_DISPUTED = [];
+      STARLINK_VERIFY_SUMMARY = null;
+      slMismatchesFetched = false;
+      renderSlVerification();
+    });
+}
+
+// Render-time integrity tripwire: disputed tails that upstream STILL serves in the equipped fleet.
+// Today this is empty (0 of the disputed set appear in STARLINK_TAILS), so the panel stays quiet.
+// If it ever becomes non-empty, renderSlVerification() raises an INTEGRITY ALERT and renderSlTable()
+// flags the offending rows.
+function getServedConflictTails() {
+  const set = new Set();
+  for (const d of STARLINK_DISPUTED) {
+    if (d && d.tail && STARLINK_TAILS.has(d.tail)) set.add(d.tail);
+  }
+  return set;
+}
+
+function formatVerifyDate(iso) {
+  const ms = Date.parse(iso);
+  if (isNaN(ms)) return '';
+  return new Date(ms).toLocaleDateString([], { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+// Stat strip + disputed table + the load-bearing integrity guard. Empty/failed ledger → hidden.
+function renderSlVerification() {
+  const section = document.getElementById('sl-verification');
+  if (!section) return;
+
+  const summary = STARLINK_VERIFY_SUMMARY;
+  const disputed = Array.isArray(STARLINK_DISPUTED) ? STARLINK_DISPUTED : [];
+  const subEl = document.getElementById('sl-hero-verify-sub');
+
+  // Degraded tier / fetch miss / empty ledger → hide the whole panel (mirrors other tab guards).
+  if (!summary && disputed.length === 0) {
+    section.style.display = 'none';
+    if (subEl) subEl.style.display = 'none';
+    return;
+  }
+  section.style.display = '';
+
+  // (1) Stat strip — verified / disputed / unverified from the summary.
+  const v = summary || {};
+  const disputedCount = (v.disputed != null) ? v.disputed : disputed.length;
+  document.getElementById('sl-verify-verified').textContent = (v.verifiedStarlink != null) ? v.verifiedStarlink : '—';
+  document.getElementById('sl-verify-disputed').textContent = disputedCount;
+  document.getElementById('sl-verify-unverified').textContent = (v.unverified != null) ? v.unverified : '—';
+
+  // Load-bearing guard.
+  const conflicts = getServedConflictTails();
+  const alertEl = document.getElementById('sl-verify-alert');
+  if (conflicts.size > 0) {
+    const tails = [...conflicts].map(escapeHtml).join(', ');
+    alertEl.innerHTML = '<span class="sl-verify-alert-badge">⚠ INTEGRITY ALERT</span>' +
+      '<span class="sl-verify-alert-text">' + conflicts.size + ' disputed ' +
+      (conflicts.size === 1 ? 'tail is' : 'tails are') +
+      ' still present in the served Starlink fleet: <strong>' + tails + '</strong>. ' +
+      'These were overruled by official verification and should be excluded — check the data pipeline.</span>';
+    alertEl.style.display = '';
+  } else {
+    alertEl.style.display = 'none';
+    alertEl.innerHTML = '';
+  }
+
+  // (2) Disputed table — Tail · Airframe · "DISPUTED Starlink → Viasat/Thales" · verified-when.
+  const tbody = document.getElementById('sl-verify-tbody');
+  if (disputed.length === 0) {
+    tbody.innerHTML = '<tr><td colspan="4" class="sl-verify-empty">No disputed claims on record.</td></tr>';
+  } else {
+    tbody.innerHTML = disputed.map(d => {
+      const tail = escapeHtml(d.tail || '');
+      const air = escapeHtml(d.aircraft || '—');
+      const verifiedAs = escapeHtml(d.verifiedAs || 'Not Starlink');
+      const when = d.verifiedAt ? escapeHtml(formatVerifyDate(d.verifiedAt)) : '—';
+      const conflictDot = conflicts.has(d.tail)
+        ? ' <span class="sl-verify-dot" title="Still served in the equipped fleet — integrity conflict">!</span>'
+        : '';
+      return '<tr>' +
+        '<td><span class="sl-tail">' + tail + '</span>' + conflictDot + '</td>' +
+        '<td>' + air + '</td>' +
+        '<td class="sl-verify-transition"><span class="sl-verify-badge">Disputed</span> Starlink <span class="sl-verify-arrow">→</span> ' + verifiedAs + '</td>' +
+        '<td class="sl-verify-when">' + when + '</td>' +
+        '</tr>';
+    }).join('');
+  }
+
+  // Optional muted hero sub-line — keeps the 397/disputed figures strictly inside this panel's
+  // context so they never overwrite the served count in the big hero number.
+  if (subEl) {
+    if (summary && summary.verifiedStarlink != null) {
+      subEl.textContent = summary.verifiedStarlink + ' verified · ' + disputedCount + ' disputed';
+      subEl.style.display = '';
+    } else {
+      subEl.style.display = 'none';
+    }
+  }
 }
 
 // ═══ INSTALL PACE ═══
@@ -2931,6 +3059,8 @@ function renderSlTable() {
   const liveMap = getStarlinkAirborneMap();
   const hasLive = allFlights.length > 0;
   const nowSec = Date.now() / 1000;
+  // Disputed-but-still-served tails (normally empty). Marked with a red integrity dot below.
+  const conflictTails = getServedConflictTails();
 
   // Hide the Status / Next Flight columns when the data behind them is unavailable (degraded modes)
   document.getElementById('sl-status-th').style.display = hasLive ? '' : 'none';
@@ -2968,8 +3098,9 @@ function renderSlTable() {
     }
 
     const newBadge = isRecentlyFound(s.dateFound) ? ` <span class="starlink-new-badge" title="Starlink equipment first seen ${escapeHtml(s.dateFound)}">NEW</span>` : '';
+    const conflictDot = conflictTails.has(s.tail) ? ` <span class="sl-verify-dot" title="Disputed by official verification — should not be served. See the Verification Ledger below.">!</span>` : '';
     rows.push(`<tr class="sl-row${expanded ? ' expanded' : ''}" data-action="sl-row-toggle" data-tail="${escapeHtml(s.tail)}" tabindex="0" role="button" aria-expanded="${expanded}">` +
-      `<td><span class="sl-tail">${escapeHtml(s.tail)}</span>${newBadge}</td>` +
+      `<td><span class="sl-tail">${escapeHtml(s.tail)}</span>${newBadge}${conflictDot}</td>` +
       `<td>${escapeHtml(s.fleet)}</td><td>${escapeHtml(s.type)}</td><td style="font-size:10px">${escapeHtml(s.operator)}</td>` +
       statusHtml + nextHtml + '</tr>');
 

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -2688,7 +2688,14 @@ function renderSlVerification() {
   const subEl = document.getElementById('sl-hero-verify-sub');
 
   // Degraded tier / fetch miss / empty ledger → hide the whole panel (mirrors other tab guards).
-  if (!summary && disputed.length === 0) {
+  // adapt() returns a truthy zero-filled summary on any HTTP 200, so a shape drift (upstream
+  // renames a field we don't recognise) would otherwise render a contradictory "0 / 0 / 0" panel
+  // and a "0 verified · 0 disputed" hero sub-line under the big 400. Treat "no meaningful data"
+  // (no disputed rows AND every summary counter zero/absent) as empty and hide.
+  const hasData = disputed.length > 0 || !!(summary && (
+    summary.verifiedStarlink || summary.disputed || summary.unverified || summary.totalPlanes
+  ));
+  if (!hasData) {
     section.style.display = 'none';
     if (subEl) subEl.style.display = 'none';
     return;

--- a/tests/starlink-mismatches.test.js
+++ b/tests/starlink-mismatches.test.js
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import handler, { _resetCacheForTest } from '../api/starlink-mismatches.js';
+
+function createRes() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: null,
+    setHeader(name, value) { this.headers[name] = value; },
+    status(code) { this.statusCode = code; return this; },
+    json(payload) { this.body = payload; return this; },
+  };
+}
+
+function makeReq(overrides = {}) {
+  return {
+    method: 'GET',
+    headers: {},
+    query: {},
+    ...overrides,
+  };
+}
+
+// Mirrors a plausible live upstream: a `summary` block + a `disputed` array with mixed casing on
+// operator/type and an epoch-seconds verifiedAt. verified_as is sometimes Thales, not only Viasat.
+function mockUpstreamResponse() {
+  return {
+    summary: { verifiedStarlink: 397, disputed: 2, unverified: 5, totalPlanes: 1781, generatedAt: '2026-06-14T00:00:00Z' },
+    disputed: [
+      { tail: 'n127sy', aircraft: 'Bombardier CRJ-550', operator: 'Skywest dba UAX', verifiedAs: 'Viasat', verifiedAt: 1780270800, dateFound: '2026-01-15' },
+      { tail: 'N830UA', aircraft: 'Boeing 737-824', operator: 'United Airlines', verifiedAs: 'Thales', verifiedAt: '2026-03-02T12:00:00Z', dateFound: '2026-02-01' },
+    ],
+  };
+}
+
+describe('starlink-mismatches API', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    _resetCacheForTest();
+  });
+
+  it('rejects non-GET requests', async () => {
+    const res = createRes();
+    await handler(makeReq({ method: 'POST' }), res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it('rejects a disallowed origin', async () => {
+    const res = createRes();
+    await handler(makeReq({ headers: { origin: 'https://evil.example' } }), res);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns 502 on upstream connection failure', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+    const res = createRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(502);
+    expect(res.body.error).toMatch(/unavailable/);
+  });
+
+  it('forwards upstream non-2xx status', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 503 });
+    const res = createRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(503);
+  });
+
+  it('adapts the upstream ledger into summary + normalized disputed rows', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => mockUpstreamResponse(),
+    });
+    const res = createRes();
+    await handler(makeReq(), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.summary.verifiedStarlink).toBe(397);
+    expect(res.body.summary.disputed).toBe(2);
+    expect(res.body.summary.unverified).toBe(5);
+    expect(res.body.summary.totalPlanes).toBe(1781);
+
+    expect(res.body.disputed).toHaveLength(2);
+    const [a, b] = res.body.disputed;
+    // tail upper-cased so it can be set-compared against the served STARLINK_TAILS
+    expect(a.tail).toBe('N127SY');
+    // type + operator normalized via the shared starlink normalizer
+    expect(a.aircraft).toBe('CRJ-550');
+    expect(a.operator).toBe('SkyWest dba UAX');
+    // epoch-seconds verifiedAt promoted to ISO
+    expect(a.verifiedAt).toBe(new Date(1780270800 * 1000).toISOString());
+    // verified_as carries Thales, not only Viasat
+    expect(b.verifiedAs).toBe('Thales');
+    expect(b.aircraft).toBe('737-800');
+  });
+
+  it('degrades to an empty ledger when fields are missing rather than throwing', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    });
+    const res = createRes();
+    await handler(makeReq(), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.disputed).toEqual([]);
+    expect(res.body.summary.verifiedStarlink).toBe(0);
+    expect(res.body.summary.disputed).toBe(0);
+    expect(typeof res.body.summary.generatedAt).toBe('string');
+  });
+
+  it('tolerates an alternate `mismatches` array key and partial rows', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ mismatches: [{ TailNumber: 'N999XY' }, { tail: '' }] }),
+    });
+    const res = createRes();
+    await handler(makeReq(), res);
+
+    expect(res.statusCode).toBe(200);
+    // blank tail is dropped; the partial row defaults its other fields
+    expect(res.body.disputed).toHaveLength(1);
+    expect(res.body.disputed[0].tail).toBe('N999XY');
+    expect(res.body.disputed[0].verifiedAs).toBe('Not Starlink');
+    expect(res.body.summary.disputed).toBe(1);
+  });
+
+  it('serves a cached result without a second upstream fetch', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => mockUpstreamResponse(),
+    });
+
+    await handler(makeReq(), createRes());
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    const res2 = createRes();
+    await handler(makeReq(), res2);
+    expect(res2.statusCode).toBe(200);
+    expect(res2.body.disputed).toHaveLength(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(res2.headers['Cache-Control']).toMatch(/s-maxage=2700/);
+  });
+
+  it('short-circuits to 502 inside the negative-cache window', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+
+    await handler(makeReq(), createRes());
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    const res2 = createRes();
+    await handler(makeReq(), res2);
+    expect(res2.statusCode).toBe(502);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends the correct User-Agent header to upstream', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => mockUpstreamResponse(),
+    });
+    await handler(makeReq(), createRes());
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/api/mismatches'),
+      expect.objectContaining({
+        headers: { 'User-Agent': 'BlueBoard-StarlinkMismatches/1.0' },
+      })
+    );
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -29,6 +29,7 @@
         "api/predict-flight.ts": { "maxDuration": 15 },
         "api/check-flight.ts": { "maxDuration": 15 },
         "api/fleet-summary.ts": { "maxDuration": 10 },
+        "api/starlink-mismatches.ts": { "maxDuration": 15 },
         "api/news-notify.ts": { "maxDuration": 15 },
         "api/tsa.ts": { "maxDuration": 30 },
         "api/cron/refresh-tsa.ts": { "maxDuration": 30 },


### PR DESCRIPTION
## What

Adds a **Verification Ledger** to the STARLINK tab — a data-integrity panel surfacing community-spreadsheet Starlink claims that official united.com verification **overruled**.

- **`api/starlink-mismatches.ts`** — new BB proxy over `unitedstarlinktracker.com/api/mismatches`, cloned from the `api/check-flight.ts` skeleton: GET-only, origin-locked to theblueboard.co/localhost, `createRateLimiter('starlink-mismatches', 20)`, ~4s `AbortController`, negative cache. Upstream sends `Cache-Control: no-store`, so we hold a **45-minute in-memory cache**. The adapter is deliberately tolerant — every field defaults, and several plausible upstream key spellings are accepted; a shape drift degrades to an empty/hidden panel rather than throwing a 502. Reuses `normalizeType`/`normalizeOperator` from `_starlink-normalize.ts`.
- **`vercel.json`** — route added with `maxDuration: 15`.
- **Frontend** — collapsible `<section id="sl-verification">` immediately after the aircraft table in `#tab-starlink`. New `fetchStarlinkMismatches()` (lazy/non-blocking, mirrors `fetchStarlinkPredictions`) populates `STARLINK_DISPUTED` + `STARLINK_VERIFY_SUMMARY`; `renderSlVerification()` is wired into the idempotent `initStarlinkTab()` and the 30s refresh cadence. Panel shows: (1) a VERIFIED STARLINK / DISPUTED / UNVERIFIED stat strip, (2) a disputed-tails table (Tail · Airframe · red **DISPUTED** badge `Starlink → Viasat/Thales` · verified-when), (3) explanatory copy that these are community claims upstream **already excludes** from the served fleet — so BB is not wrong. `verified_as` carries Thales, not only Viasat.

## Why — the load-bearing guard

At render time, `getServedConflictTails()` computes `STARLINK_DISPUTED ∩ STARLINK_TAILS`. **Today this is empty (0 disputed tails appear in the served array), so the panel is quiet.** If it ever becomes non-empty (upstream keeps a Viasat/Thales-verified tail in `starlinkPlanes`), the panel raises a red **INTEGRITY ALERT** and the offending rows in the main aircraft table get a red `!` integrity marker.

The hero's big served count (400) is **not** overwritten with `summary.verifiedStarlink` (397) — the two pipelines disagree by design. The 397/disputed figures appear only as an optional muted sub-line strictly inside this panel.

## Scope boundaries honored

- Does **not** pull in `verified_wifi`/`verified_at` from `/api/check-flight` (separate bug-fix, out of scope).
- Does **not** broaden the `/api/(.*)` CORS origin-lock.
- Degraded-tier safe: empty ledger / fetch failure / static fallback all hide the panel via `display:none`.

## Caveats / risks

- The exact upstream `/api/mismatches` field names were **not verified against the live endpoint**; the adapter is defensively tolerant of multiple key spellings (`disputed`/`mismatches`/`planes`, `tail`/`TailNumber`, `verifiedAs`/`verified_as`, etc.). If the live shape differs from all guesses, the panel degrades to hidden rather than erroring — worth a quick live check post-merge.
- Disputed-tail matching uppercases the tail before set-comparing against `STARLINK_TAILS` (United regs are already uppercase no-dash, matching how `_starlink-normalize.ts` trims them).

## Test evidence

- `bun run typecheck` — **pass** (clean `tsc --noEmit`).
- `bun run test` — **pass** (51 files, 713 tests; includes 10 new cases in `tests/starlink-mismatches.test.js` covering shape adaptation, missing-field degrade, alternate array key, cache hit, negative cache, origin lock, User-Agent).
- `bun run build:dashboard` — **pass** (bundles `src/dashboard/main.js`, 235 kB).

**⚠️ merge = deploy to prod — review before merging**

🤖 Generated with [Claude Code](https://claude.com/claude-code)