### PR TITLE
feat(starlink): airborne Starlink markers + map filter on LIVE OPS

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -118,6 +118,14 @@ main{display:contents}
 .ctrl-btn{background:linear-gradient(180deg,var(--ua-panel) 0%,rgba(17,26,39,.96) 100%);border:1px solid var(--ua-border);color:var(--ua-muted);padding:5px 10px;border-radius:6px;cursor:pointer;font-size:10px;font-family:var(--font-mono);transition:background-color .2s cubic-bezier(.4,0,.2,1),border-color .2s cubic-bezier(.4,0,.2,1),color .2s cubic-bezier(.4,0,.2,1),transform .15s cubic-bezier(.4,0,.2,1)}
 .ctrl-btn:hover{background:rgba(0,93,170,.3);border-color:var(--ua-blue)}
 .ctrl-btn.active{border-color:var(--ua-accent);color:var(--ua-accent)}
+/* Degraded tier: Starlink toggle disabled (no tails loaded) — greyed, no hover affordance */
+.ctrl-btn:disabled,.ctrl-btn.ctrl-btn-disabled{opacity:.4;cursor:not-allowed}
+.ctrl-btn:disabled:hover,.ctrl-btn.ctrl-btn-disabled:hover{background:linear-gradient(180deg,var(--ua-panel) 0%,rgba(17,26,39,.96) 100%);border-color:var(--ua-border);color:var(--ua-muted)}
+/* Map marker legend — one amber Starlink key, grouped under the control ladder. The dot
+   mirrors the marker's amber glow halo; the "Starlink" text means color is not the sole signal. */
+#map-legend{display:flex;align-items:center;gap:6px;margin-top:5px;padding:5px 10px;background:linear-gradient(180deg,var(--ua-panel) 0%,rgba(17,26,39,.96) 100%);border:1px solid var(--ua-border);border-radius:6px;font-size:10px;font-family:var(--font-mono);color:var(--ua-muted);text-transform:uppercase;letter-spacing:.5px;white-space:nowrap;pointer-events:none}
+.map-legend-dot{width:9px;height:9px;border-radius:50%;display:inline-block;flex-shrink:0}
+.map-legend-dot-starlink{background:#fbbf24;box-shadow:0 0 4px #fbbf24,0 0 7px rgba(251,191,36,.7)}
 #search-box{position:absolute;top:10px;left:10px;z-index:712}
 #search-input{background:rgba(10,14,20,.9);border:1px solid var(--ua-border);color:var(--ua-text);padding:7px 12px;border-radius:4px;font-family:var(--font-mono);font-size:11px;width:220px}
 #search-input:focus{border-color:var(--ua-accent)}
@@ -475,6 +483,10 @@ tbody td{padding:5px 8px;white-space:nowrap}
 .sl-chip{display:inline-flex;align-items:center;gap:6px;font-family:var(--font-mono);font-size:10px;padding:4px 10px;border-radius:3px;white-space:nowrap}
 .sl-chip-new{background:var(--ua-amber-soft);border:1px solid rgba(196,163,90,.25);color:var(--ua-amber)}
 .sl-chip-live{background:rgba(34,197,94,.1);border:1px solid rgba(34,197,94,.2);color:var(--ua-green)}
+/* Click-through chip → LIVE OPS map with the Starlink filter pre-enabled */
+.sl-chip-clickable{cursor:pointer;transition:background .15s ease,border-color .15s ease,transform .15s ease}
+.sl-chip-clickable:hover{background:rgba(34,197,94,.18);border-color:rgba(34,197,94,.45)}
+.sl-chip-clickable:active{transform:scale(.97)}
 .sl-filters{display:flex;gap:8px;margin-bottom:12px;flex-wrap:wrap;align-items:center}
 .sl-filters input,.sl-filters select{background:var(--ua-panel);color:var(--ua-text);border:1px solid var(--ua-border);padding:5px 10px;font-family:var(--font-mono);font-size:10px;border-radius:3px}
 .sl-new-toggle{background:var(--ua-panel);color:var(--ua-amber);border:1px solid rgba(196,163,90,.4);padding:5px 10px;font-family:var(--font-mono);font-size:10px;border-radius:3px;cursor:pointer;transition:background .15s ease,border-color .15s ease}
@@ -727,6 +739,8 @@ tbody td{padding:5px 8px;white-space:nowrap}
   #mobile-sidebar-toggle{display:flex!important;position:fixed;top:96px;left:12px;z-index:707;width:auto;margin:0}
   /* ── Map controls: expandable FAB + floating panel ── */
   #tab-live #controls{top:auto;bottom:70px;right:auto;left:12px;transform:none;display:flex;flex-direction:column;align-items:flex-start;gap:8px;z-index:712}
+  /* Legend lives in the desktop control ladder; the mobile controls collapse to a FAB, so hide it there (amber glow markers still convey the signal). */
+  #map-legend{display:none!important}
   #ctrl-panel{display:none;flex-direction:column;background:rgba(10,14,20,.95);border:1px solid var(--ua-border);border-radius:12px;padding:6px;gap:4px;box-shadow:0 4px 20px rgba(0,0,0,.5)}
   #controls.ctrl-menu-open #ctrl-panel{display:flex;animation:ctrlPanelIn .2s ease-out}
   #ctrl-panel .ctrl-btn{display:flex;padding:10px 14px;font-size:12px;min-height:40px;border-radius:8px;white-space:nowrap;background:rgba(30,41,59,.4);border-color:transparent}

--- a/public/index.html
+++ b/public/index.html
@@ -336,10 +336,12 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
         <div id="ctrl-panel" role="toolbar" aria-label="Map controls">
           <button class="ctrl-btn" data-action="toggle-hubs" id="btn-hubs" aria-pressed="false"><span aria-hidden="true">🏢</span> Hubs</button>
           <button class="ctrl-btn" data-action="toggle-longhaul" id="btn-longhaul" aria-pressed="false"><span aria-hidden="true">🌍</span> Long-haul</button>
+          <button class="ctrl-btn ctrl-btn-disabled" data-action="toggle-starlink-layer" id="btn-starlink" aria-pressed="false" disabled aria-disabled="true" title="Starlink data unavailable"><span aria-hidden="true">⚡</span> Starlink</button>
           <button class="ctrl-btn" data-action="toggle-weather" id="btn-wx" aria-pressed="false"><span aria-hidden="true">🌧</span> Weather</button>
           <button class="ctrl-btn" data-action="view-pacific" id="btn-pacific" aria-label="Pan to Pacific view"><span aria-hidden="true">🌏</span> Pacific</button>
           <button class="ctrl-btn" data-action="refresh-flights" id="btn-refresh" aria-label="Refresh flight data"><span aria-hidden="true">🔄</span> Refresh</button>
         </div>
+        <div id="map-legend" aria-label="Map marker legend" style="display:none"><span class="map-legend-dot map-legend-dot-starlink" aria-hidden="true"></span> Starlink</div>
         <button id="mobile-ctrl-toggle" aria-label="Map layers"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 2 10 5-10 5L2 7z"/><path d="m2 17 10 5 10-5"/><path d="m2 12 10 5 10-5"/></svg></button>
       </div>
     </div>

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -357,7 +357,7 @@ const IATA_CITIES = {
 
 // ═══ GLOBALS ═══
 let map, flightMarkers = {}, routeLine = null, routeGroup = null, hubMarkers = [], wxLayer = null;
-let allFlights = [], showHubs = true, showLonghaul = false, showWeather = false;
+let allFlights = [], showHubs = true, showLonghaul = false, showWeather = false, showStarlinkOnly = false;
 let activeHubFilter = null, activePhaseFilter = null;
 let refreshTimer = null, countdown = 30;
 let deepLinkHandled = false;
@@ -882,6 +882,18 @@ function matchAircraft(f) {
   return null;
 }
 
+// Single source of truth for "is this live flight a Starlink-equipped tail?".
+// Mirrors the popup badge: prefer matchAircraft(f) for membership recovery (handles
+// blank-reg via icao24→N-number), then fall back to the raw reg dash-stripped + uppercased
+// — the SAME normalization getStarlinkAirborneMap/the popup use — so map markers and the
+// popup CONFIRMED badge stay consistent. Returns false in degraded tier (empty STARLINK_TAILS).
+function isStarlinkFlight(f) {
+  if (!STARLINK_TAILS.size || !f) return false;
+  const ac = matchAircraft(f);
+  if (ac) return STARLINK_TAILS.has(ac.r);
+  return !!(f.reg && STARLINK_TAILS.has(f.reg.replace(/-/g, '').toUpperCase()));
+}
+
 // ═══ MAP INIT ═══
 function initMap() {
   var homeCode = getHomeAirport();
@@ -960,6 +972,35 @@ function drawHubs() {
 
 function toggleHubs() { showHubs = !showHubs; drawHubs(); const el = document.getElementById('btn-hubs'); el.classList.toggle('active'); el.setAttribute('aria-pressed', String(showHubs)); }
 function toggleLonghaul() { showLonghaul = !showLonghaul; const el = document.getElementById('btn-longhaul'); el.classList.toggle('active'); el.setAttribute('aria-pressed', String(showLonghaul)); updateMarkers(); }
+function toggleStarlinkLayer() {
+  // Degraded tier (no Starlink tails loaded) → no-op; the button is also disabled/greyed.
+  if (!STARLINK_TAILS.size) return;
+  showStarlinkOnly = !showStarlinkOnly;
+  const el = document.getElementById('btn-starlink');
+  if (el) { el.classList.toggle('active', showStarlinkOnly); el.setAttribute('aria-pressed', String(showStarlinkOnly)); }
+  updateMarkers();
+}
+// Reflect data availability onto the Starlink toggle + legend. Degraded tier
+// (static fallback, empty STARLINK_TAILS) disables/greys the control and hides the
+// legend rather than offering a filter that would empty the map.
+function updateStarlinkControlState() {
+  const has = STARLINK_TAILS.size > 0;
+  const btn = document.getElementById('btn-starlink');
+  if (btn) {
+    btn.disabled = !has;
+    btn.setAttribute('aria-disabled', String(!has));
+    btn.classList.toggle('ctrl-btn-disabled', !has);
+    if (!has) {
+      // Force the filter off if data disappeared while it was active.
+      if (showStarlinkOnly) { showStarlinkOnly = false; btn.classList.remove('active'); btn.setAttribute('aria-pressed', 'false'); if (map) updateMarkers(); }
+      btn.title = 'Starlink data unavailable';
+    } else {
+      btn.removeAttribute('title');
+    }
+  }
+  const legend = document.getElementById('map-legend');
+  if (legend) legend.style.display = has ? '' : 'none';
+}
 function toggleWeather() {
   showWeather = !showWeather;
   const wxBtn = document.getElementById('btn-wx'); wxBtn.classList.toggle('active'); wxBtn.setAttribute('aria-pressed', String(showWeather));
@@ -1120,17 +1161,24 @@ function isLonghaulFlight(f) {
   return num > 0 && num < 100;
 }
 
-// Icon cache: key = "hdg_rounded|isLonghaul|phase|isWatched" → L.divIcon
+// Icon cache: key = "hdg_rounded|isLonghaul|phase|isWatched|isStarlink" → L.divIcon
 const _iconCache = {};
-function createPlaneIcon(hdg, isLonghaul, phase, isWatched) {
+function createPlaneIcon(hdg, isLonghaul, phase, isWatched, isStarlink) {
   // Round heading to nearest 5° to maximize cache hits
   const hdgRounded = Math.round((hdg || 0) / 5) * 5;
-  const cacheKey = `${hdgRounded}|${isLonghaul?1:0}|${phase}|${isWatched?1:0}`;
+  const cacheKey = `${hdgRounded}|${isLonghaul?1:0}|${phase}|${isWatched?1:0}|${isStarlink?1:0}`;
   if (_iconCache[cacheKey]) return _iconCache[cacheKey];
   const color = isWatched ? '#22c55e' : (isLonghaul ? '#fbbf24' : (phase === 'Ground' ? '#64748B' : '#6BAAED'));
   const size = isWatched ? 16 : (isLonghaul ? 14 : 10);
+  // Starlink marker treatment: an amber glow HALO that STACKS on top of the existing
+  // phase/long-haul/watched fill (we keep the fill so phase info is never lost — a recolor
+  // would collide with long-haul's amber). Pairs the amber color with an enlarged glow shape
+  // so color is not the sole signal (DESIGN.md). #fbbf24 is the map's existing amber.
+  const filter = isStarlink
+    ? `drop-shadow(0 0 2px ${color}) drop-shadow(0 0 4px #fbbf24) drop-shadow(0 0 7px #fbbf24)`
+    : `drop-shadow(0 0 2px ${color})`;
   // SVG plane pointing north (0°) — classic top-down aircraft silhouette, cross-platform consistent
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 256 256" fill="${color}" style="filter:drop-shadow(0 0 2px ${color})"><path d="M128 16c-4 0-8 3-9 7l-15 72-88 34c-3 1-4 4-4 7s2 5 5 6l87 20 4 52-28 18c-2 1-3 3-3 5v8c0 2 1 4 3 4l20-6h28l20 6c2 0 3-2 3-4v-8c0-2-1-4-3-5l-28-18 4-52 87-20c3-1 5-3 5-6s-1-6-4-7l-88-34-15-72c-1-4-5-7-9-7z"/></svg>`;
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 256 256" fill="${color}" style="filter:${filter}"><path d="M128 16c-4 0-8 3-9 7l-15 72-88 34c-3 1-4 4-4 7s2 5 5 6l87 20 4 52-28 18c-2 1-3 3-3 5v8c0 2 1 4 3 4l20-6h28l20 6c2 0 3-2 3-4v-8c0-2-1-4-3-5l-28-18 4-52 87-20c3-1 5-3 5-6s-1-6-4-7l-88-34-15-72c-1-4-5-7-9-7z"/></svg>`;
   const icon = L.divIcon({
     html: `<div style="transform:rotate(${hdgRounded}deg);line-height:0">${svg}</div>`,
     iconSize: [size, size], iconAnchor: [size/2, size/2], className: ''
@@ -1153,6 +1201,7 @@ function getFilteredFlights() {
       const phaseGroup = getPhaseGroup(p.phase);
       if (phaseGroup !== activePhaseFilter) return false;
     }
+    if (showStarlinkOnly && !isStarlinkFlight(f)) return false;
     return true;
   });
 }
@@ -1188,7 +1237,8 @@ function updateMarkers() {
     const phaseInfo = getPhase(f.alt, f.vr, f.spd);
     const flightId = f.flightIATA || '';
     const isWatched = flightId && watchedSet.has(flightId);
-    const icon = createPlaneIcon(f.hdg, isLonghaul, phaseInfo.phase, isWatched);
+    const isStarlink = isStarlinkFlight(f);
+    const icon = createPlaneIcon(f.hdg, isLonghaul, phaseInfo.phase, isWatched, isStarlink);
 
     // Normalize longitude to nearest world copy relative to map center
     // so IDL-crossing flights (e.g. SFO→BNE) are always visible
@@ -1240,7 +1290,7 @@ function showFlightPopup(f, marker) {
   const phaseInfo = getPhase(f.alt, f.vr, f.spd);
   const squawk = decodeSquawk(f.squawk);
   const aircraft = matchAircraft(f);
-  const isStarlink = aircraft ? STARLINK_TAILS.has(aircraft.r) : (f.reg && STARLINK_TAILS.has(f.reg));
+  const isStarlink = isStarlinkFlight(f);
   const flightNum = f.flightIATA || f.callsign.replace(/^UAL/, '');
   const displayFlight = f.flightIATA || f.callsign || 'N/A';
 
@@ -2659,7 +2709,8 @@ function renderSlHero() {
   const airborneCount = Object.keys(getStarlinkAirborneMap()).length;
   let chips = '';
   if (newThisWeek > 0) chips += '<span class="sl-chip sl-chip-new">+' + newThisWeek + ' NEW THIS WEEK</span>';
-  if (airborneCount > 0) chips += '<span class="sl-chip sl-chip-live">● ' + airborneCount + ' AIRBORNE NOW</span>';
+  // The live chip is a click-through to the LIVE OPS map with the Starlink filter pre-enabled.
+  if (airborneCount > 0) chips += '<span class="sl-chip sl-chip-live sl-chip-clickable" data-action="view-starlink-on-map" role="button" tabindex="0" title="Show these on the live map" aria-label="Show ' + airborneCount + ' airborne Starlink aircraft on the live map">● ' + airborneCount + ' AIRBORNE NOW</span>';
   document.getElementById('sl-hero-chips').innerHTML = chips;
 
   // Source line: count + freshness
@@ -6102,6 +6153,15 @@ document.addEventListener('click', function(e) {
     case 'toggle-longhaul':
       toggleLonghaul();
       break;
+    case 'toggle-starlink-layer':
+      toggleStarlinkLayer();
+      break;
+    case 'view-starlink-on-map':
+      // Click-through from the STARLINK tab's "● N AIRBORNE NOW" chip: jump to the
+      // LIVE OPS map with the Starlink-only filter pre-enabled.
+      switchToTab('tab-live');
+      if (STARLINK_TAILS.size && !showStarlinkOnly) toggleStarlinkLayer();
+      break;
     case 'toggle-weather':
       toggleWeather();
       break;
@@ -6493,6 +6553,8 @@ async function initApp() {
   var acDeepLink = new URLSearchParams(location.search).get('aircraft');
   const loadFleetAndInit = async () => {
     await loadFleetData();
+    // STARLINK_TAILS is now populated (or empty in degraded tier) — sync the map toggle + legend.
+    updateStarlinkControlState();
     if (allFlights.length > 0) {
       updateStats();
       updateAnalytics();


### PR DESCRIPTION
## What

Makes airborne Starlink-equipped aircraft visible and filterable on the existing LIVE OPS Leaflet map.

- **Marker treatment** — `createPlaneIcon()`/`updateMarkers()` thread an `isStarlink` flag that renders an **amber glow halo STACKED on top of** the existing phase/long-haul/watched fill (an enlarged amber drop-shadow). The fill is *not* recolored, so phase info is never lost and it doesn't collide with long-haul's amber. `isStarlink` is added to the `_iconCache` key so stale icons can't serve.
- **Membership** — new `isStarlinkFlight(f)` is the single source of truth: prefers `matchAircraft(f)` for recovery (blank-reg via icao24→N-number), then falls back to the raw reg dash-stripped + uppercased — the same normalization the popup / `getStarlinkAirborneMap` use. The popup `CONFIRMED` badge now calls the same helper, so map markers and the popup stay consistent.
- **Filter toggle** — new "⚡ Starlink" `.ctrl-btn` (`#btn-starlink`) right after Long-haul, reusing `.ctrl-btn/.active`, `aria-pressed`, and the mobile collapse. Adds module state `showStarlinkOnly`, `toggleStarlinkLayer()` mirroring `toggleLonghaul()`, a `toggle-starlink-layer` dispatch case, and a `getFilteredFlights()` clause that keeps only Starlink tails when on.
- **Click-through** — the STARLINK tab's "● N AIRBORNE NOW" chip is now a button that switches to LIVE OPS with `showStarlinkOnly` pre-enabled (`view-starlink-on-map`; mouse + Enter/Space).
- **Legend** — one amber Starlink legend dot grouped under the control ladder (its dot mirrors the marker glow; paired with the "Starlink" text so color isn't the sole signal). Hidden on mobile where the toolbar collapses to a FAB.

## Why

Starlink rollout is the product's headline story but airborne Starlink jets were invisible on the live map and unfilterable. This surfaces them without a new endpoint — pure presentation over `/api/fr24-feed ∩ STARLINK_TAILS`, both already loaded.

## Degraded-tier guard

If `STARLINK_TAILS` is empty (static-fallback tier), `updateStarlinkControlState()` disables/greys the toggle and hides the legend instead of offering a filter that would empty the map. The toggle also no-ops defensively. When tails exist but `flightsByTail`/`dateFound` are missing, markers/filter still work (membership uses `STARLINK_TAILS` only).

## Caveats / risks

- The amber glow halo uses `#fbbf24` (the map's existing amber, also used for long-haul fill), not the CSS token `--ua-amber` `#C4A35A` — consistent with the rest of the map palette and brighter against the dark basemap. A Starlink long-haul jet is amber-fill + amber-halo; the halo (an enlarged glow shape, not a recolor) still reads as a distinct Starlink signal.
- No automated test was added: this is presentation logic inside the `src/dashboard/main.js` browser bundle (DOM/Leaflet, not import-friendly) and there is no new `api/` endpoint, so the gate's "new endpoint → add a vitest test" clause doesn't apply. Validated via build + full suite below; live in-browser QA was not performed.
- The legend is desktop-only by design; mobile users rely on the amber glow markers + popup badge.

## Test evidence

- `bun run typecheck` — clean (exit 0)
- `bun run test` — **703/703 pass across 50 files**
- `bun run build:dashboard` — succeeds (bundles `src/dashboard/main.js`)

**⚠️ merge = deploy to prod — review before merging**

🤖 Generated with [Claude Code](https://claude.com/claude-code)