### PR TITLE
feat(starlink): hub departures board (live NOC FIDS) on the STARLINK tab

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -584,6 +584,50 @@ tbody td{padding:5px 8px;white-space:nowrap}
 .sl-verify-when{color:var(--ua-muted);font-size:10px}
 .sl-verify-empty{text-align:center;color:var(--ua-muted);padding:18px;font-size:11px}
 .sl-verify-dot{display:inline-flex;align-items:center;justify-content:center;width:13px;height:13px;border-radius:50%;background:var(--ua-red);color:#fff;font-family:var(--font-mono);font-size:9px;font-weight:700;line-height:1;vertical-align:middle;margin-left:6px}
+/* ── Hub Departures Board (live NOC FIDS) ──
+   Visually distinct from the per-tail roster table: full-radius elevated panel, hub-filter pills,
+   time-bucket section labels, and a time-first grid row with a green left rail when airborne. */
+.sl-board{background:linear-gradient(180deg,var(--ua-panel-elevated) 0%,rgba(17,26,39,.7) 100%);border:1px solid var(--ua-border);border-radius:6px;padding:14px 16px;margin-bottom:14px}
+.sl-board-note{font-family:var(--font-mono);font-size:10px;color:var(--ua-dim);background:var(--ua-panel);border:1px dashed var(--ua-border);border-radius:6px;padding:10px 14px;margin-bottom:14px}
+.sl-board-head{display:flex;justify-content:space-between;align-items:flex-start;gap:12px;margin-bottom:12px;flex-wrap:wrap}
+.sl-board-label{font-family:var(--font-mono);font-size:10px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;color:var(--ua-amber);margin-bottom:3px}
+.sl-board-sub{font-family:var(--font-ui);font-size:10px;color:var(--ua-muted)}
+.sl-board-fresh{color:var(--ua-dim)}
+.sl-board-windows{display:flex;gap:6px;flex-shrink:0}
+/* Cross-Nav rectangular pill (DESIGN.md): mono 11px/600, radius 4, outline active state */
+.sl-board-pill{font-family:var(--font-mono);font-size:11px;font-weight:600;letter-spacing:.5px;padding:4px 10px;border-radius:4px;border:1px solid var(--ua-border);background:var(--ua-panel);color:var(--ua-muted);cursor:pointer;transition:color .15s ease,border-color .15s ease,background-color .15s ease;display:inline-flex;align-items:center;gap:5px}
+.sl-board-pill:hover{color:var(--ua-text);border-color:var(--ua-blue)}
+.sl-board-pill.active{border-color:var(--ua-blue);color:var(--ua-blue);background:var(--ua-blue-soft)}
+.sl-board-pill-n{font-size:9px;color:var(--ua-dim)}
+.sl-board-pill.active .sl-board-pill-n{color:var(--ua-blue)}
+.sl-board-pill-empty{opacity:.5}
+.sl-board-pills{display:flex;gap:6px;flex-wrap:wrap;margin-bottom:12px;padding-bottom:12px;border-bottom:1px solid var(--ua-border-subtle)}
+.sl-board-bucket-label{font-family:var(--font-mono);font-size:10px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;color:var(--ua-amber);margin:14px 0 6px;display:flex;align-items:center;gap:8px}
+.sl-board-bucket-label:first-child{margin-top:0}
+.sl-board-bucket-n{font-size:9px;color:var(--ua-dim);font-weight:400;letter-spacing:.5px}
+.sl-board-row{display:grid;grid-template-columns:92px minmax(150px,1.4fr) minmax(115px,1fr) 84px 112px;gap:10px;align-items:center;padding:6px 8px;border-bottom:1px solid var(--ua-border-subtle);font-family:var(--font-mono);border-left:2px solid transparent}
+.sl-board-row:hover{background:rgba(0,93,170,.06)}
+.sl-board-row.airborne{border-left-color:var(--ua-green);background:rgba(34,197,94,.04)}
+.sl-board-time{font-size:12px;font-weight:700;color:var(--ua-text);display:flex;flex-direction:column;line-height:1.25}
+.sl-board-rel{font-size:8px;font-weight:400;color:var(--ua-dim);letter-spacing:.3px}
+.sl-board-flt{display:flex;flex-direction:column;gap:1px;background:none;border:none;padding:0;text-align:left;cursor:pointer;font-family:inherit;min-width:0}
+.sl-board-cs{font-size:11px;font-weight:600;color:var(--ua-accent)}
+.sl-board-flt:hover .sl-board-cs{text-decoration:underline}
+.sl-board-op{font-size:9px;color:var(--ua-muted);text-transform:uppercase;letter-spacing:.5px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.sl-board-route{font-size:11px;color:var(--ua-text);display:inline-flex;align-items:center;gap:6px;min-width:0}
+.sl-board-orig{color:var(--ua-muted)}
+.sl-board-arrow{color:var(--ua-dim)}
+.sl-board-dest{font-weight:600}
+.sl-board-type{font-size:9px;color:var(--ua-dim);text-transform:uppercase;letter-spacing:.5px}
+.sl-board-status{display:flex;align-items:center;gap:6px;justify-content:flex-end}
+.sl-board-live{font-size:9px;font-weight:600;color:var(--ua-green);white-space:nowrap}
+.sl-board-sched{font-size:9px;color:var(--ua-dim);letter-spacing:.5px}
+.sl-board-track{font-family:var(--font-mono);font-size:9px;font-weight:600;padding:2px 7px;border-radius:3px;border:1px solid var(--ua-blue);background:var(--ua-blue);color:#fff;cursor:pointer;white-space:nowrap}
+.sl-board-track:hover{background:#0068c0;border-color:#0068c0}
+.sl-board-showall{display:block;width:100%;margin-top:10px;padding:7px;font-family:var(--font-mono);font-size:10px;font-weight:600;color:var(--ua-accent);background:var(--ua-panel);border:1px solid var(--ua-border);border-radius:4px;cursor:pointer;transition:border-color .15s ease}
+.sl-board-showall:hover{border-color:var(--ua-accent)}
+.sl-board-empty{font-family:var(--font-mono);font-size:11px;color:var(--ua-muted);padding:18px 8px;text-align:center}
+.sl-board-foot{font-family:var(--font-ui);font-size:9px;color:var(--ua-dim);margin-top:12px;padding-top:10px;border-top:1px solid var(--ua-border-subtle);line-height:1.5}
 @media (max-width:600px){
   .sl-hero{grid-template-columns:1fr;gap:14px}
   .sl-hero-chips{flex-direction:row;align-items:flex-start;flex-wrap:wrap}
@@ -593,6 +637,12 @@ tbody td{padding:5px 8px;white-space:nowrap}
   .sl-verify-head{flex-direction:column;align-items:flex-start;gap:10px}
   .sl-verify-strip{width:100%}
   .sl-verify-stat{flex:1}
+  .sl-board-row{grid-template-columns:56px 1fr;gap:2px 10px;padding:8px}
+  .sl-board-time{grid-row:1 / span 3}
+  .sl-board-flt{grid-column:2;grid-row:1}
+  .sl-board-route{grid-column:2;grid-row:2}
+  .sl-board-type{display:none}
+  .sl-board-status{grid-column:2;grid-row:3;justify-content:flex-start;margin-top:2px}
 }
 
 /* Special Aircraft Badge & Tracker */

--- a/public/index.html
+++ b/public/index.html
@@ -636,6 +636,22 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
       </div>
       <div class="sl-trend-foot" id="sl-trend-foot"></div>
     </div>
+    <!-- HUB DEPARTURES BOARD — live NOC FIDS built client-side from STARLINK_FLIGHTS_BY_TAIL (renderSlRoutesBoard). Hidden in degraded tier. -->
+    <div class="sl-board-note" id="sl-board-note" style="display:none">Live departures board unavailable — Starlink schedule feed is offline (showing the fleet roster only).</div>
+    <div class="sl-board" id="sl-board" style="display:none">
+      <div class="sl-board-head">
+        <div class="sl-board-titles">
+          <div class="sl-board-label">Hub Departures Board</div>
+          <div class="sl-board-sub">United Starlink aircraft departing the hubs · operating callsigns · <span id="sl-board-updated" class="sl-board-fresh">scheduled times</span></div>
+        </div>
+        <div class="sl-board-windows" id="sl-board-windows" role="group" aria-label="Departure window">
+          <button class="sl-board-pill active" data-action="sl-board-window" data-window="12" aria-pressed="true">12H</button>
+          <button class="sl-board-pill" data-action="sl-board-window" data-window="48" aria-pressed="false">48H</button>
+        </div>
+      </div>
+      <div class="sl-board-pills" id="sl-board-pills" role="group" aria-label="Filter departures by hub"></div>
+      <div class="sl-board-body" id="sl-board-body"></div>
+      <div class="sl-board-foot">A NOC departures board, not a passenger FIDS. Callsigns are the operating carrier (SkyWest, Republic, Mesa…), not United marketing flight numbers. Times are scheduled / last-seen, served through The Blue Board's cache (up to 6h) — not live ATC.</div>
     <div class="sl-chart-card" id="sl-chart-card" style="display:none">
       <div class="sl-chart-label">Installation Velocity</div>
       <div class="sl-chart-sub" id="sl-chart-sub">Aircraft equipped per month</div>

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -4,7 +4,7 @@ import { formatDelayExplainFAAStatus, getScheduleRiskContext } from '../lib/dela
 import { getMetarStationForIata, INTL_AIRPORTS } from '../lib/airport-metadata.js';
 import { chunkMetarStationIds, normalizeMetarPayload } from '../lib/metar.js';
 import { categorizeFleetStatus, FLEET_HEALTH_CATEGORIES, FLEET_FAMILIES, normalizeWifi, WIFI_DISPLAY, sortFleetData, filterFleetData, parseFleetDeepLink, TAB_MAP, VALID_FLEET_VIEWS } from '../lib/fleet-utils.js';
-import { bucketInstallsByMonth, computeInstallPace } from '../lib/starlink-utils.js';
+import { bucketInstallsByMonth, computeInstallPace, buildDeparturesBoard } from '../lib/starlink-utils.js';
 import { getFlightPopupMetrics } from '../lib/flight-popup.js';
 import { getScheduleFleetFamily } from '../lib/schedule-filters.js';
 import { getStartOfHubDay, getHubDayLabel } from '../lib/hubTz.js';
@@ -1125,7 +1125,7 @@ async function refreshFlights() {
     [updateMarkers, updateStats, updateHubStats, updateTicker].forEach(fn => { try { fn(); } catch(e) { console.error(fn.name + ':', e); } });
     try { if (document.getElementById('tab-myflight')?.classList.contains('active')) renderMyFlights(); } catch(e) { console.error('renderMyFlights:', e); }
     try { if (document.getElementById('tab-fleet')?.classList.contains('active')) updateLiveFleetPanel(); } catch(e) { console.error('updateLiveFleetPanel:', e); }
-    try { if (document.getElementById('tab-starlink')?.classList.contains('active') && slInitialized) { renderSlHero(); renderSlTrend(); renderSlTable(); renderSlVerification(); } } catch(e) { console.error('renderStarlinkTab:', e); }
+    try { if (document.getElementById('tab-starlink')?.classList.contains('active') && slInitialized) { renderSlHero(); renderSlTrend(); renderSlRoutesBoard(); renderSlTable(); renderSlVerification(); } } catch(e) { console.error('renderStarlinkTab:', e); }
     try { if (document.getElementById('tab-analytics')?.classList.contains('active')) updateAnalytics(); } catch(e) { console.error('updateAnalytics:', e); }
     // Handle deep link: ?flight=UA1234 on first load (also supports ?q= for SearchAction compatibility)
     if (!deepLinkHandled) {
@@ -2554,6 +2554,11 @@ let STARLINK_DISPUTED = [];         // [{ tail, aircraft, operator, verifiedAs, 
 let STARLINK_VERIFY_SUMMARY = null; // { verifiedStarlink, disputed, unverified, totalPlanes, generatedAt }
 let slMismatchesFetched = false;    // one-shot fetch guard (the ledger changes slowly)
 
+// Departures-board state (the hub FIDS panel above the roster table)
+let slBoardHub = null;       // active hub filter; null = all hubs
+let slBoardWindow = 12;      // departure window in hours: 12 (default) | 48
+let slBoardShowAll = false;  // bypass the per-hub render cap (48h view)
+
 // A plane counts as "newly equipped" if upstream first recorded its Starlink (DateFound) within the
 // last 7 days. Computed against the live clock so the badge ages out on its own.
 function isRecentlyFound(dateFound) {
@@ -2627,6 +2632,7 @@ function initStarlinkTab() {
   renderSlHero();
   renderSlTrend();
   renderSlChart();
+  renderSlRoutesBoard();
   renderSlTable();
   fetchStarlinkMismatches(); // lazy/non-blocking; resolves into renderSlVerification()
   renderSlVerification();    // reflect any already-loaded ledger on an idempotent re-open
@@ -2944,6 +2950,131 @@ function renderSlChart() {
     if (undated > 0) notes.push(undated + ' aircraft have no recorded install date');
     fnEl.textContent = notes.join(' · ');
   }
+}
+
+// ═══ HUB DEPARTURES BOARD ═══
+// A NOC-style FIDS built 100% client-side from STARLINK_FLIGHTS_BY_TAIL (no endpoint, no server
+// change). Flattens the per-tail flights, joins fleet + live-airborne data, keeps hub departures in
+// the active window, and groups them under time-bucket section labels. Honesty: callsigns are the
+// OPERATING carrier (SKW####/RPA####/…), not UA marketing numbers, and times are scheduled/last-seen
+// (served through BB's up-to-6h cache), not live ATC — both are labelled as such on the panel.
+function renderSlRoutesBoard() {
+  const board = document.getElementById('sl-board');
+  if (!board) return;
+  const note = document.getElementById('sl-board-note');
+
+  // Degraded tier (static fallback has empty flightsByTail / no fleet): hide the whole panel and
+  // surface a one-line note instead — mirrors the sl-next-th column toggle.
+  const hasFlights = Object.keys(STARLINK_FLIGHTS_BY_TAIL).length > 0;
+  if (!hasFlights || STARLINK_DB.length === 0) {
+    board.style.display = 'none';
+    if (note) note.style.display = '';
+    return;
+  }
+  board.style.display = '';
+  if (note) note.style.display = 'none';
+
+  const aircraftByTail = {};
+  for (const s of STARLINK_DB) aircraftByTail[s.tail] = s;
+  const airborneByTail = getStarlinkAirborneMap(); // tail → live flight (has icao24)
+
+  const now = Date.now() / 1000;
+  const windowSec = slBoardWindow * 3600;
+  // Cap the DOM only in the wide 48h view (~1492 rows) unless the user asked for all.
+  const capPerHub = (slBoardWindow >= 48 && !slBoardShowAll) ? 40 : Infinity;
+
+  const data = buildDeparturesBoard(STARLINK_FLIGHTS_BY_TAIL, aircraftByTail, airborneByTail, HUB_CODES, {
+    now, windowSec, graceSec: 1800, hub: slBoardHub, capPerHub,
+  });
+
+  // Freshness — surface STARLINK_LAST_UPDATED so the panel never reads as live ATC.
+  const freshEl = document.getElementById('sl-board-updated');
+  if (freshEl) {
+    if (STARLINK_LAST_UPDATED) {
+      const ago = Math.round((Date.now() - new Date(STARLINK_LAST_UPDATED).getTime()) / 60000);
+      freshEl.textContent = ago < 60 ? ('updated ' + ago + 'm ago')
+        : ago < 1440 ? ('updated ' + Math.round(ago / 60) + 'h ago')
+        : ('updated ' + Math.round(ago / 1440) + 'd ago');
+    } else {
+      freshEl.textContent = 'scheduled times';
+    }
+  }
+
+  // Window toggle active state
+  document.querySelectorAll('#sl-board-windows [data-window]').forEach(btn => {
+    const on = Number(btn.dataset.window) === slBoardWindow;
+    btn.classList.toggle('active', on);
+    btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+  });
+
+  // Hub-filter pills (Cross-Nav rectangular pill component). Counts are integers from our own data.
+  const pillsEl = document.getElementById('sl-board-pills');
+  if (pillsEl) {
+    const allActive = !slBoardHub;
+    const pills = [
+      `<button class="sl-board-pill${allActive ? ' active' : ''}" data-action="sl-board-hub" data-hub="" aria-pressed="${allActive}">ALL <span class="sl-board-pill-n">${data.allCount}</span></button>`,
+    ];
+    for (const h of HUB_CODES) {
+      const n = data.hubCounts[h] || 0;
+      const active = slBoardHub === h;
+      pills.push(
+        `<button class="sl-board-pill${active ? ' active' : ''}${n === 0 ? ' sl-board-pill-empty' : ''}" data-action="sl-board-hub" data-hub="${escapeHtml(h)}" aria-pressed="${active}">${escapeHtml(h)} <span class="sl-board-pill-n">${n}</span></button>`
+      );
+    }
+    pillsEl.innerHTML = pills.join('');
+  }
+
+  // Body — time-bucket sections
+  const body = document.getElementById('sl-board-body');
+  if (!body) return;
+  if (data.buckets.length === 0) {
+    const scope = slBoardHub ? escapeHtml(slBoardHub) : 'the hubs';
+    body.innerHTML = `<div class="sl-board-empty">No United Starlink departures from ${scope} in the next ${slBoardWindow}h.</div>`;
+    return;
+  }
+
+  let html = '';
+  for (const bucket of data.buckets) {
+    html += `<div class="sl-board-bucket-label">${escapeHtml(bucket.label)} <span class="sl-board-bucket-n">${bucket.rows.length}</span></div>`;
+    for (const r of bucket.rows) html += renderSlBoardRow(r, now);
+  }
+  if (data.hiddenCount > 0) {
+    html += `<button class="sl-board-showall" data-action="sl-board-show-all">Show all · ${data.hiddenCount} more capped at 40/hub ▾</button>`;
+  }
+  body.innerHTML = html;
+}
+
+// One departures-board row: scheduled time + relative hint, operating callsign + carrier, route,
+// airframe, and live status (📡 Track reuses the existing delegated sl-track → focusFlight action;
+// the callsign opens the existing aircraft-detail modal). All fields are escaped.
+function renderSlBoardRow(r, now) {
+  const t = formatFlightTime(r.departure_ts);
+  const mins = Math.round((r.departure_ts - now) / 60);
+  let rel;
+  if (mins < 0) rel = Math.abs(mins) + 'm ago';
+  else if (mins < 60) rel = '+' + mins + 'm';
+  else { const h = Math.floor(mins / 60), mm = mins % 60; rel = '+' + h + 'h' + (mm ? ' ' + mm + 'm' : ''); }
+
+  // Operator label: drop the " dba UAX"/"dba United Express" tail so the carrier reads cleanly.
+  const operator = (r.operator || '').replace(/\s*dba\b.*$/i, '').trim() || 'United';
+
+  const status = r.airborne
+    ? '<span class="sl-board-live">● Airborne</span>'
+    : '<span class="sl-board-sched">SCHED</span>';
+  const track = (r.airborne && r.icao24)
+    ? `<button class="sl-board-track" data-action="sl-track" data-icao24="${escapeHtml(r.icao24)}" title="Track ${escapeHtml(r.tail)} on the live map">📡 Track</button>`
+    : '';
+
+  return `<div class="sl-board-row${r.airborne ? ' airborne' : ''}">` +
+    `<span class="sl-board-time">${escapeHtml(t)}<span class="sl-board-rel">${escapeHtml(rel)}</span></span>` +
+    `<button class="sl-board-flt" data-action="aircraft-detail" data-reg="${escapeHtml(r.tail)}" title="Aircraft details · ${escapeHtml(r.tail)}">` +
+      `<span class="sl-board-cs">${escapeHtml(r.flight_number || '—')}</span>` +
+      `<span class="sl-board-op">${escapeHtml(operator)} · ${escapeHtml(r.tail)}</span>` +
+    `</button>` +
+    `<span class="sl-board-route"><span class="sl-board-orig">${escapeHtml(r.origin)}</span><span class="sl-board-arrow">→</span><span class="sl-board-dest">${escapeHtml(r.destination || '???')}</span></span>` +
+    `<span class="sl-board-type">${escapeHtml(r.type || '')}</span>` +
+    `<span class="sl-board-status">${status}${track}</span>` +
+  `</div>`;
 }
 
 // Hero band: equipped count, Express/Mainline rollout bars, new-this-week + airborne-now chips.
@@ -6690,6 +6821,23 @@ document.addEventListener('click', function(e) {
     case 'sl-track': {
       const slIcao = actionEl.dataset.icao24;
       if (slIcao) focusFlight(slIcao); // focusFlight switches to LIVE OPS and centers the map
+      break;
+    }
+    case 'sl-board-hub': {
+      const h = actionEl.dataset.hub || '';
+      slBoardHub = h || null;
+      slBoardShowAll = false; // a new hub selection resets the per-hub cap
+      renderSlRoutesBoard();
+      break;
+    }
+    case 'sl-board-window': {
+      const w = Number(actionEl.dataset.window);
+      if (w === 12 || w === 48) { slBoardWindow = w; slBoardShowAll = false; renderSlRoutesBoard(); }
+      break;
+    }
+    case 'sl-board-show-all': {
+      slBoardShowAll = true;
+      renderSlRoutesBoard();
       break;
     }
     case 'aircraft-detail': {

--- a/src/lib/starlink-utils.js
+++ b/src/lib/starlink-utils.js
@@ -171,3 +171,123 @@ export function computeInstallPace(aircraft, nowDate = new Date(), opts = {}) {
 
   return { weeks, peak, thisWeek: rawCounts[weeksWindow - 1], pace, paceWeeks, dated, remaining, etaWeeks, etaDate };
 }
+
+// ═══ HUB DEPARTURES BOARD ═══
+// Time-bucket section labels, in render order. A departure's bucket is chosen by how far in the
+// future it departs (negative deltas — the now-1800 grace window — fall into "WITHIN 1 HOUR").
+export const DEPARTURE_BUCKETS = [
+  { label: 'WITHIN 1 HOUR', maxSec: 3600 },
+  { label: '1–3 HRS', maxSec: 3 * 3600 },
+  { label: '3–12 HRS', maxSec: 12 * 3600 },
+  { label: '12–48 HRS', maxSec: 48 * 3600 },
+];
+
+/** Pick the time-bucket label for a departure `deltaSec` seconds from now. */
+export function departureBucketLabel(deltaSec) {
+  for (const b of DEPARTURE_BUCKETS) if (deltaSec < b.maxSec) return b.label;
+  return DEPARTURE_BUCKETS[DEPARTURE_BUCKETS.length - 1].label;
+}
+
+/**
+ * Build a NOC hub departures board, 100% client-side, from the data already in memory.
+ *
+ * Flattens STARLINK_FLIGHTS_BY_TAIL into rows, joins each tail to its fleet entry (type/fleet/
+ * operator) and to the live airborne map (status/icao24), then keeps only departures FROM a hub
+ * within the [now - graceSec, now + windowSec] window, sorted ascending and grouped into time
+ * buckets for rendering.
+ *
+ * @param {Record<string, Array<{flight_number?:string, origin?:string, destination?:string, departure_ts?:number, departure_time?:string, arrival_time?:string}>>} flightsByTail
+ * @param {Record<string, {type?:string, fleet?:string, operator?:string}>} aircraftByTail - tail → fleet DB entry
+ * @param {Record<string, {icao24?:string}>|Map<string,{icao24?:string}>} airborneByTail - tail → live flight (has icao24)
+ * @param {string[]} hubCodes - hub IATA codes to include as origins
+ * @param {{now?:number, windowSec?:number, graceSec?:number, hub?:(string|null), capPerHub?:number}} [opts]
+ * @returns {{ hubCounts: Record<string,number>, allCount: number, totalInWindow: number, buckets: Array<{label:string, rows:object[]}>, shownCount: number, hiddenCount: number }}
+ *   - hubCounts/allCount are computed over the window BEFORE the hub filter (so per-hub pills, incl.
+ *     empty Pacific hubs at 0, render their true counts regardless of the active selection).
+ *   - buckets/shownCount/hiddenCount reflect the active hub filter and the per-hub render cap.
+ */
+export function buildDeparturesBoard(flightsByTail, aircraftByTail, airborneByTail, hubCodes, opts = {}) {
+  const now = typeof opts.now === 'number' ? opts.now : Date.now() / 1000;
+  const windowSec = typeof opts.windowSec === 'number' ? opts.windowSec : 12 * 3600;
+  const graceSec = typeof opts.graceSec === 'number' ? opts.graceSec : 1800;
+  const hub = opts.hub || null;
+  const capPerHub = typeof opts.capPerHub === 'number' ? opts.capPerHub : Infinity;
+
+  const hubList = Array.isArray(hubCodes) ? hubCodes : [];
+  const hubSet = new Set(hubList);
+  const hubCounts = {};
+  for (const h of hubList) hubCounts[h] = 0;
+
+  const lo = now - graceSec;
+  const hi = now + windowSec;
+  const lookupAir = (tail) =>
+    airborneByTail && (typeof airborneByTail.get === 'function' ? airborneByTail.get(tail) : airborneByTail[tail]);
+
+  // 1. flatten + 2. window/hub filter, joining each tail to its fleet entry + live status
+  const rows = [];
+  for (const tail of Object.keys(flightsByTail || {})) {
+    const ac = (aircraftByTail && aircraftByTail[tail]) || null;
+    const air = lookupAir(tail) || null;
+    const flights = flightsByTail[tail] || [];
+    for (const f of flights) {
+      const ts = Number(f && f.departure_ts) || 0;
+      if (!ts || ts < lo || ts > hi) continue;
+      const origin = String((f && f.origin) || '').toUpperCase();
+      if (!hubSet.has(origin)) continue;
+      hubCounts[origin] = (hubCounts[origin] || 0) + 1; // count over window, pre-hub-filter
+      if (hub && origin !== hub) continue;
+      rows.push({
+        tail,
+        flight_number: String((f && f.flight_number) || ''),
+        origin,
+        destination: String((f && f.destination) || '').toUpperCase(),
+        departure_ts: ts,
+        departure_time: String((f && f.departure_time) || ''),
+        arrival_time: String((f && f.arrival_time) || ''),
+        type: ac ? String(ac.type || '') : '',
+        fleet: ac ? String(ac.fleet || '') : '',
+        operator: ac ? String(ac.operator || '') : '',
+        airborne: !!air,
+        icao24: air ? String(air.icao24 || '') : '',
+        deltaSec: ts - now,
+      });
+    }
+  }
+
+  const allCount = hubList.reduce((s, h) => s + (hubCounts[h] || 0), 0);
+
+  // 3. sort ascending by departure_ts
+  rows.sort((a, b) => a.departure_ts - b.departure_ts);
+
+  // 4. per-hub render cap (bounds the DOM in the 48h window); keep the earliest N per origin
+  const perHubSeen = {};
+  let hiddenCount = 0;
+  const kept = [];
+  for (const r of rows) {
+    const c = (perHubSeen[r.origin] = (perHubSeen[r.origin] || 0) + 1);
+    if (c > capPerHub) { hiddenCount++; continue; }
+    kept.push(r);
+  }
+
+  // 5. group into time buckets (fixed order; only non-empty buckets are returned)
+  const byLabel = new Map();
+  for (const r of kept) {
+    const label = departureBucketLabel(r.deltaSec);
+    if (!byLabel.has(label)) byLabel.set(label, []);
+    byLabel.get(label).push(r);
+  }
+  const buckets = [];
+  for (const b of DEPARTURE_BUCKETS) {
+    const list = byLabel.get(b.label);
+    if (list && list.length) buckets.push({ label: b.label, rows: list });
+  }
+
+  return {
+    hubCounts,
+    allCount,
+    totalInWindow: hub ? rows.length : allCount,
+    buckets,
+    shownCount: kept.length,
+    hiddenCount,
+  };
+}

--- a/tests/starlink-departures-board.test.js
+++ b/tests/starlink-departures-board.test.js
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildDeparturesBoard,
+  departureBucketLabel,
+  DEPARTURE_BUCKETS,
+} from '../src/lib/starlink-utils.js';
+
+// Fixed "now" so the time-window math is deterministic.
+const NOW = 1_700_000_000; // seconds
+const H = 3600;
+
+// Hubs used by the dashboard (EWR/IAH/.../NRT/GUM). NRT & GUM are the empty Pacific hubs.
+const HUBS = ['EWR', 'IAH', 'ORD', 'DEN', 'SFO', 'LAX', 'IAD', 'NRT', 'GUM'];
+
+// Minimal flight + aircraft factories matching the /api/starlink-data shape.
+const flight = (origin, dest, offsetSec, flight_number = 'SKW1234') => ({
+  flight_number,
+  origin,
+  destination: dest,
+  departure_ts: NOW + offsetSec,
+  departure_time: new Date((NOW + offsetSec) * 1000).toISOString(),
+  arrival_time: '',
+  airline: 'UA',
+});
+
+const aircraftByTail = {
+  N100: { type: 'ERJ-175', fleet: 'Express', operator: 'SkyWest dba UAX' },
+  N200: { type: '737 MAX 8', fleet: 'Mainline', operator: 'United Airlines' },
+  N300: { type: 'CRJ-550', fleet: 'Express', operator: 'GoJet dba UAX' },
+};
+
+describe('departureBucketLabel', () => {
+  it('maps deltas to the four time buckets, with the grace window in WITHIN 1 HOUR', () => {
+    expect(departureBucketLabel(-1800)).toBe('WITHIN 1 HOUR'); // departed 30m ago (grace)
+    expect(departureBucketLabel(0)).toBe('WITHIN 1 HOUR');
+    expect(departureBucketLabel(59 * 60)).toBe('WITHIN 1 HOUR');
+    expect(departureBucketLabel(2 * H)).toBe('1–3 HRS');
+    expect(departureBucketLabel(6 * H)).toBe('3–12 HRS');
+    expect(departureBucketLabel(24 * H)).toBe('12–48 HRS');
+    expect(departureBucketLabel(100 * H)).toBe('12–48 HRS'); // clamps to last bucket
+  });
+
+  it('exposes the buckets in render order', () => {
+    expect(DEPARTURE_BUCKETS.map((b) => b.label)).toEqual([
+      'WITHIN 1 HOUR', '1–3 HRS', '3–12 HRS', '12–48 HRS',
+    ]);
+  });
+});
+
+describe('buildDeparturesBoard', () => {
+  it('flattens, keeps only hub departures inside the window, and sorts ascending', () => {
+    const flightsByTail = {
+      N100: [
+        flight('EWR', 'ORD', 2 * H),       // kept
+        flight('EWR', 'DEN', -10 * H),     // dropped: before the grace window
+      ],
+      N200: [
+        flight('SFO', 'NRT', 5 * H),       // kept
+        flight('SFO', 'LHR', 30 * H),      // dropped: outside the 12h window
+      ],
+      N300: [
+        flight('XNA', 'ORD', 1 * H),       // dropped: origin XNA is not a hub
+      ],
+    };
+    const out = buildDeparturesBoard(flightsByTail, aircraftByTail, {}, HUBS, {
+      now: NOW, windowSec: 12 * H,
+    });
+
+    const all = out.buckets.flatMap((b) => b.rows);
+    expect(all.map((r) => `${r.origin}->${r.destination}`)).toEqual(['EWR->ORD', 'SFO->NRT']);
+    // sorted ascending by departure_ts
+    expect(all[0].departure_ts).toBeLessThan(all[1].departure_ts);
+    expect(out.shownCount).toBe(2);
+  });
+
+  it('includes the now-1800 grace departure and routes it to WITHIN 1 HOUR', () => {
+    const flightsByTail = { N100: [flight('EWR', 'ORD', -1500)] }; // left 25m ago
+    const out = buildDeparturesBoard(flightsByTail, aircraftByTail, {}, HUBS, { now: NOW });
+    expect(out.shownCount).toBe(1);
+    expect(out.buckets[0].label).toBe('WITHIN 1 HOUR');
+    expect(out.buckets[0].rows[0].origin).toBe('EWR');
+  });
+
+  it('joins fleet data and live-airborne status (icao24) by tail', () => {
+    const flightsByTail = { N100: [flight('EWR', 'ORD', 1 * H)] };
+    const airborneByTail = { N100: { icao24: 'a1b2c3' } };
+    const out = buildDeparturesBoard(flightsByTail, aircraftByTail, airborneByTail, HUBS, { now: NOW });
+    const row = out.buckets[0].rows[0];
+    expect(row).toMatchObject({
+      tail: 'N100',
+      type: 'ERJ-175',
+      fleet: 'Express',
+      operator: 'SkyWest dba UAX',
+      airborne: true,
+      icao24: 'a1b2c3',
+    });
+  });
+
+  it('accepts a Map for the airborne lookup (as getStarlinkAirborneMap-like callers may pass)', () => {
+    const flightsByTail = { N100: [flight('EWR', 'ORD', 1 * H)] };
+    const airborneMap = new Map([['N100', { icao24: 'deadbe' }]]);
+    const out = buildDeparturesBoard(flightsByTail, aircraftByTail, airborneMap, HUBS, { now: NOW });
+    expect(out.buckets[0].rows[0]).toMatchObject({ airborne: true, icao24: 'deadbe' });
+  });
+
+  it('groups departures under the correct time-bucket section labels', () => {
+    const flightsByTail = {
+      N100: [flight('EWR', 'ORD', 30 * 60)],   // WITHIN 1 HOUR
+      N200: [flight('IAH', 'DEN', 2 * H)],      // 1–3 HRS
+      N300: [flight('ORD', 'LAX', 6 * H)],      // 3–12 HRS
+    };
+    const out = buildDeparturesBoard(flightsByTail, aircraftByTail, {}, HUBS, {
+      now: NOW, windowSec: 12 * H,
+    });
+    expect(out.buckets.map((b) => b.label)).toEqual(['WITHIN 1 HOUR', '1–3 HRS', '3–12 HRS']);
+    expect(out.buckets.map((b) => b.rows.length)).toEqual([1, 1, 1]);
+  });
+
+  it('computes per-hub counts over the window (pre-filter), with empty Pacific hubs at 0', () => {
+    const flightsByTail = {
+      N100: [flight('EWR', 'ORD', 1 * H), flight('EWR', 'DEN', 2 * H)],
+      N200: [flight('SFO', 'LAX', 3 * H)],
+    };
+    const out = buildDeparturesBoard(flightsByTail, aircraftByTail, {}, HUBS, {
+      now: NOW, windowSec: 12 * H,
+    });
+    expect(out.hubCounts.EWR).toBe(2);
+    expect(out.hubCounts.SFO).toBe(1);
+    expect(out.hubCounts.NRT).toBe(0); // empty Pacific hub renders gracefully
+    expect(out.hubCounts.GUM).toBe(0);
+    expect(out.allCount).toBe(3);
+  });
+
+  it('applies the hub filter without changing the pre-filter hub counts', () => {
+    const flightsByTail = {
+      N100: [flight('EWR', 'ORD', 1 * H)],
+      N200: [flight('SFO', 'LAX', 2 * H)],
+    };
+    const out = buildDeparturesBoard(flightsByTail, aircraftByTail, {}, HUBS, {
+      now: NOW, windowSec: 12 * H, hub: 'EWR',
+    });
+    const all = out.buckets.flatMap((b) => b.rows);
+    expect(all).toHaveLength(1);
+    expect(all[0].origin).toBe('EWR');
+    // pills still show every hub's count regardless of the active selection
+    expect(out.hubCounts.SFO).toBe(1);
+    expect(out.allCount).toBe(2);
+    expect(out.totalInWindow).toBe(1); // filtered total
+  });
+
+  it('caps rows per hub and reports the hidden count; show-all (Infinity) reveals them', () => {
+    const flightsByTail = {
+      N100: Array.from({ length: 50 }, (_, i) => flight('EWR', 'ORD', (i + 1) * 60)),
+    };
+    const capped = buildDeparturesBoard(flightsByTail, aircraftByTail, {}, HUBS, {
+      now: NOW, windowSec: 48 * H, capPerHub: 40,
+    });
+    expect(capped.shownCount).toBe(40);
+    expect(capped.hiddenCount).toBe(10);
+    // cap keeps the EARLIEST departures
+    const shown = capped.buckets.flatMap((b) => b.rows);
+    expect(shown[0].departure_ts).toBe(NOW + 60);
+
+    const uncapped = buildDeparturesBoard(flightsByTail, aircraftByTail, {}, HUBS, {
+      now: NOW, windowSec: 48 * H, capPerHub: Infinity,
+    });
+    expect(uncapped.shownCount).toBe(50);
+    expect(uncapped.hiddenCount).toBe(0);
+  });
+
+  it('returns an empty (but well-formed) board for empty / missing input', () => {
+    const out = buildDeparturesBoard({}, {}, {}, HUBS, { now: NOW });
+    expect(out.buckets).toEqual([]);
+    expect(out.shownCount).toBe(0);
+    expect(out.allCount).toBe(0);
+    expect(out.hubCounts.GUM).toBe(0);
+
+    const nullish = buildDeparturesBoard(null, null, null, HUBS, { now: NOW });
+    expect(nullish.buckets).toEqual([]);
+    expect(nullish.shownCount).toBe(0);
+  });
+
+  it('ignores flights with no usable departure_ts', () => {
+    const flightsByTail = {
+      N100: [
+        { flight_number: 'SKW1', origin: 'EWR', destination: 'ORD', departure_ts: 0 },
+        flight('EWR', 'DEN', 1 * H),
+      ],
+    };
+    const out = buildDeparturesBoard(flightsByTail, aircraftByTail, {}, HUBS, { now: NOW });
+    expect(out.shownCount).toBe(1);
+    expect(out.buckets[0].rows[0].destination).toBe('DEN');
+  });
+});


### PR DESCRIPTION
## What

Adds a **Hub Departures Board** to the STARLINK tab — a NOC-style FIDS built **100% client-side** from the data already in memory (`STARLINK_FLIGHTS_BY_TAIL`, loaded from `/api/starlink-data`). **No new endpoint, no server change.**

It flattens the per-tail flights, joins each tail to the fleet DB (type/fleet/operator) and the live airborne map (status/icao24), keeps departures whose origin is a hub and whose `departure_ts` falls in `[now-1800, now+windowSec]`, sorts ascending, and groups them under time-bucket section labels (**WITHIN 1 HOUR / 1–3 HRS / 3–12 HRS / 12–48 HRS**).

- **Filters:** hub-filter pills (reusing the Cross-Nav rectangular pill component) + a **12H / 48H** window toggle, driving new module state `slBoardHub` / `slBoardWindow`.
- **Default 12h** (~109 rows); **48h** (~1492 rows) applies a **per-hub render cap (40/hub + "show all")** to bound the DOM.
- **Live:** airborne rows get a green left rail + a **📡 Track** button reusing the existing delegated `sl-track` action (→ `focusFlight(icao24)`); a row's callsign opens the existing aircraft-detail modal. Wired into `initStarlinkTab()` **and** the ~30s active-tab refresh hook so airborne badges stay live.
- Pure logic lives in `src/lib/starlink-utils.js` (`buildDeparturesBoard`) for testability; rendering (`renderSlRoutesBoard`/`renderSlBoardRow`) in `src/dashboard/main.js`. New panel markup sits between `.sl-hero` and `.sl-filters`; CSS uses existing DESIGN.md tokens (JetBrains Mono, amber section labels, blue-outline pills, green airborne rail).

## Why

The schedule data is already fetched and held in the client for the per-tail "Next Flight" column, but there was no hub-level, time-ordered view of where the Starlink fleet is going. This surfaces it as an ops board without any new network cost.

## Honesty / caveats (carried from the spec)

- **It's a NOC departures board, not a passenger FIDS.** `flight_number` is the **operating callsign** (SKW####, RPA####, ASH####…), not the United marketing number — rows are labelled with the **operator** (from the fleet DB) and the tail.
- **Times are scheduled / last-seen**, served through The Blue Board's cache (up to 6h) — **not live ATC**. The `now-1800` grace + the airborne-now ● join soften this; the panel surfaces `STARLINK_LAST_UPDATED` freshness and a footnote spells it out.
- **Empty Pacific hubs (NRT/GUM = 0)** render their `0` count gracefully.
- **Degraded tier** (static fallback → empty `flightsByTail`): the whole panel is hidden and replaced with a one-line "schedule feed unavailable" note, mirroring the existing `sl-next-th` column toggle.
- Made deliberately distinct from the per-tail "Next Flight" column (hub grouping + time buckets + elevated full-radius panel) so it doesn't read as a second aircraft list.
- **Out of scope (not pursued):** crossing with `/api/schedule` (9 slow hub scrapes — deferred); upstream `/routes` (HTML-only) / `/api/routes` (404).

## Test evidence (run in the worktree)

- `bun run typecheck` — **pass** (clean, exit 0)
- `bun run test` (vitest) — **pass**: 51 files / **715 tests**, incl. the new `tests/starlink-departures-board.test.js` (12 tests covering window/grace filtering, hub filter, time-bucket grouping, fleet + airborne join, Map-shaped airborne lookup, per-hub counts incl. NRT/GUM=0, per-hub cap + show-all, and empty/invalid input)
- `bun run build:dashboard` — **pass** (vite bundle built, exit 0)

**⚠️ merge = deploy to prod — review before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)