### PR TITLE
feat(starlink): reorder STARLINK tab into one rollout story + fix unclosed board div

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -553,8 +553,18 @@ tbody td{padding:5px 8px;white-space:nowrap}
 .sl-trend-stat-note{font-family:var(--font-mono);font-size:8px;color:var(--ua-dim);margin-top:2px}
 .sl-trend-foot{font-family:var(--font-mono);font-size:8px;color:var(--ua-dim);margin-top:8px}
 .sl-trend-foot:empty{display:none}
+/* Pace + ETA caption, folded into the Installation Velocity card — two stats, not three. */
+.sl-velo-stats{grid-template-columns:repeat(2,1fr);margin-top:16px}
+.sl-velo-stats .sl-trend-stat-v{font-size:20px}
+/* Industry-coverage strip, demoted to quiet context below the rollout chart. */
+.sl-industry-demoted{max-width:760px;opacity:.9}
+.sl-industry-demoted .sl-hero-label{color:var(--ua-dim)}
 /* ═══ VERIFICATION LEDGER ═══ */
 .sl-hero-verify-sub{font-family:var(--font-mono);font-size:9px;color:var(--ua-dim);letter-spacing:.3px;margin-top:5px}
+/* "N disputed" in the hero sub-line jumps to the ledger — underline-dotted affordance. */
+.sl-verify-jump{color:var(--ua-accent);text-decoration:underline dotted;text-underline-offset:2px;cursor:pointer}
+.sl-verify-jump:hover{color:var(--ua-amber)}
+.sl-verify-jump:focus-visible{outline:2px solid var(--ua-accent);outline-offset:2px;border-radius:2px}
 .sl-verify{margin-top:14px;background:linear-gradient(180deg,var(--ua-panel) 0%,rgba(17,26,39,.6) 100%);border:1px solid var(--ua-border);border-left:3px solid var(--ua-amber);border-radius:0 6px 6px 0;padding:16px 20px}
 .sl-verify-head{display:flex;justify-content:space-between;align-items:center;gap:16px;flex-wrap:wrap;margin-bottom:12px}
 .sl-verify-label{margin-bottom:0}

--- a/public/index.html
+++ b/public/index.html
@@ -609,34 +609,39 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
       </div>
       <div class="sl-hero-chips" id="sl-hero-chips"></div>
     </div>
-    <div class="sl-industry" id="sl-industry" style="display:none">
-      <div class="sl-hero-label">Industry · Starlink Coverage</div>
-      <div class="sl-bars" id="sl-industry-bars"></div>
-    </div>
-    <div class="sl-trend" id="sl-trend" style="display:none">
-      <div class="sl-trend-label">Install Pace</div>
-      <div class="sl-trend-sub" id="sl-trend-sub">Weekly equipped · trailing 12 weeks</div>
-      <div class="sl-trend-bars" id="sl-trend-bars" role="img" aria-label="Weekly Starlink installs, trailing 12 weeks"></div>
-      <div class="sl-trend-stats">
-        <div class="sl-trend-stat">
-          <div class="sl-trend-stat-k">This Week</div>
-          <div class="sl-trend-stat-v" id="sl-trend-thisweek">—</div>
-          <div class="sl-trend-stat-note">in progress</div>
-        </div>
+    <!-- THE ARC — rollout history with pace + ETA folded in as its caption. This velocity chart is the
+         rollout story; it replaces the standalone "Install Pace" sparkline panel (which retold the same
+         story, worse, and led with a partial-week "0"). Promoted directly under the hero count. -->
+    <div class="sl-chart-card" id="sl-chart-card" style="display:none">
+      <div class="sl-chart-label">Installation Velocity</div>
+      <div class="sl-chart-sub" id="sl-chart-sub">Aircraft equipped per month</div>
+      <div class="sl-chart-scroll"><svg id="sl-chart" viewBox="0 0 940 280" role="img" aria-label="Starlink installations per month"></svg></div>
+      <div class="sl-chart-legend">
+        <span><span class="sl-swatch" style="background:var(--ua-green)"></span>Express</span>
+        <span><span class="sl-swatch" style="background:var(--ua-accent)"></span>Mainline</span>
+        <span><span class="sl-swatch sl-swatch-line"></span>Cumulative</span>
+      </div>
+      <div class="sl-chart-footnote" id="sl-chart-footnote"></div>
+      <div class="sl-trend-stats sl-velo-stats" id="sl-velo-stats" style="display:none">
         <div class="sl-trend-stat">
           <div class="sl-trend-stat-k">Avg / Wk</div>
           <div class="sl-trend-stat-v" id="sl-trend-pace">—</div>
-          <div class="sl-trend-stat-note" id="sl-trend-pace-note">8-wk trailing</div>
+          <div class="sl-trend-stat-note" id="sl-trend-pace-note">8-wk trailing pace</div>
         </div>
         <div class="sl-trend-stat sl-trend-stat-featured">
-          <div class="sl-trend-stat-k">Express ETA</div>
+          <div class="sl-trend-stat-k">Express · 100% ETA</div>
           <div class="sl-trend-stat-v" id="sl-trend-eta">—</div>
           <div class="sl-trend-stat-note" id="sl-trend-eta-note">at current pace</div>
         </div>
       </div>
-      <div class="sl-trend-foot" id="sl-trend-foot"></div>
     </div>
-    <!-- HUB DEPARTURES BOARD — live NOC FIDS built client-side from STARLINK_FLIGHTS_BY_TAIL (renderSlRoutesBoard). Hidden in degraded tier. -->
+    <!-- Industry context — demoted: quiet context, not the second headline. -->
+    <div class="sl-industry sl-industry-demoted" id="sl-industry" style="display:none">
+      <div class="sl-hero-label">Industry · Starlink Coverage</div>
+      <div class="sl-bars" id="sl-industry-bars"></div>
+    </div>
+    <!-- LIVE — Hub Departures Board (the all-hubs view collapses to a tight per-hub slice; "Show all"
+         expands). Built client-side from STARLINK_FLIGHTS_BY_TAIL (renderSlRoutesBoard). Hidden in degraded tier. -->
     <div class="sl-board-note" id="sl-board-note" style="display:none">Live departures board unavailable — Starlink schedule feed is offline (showing the fleet roster only).</div>
     <div class="sl-board" id="sl-board" style="display:none">
       <div class="sl-board-head">
@@ -652,16 +657,6 @@ body{background:#0B1018;color:#e2e8f0;margin:0;overflow:hidden;font-family:'DM S
       <div class="sl-board-pills" id="sl-board-pills" role="group" aria-label="Filter departures by hub"></div>
       <div class="sl-board-body" id="sl-board-body"></div>
       <div class="sl-board-foot">A NOC departures board, not a passenger FIDS. Callsigns are the operating carrier (SkyWest, Republic, Mesa…), not United marketing flight numbers. Times are scheduled / last-seen, served through The Blue Board's cache (up to 6h) — not live ATC.</div>
-    <div class="sl-chart-card" id="sl-chart-card" style="display:none">
-      <div class="sl-chart-label">Installation Velocity</div>
-      <div class="sl-chart-sub" id="sl-chart-sub">Aircraft equipped per month</div>
-      <div class="sl-chart-scroll"><svg id="sl-chart" viewBox="0 0 940 280" role="img" aria-label="Starlink installations per month"></svg></div>
-      <div class="sl-chart-legend">
-        <span><span class="sl-swatch" style="background:var(--ua-green)"></span>Express</span>
-        <span><span class="sl-swatch" style="background:var(--ua-accent)"></span>Mainline</span>
-        <span><span class="sl-swatch sl-swatch-line"></span>Cumulative</span>
-      </div>
-      <div class="sl-chart-footnote" id="sl-chart-footnote"></div>
     </div>
     <div class="sl-filters" id="sl-filters">
       <input type="text" id="sl-search" aria-label="Search Starlink aircraft" placeholder="Search tail...">

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -2757,7 +2757,12 @@ function renderSlVerification() {
   // context so they never overwrite the served count in the big hero number.
   if (subEl) {
     if (summary && summary.verifiedStarlink != null) {
-      subEl.textContent = summary.verifiedStarlink + ' verified · ' + disputedCount + ' disputed';
+      // "N disputed" jumps to the verification ledger (a plain hash link can't reach it — the ledger
+      // lives inside the #tab-starlink scroll container, so the dispatch handler uses scrollIntoView).
+      // Both values are our own integer counts (coerced to Number so the innerHTML can carry no markup).
+      subEl.innerHTML = Number(summary.verifiedStarlink) + ' verified · ' +
+        '<span class="sl-verify-jump" data-action="sl-jump-verify" role="button" tabindex="0" ' +
+        'title="Jump to the verification ledger">' + Number(disputedCount) + ' disputed</span>';
       subEl.style.display = '';
     } else {
       subEl.style.display = 'none';
@@ -2772,8 +2777,14 @@ function renderSlVerification() {
 // WEEKLY ADDS over a 12-week window (never an all-time cumulative cliff), clamps backfill spikes, and
 // frames the ETA as Express-fleet "at current pace …", never a commitment.
 function renderSlTrend() {
-  const card = document.getElementById('sl-trend');
-  if (!card) return;
+  // Pace + ETA, rendered as the caption stat-row inside the Installation Velocity card
+  // (#sl-velo-stats). This was a standalone "Install Pace" panel with a 12-week sparkline, but that
+  // retold the velocity chart's story at a coarser zoom and led with a partial-week "0" that read as
+  // a stalled feed. We keep only the two things the monthly chart can't show: the trailing weekly
+  // pace and the Express-fleet "at current pace" ETA. Pace math + backfill clamp live in
+  // computeInstallPace (starlink-utils).
+  const row = document.getElementById('sl-velo-stats');
+  if (!row) return;
 
   const fs = STARLINK_FLEET_STATS;
   // Express remaining drives the ETA. Mainline (much of which is widebody/retiring that may never get
@@ -2783,34 +2794,15 @@ function renderSlTrend() {
   const pace = computeInstallPace(STARLINK_DB, new Date(),
     expressRemaining != null ? { remaining: expressRemaining } : {});
 
-  // Degraded mode (static fallback carries no dateFound): hide the whole panel, same guard the
-  // rollout bars use — never render an empty/garbage panel.
-  if (pace.dated === 0) { card.style.display = 'none'; return; }
-  card.style.display = '';
+  // Degraded mode (static fallback carries no dateFound): hide the stats, same guard the chart uses.
+  if (pace.dated === 0) { row.style.display = 'none'; return; }
+  row.style.display = '';
 
-  // Sparkline: one vertical bar per ISO week (amber fill on a --ua-border-subtle track). Backfill
-  // weeks get a striped fill (texture, not color alone) + a tooltip note.
-  const barsEl = document.getElementById('sl-trend-bars');
-  barsEl.innerHTML = pace.weeks.map(w => {
-    const pct = w.barValue > 0 ? Math.max(3, Math.round((w.barValue / pace.peak) * 100)) : 0;
-    const tip = 'Week of ' + w.label + ' · ' + w.count + ' equipped' + (w.capped ? ' (backfill batch)' : '');
-    return '<div class="sl-trend-bar" title="' + escapeHtml(tip) + '">' +
-      '<div class="sl-trend-bar-fill' + (w.capped ? ' sl-trend-bar-capped' : '') + '" style="height:' + pct + '%"></div>' +
-      '</div>';
-  }).join('');
-
-  // Window subtitle: first → last week of the displayed range.
-  const subEl = document.getElementById('sl-trend-sub');
-  if (subEl && pace.weeks.length) {
-    subEl.textContent = 'Weekly equipped · ' + pace.weeks[0].label + ' – ' + pace.weeks[pace.weeks.length - 1].label;
-  }
-
-  // 3-up readout — counts/derived numbers are our own data, safe as textContent.
-  document.getElementById('sl-trend-thisweek').textContent = pace.thisWeek;
+  // Trailing weekly pace — derived from our own data, safe as textContent.
   const paceStr = pace.pace >= 10 ? String(Math.round(pace.pace)) : String(Math.round(pace.pace * 10) / 10);
   document.getElementById('sl-trend-pace').textContent = pace.pace > 0 ? '~' + paceStr : '—';
   const paceNote = document.getElementById('sl-trend-pace-note');
-  if (paceNote) paceNote.textContent = pace.paceWeeks > 0 ? pace.paceWeeks + '-wk trailing' : 'no complete weeks';
+  if (paceNote) paceNote.textContent = pace.paceWeeks > 0 ? pace.paceWeeks + '-wk trailing pace' : 'no complete weeks';
 
   // Featured amber ETA — Express-fleet, "at current pace", never a commitment. Drops to em-dash when
   // pace or the Express denominator is unavailable.
@@ -2823,15 +2815,6 @@ function renderSlTrend() {
   } else {
     etaEl.textContent = '—';
     if (etaNote) etaNote.textContent = expressRemaining == null ? 'Express fleet n/a' : 'pace too low';
-  }
-
-  // Footnote: surface any backfill-clamped weeks so the spike never reads as a real surge.
-  const footEl = document.getElementById('sl-trend-foot');
-  if (footEl) {
-    const capped = pace.weeks.filter(w => w.capped);
-    footEl.textContent = capped.length
-      ? '* ' + capped.map(w => 'Week of ' + w.label + ' (' + w.count + ') is a backfill detection batch — bar clamped').join(' · ')
-      : '';
   }
 }
 
@@ -2980,8 +2963,13 @@ function renderSlRoutesBoard() {
 
   const now = Date.now() / 1000;
   const windowSec = slBoardWindow * 3600;
-  // Cap the DOM only in the wide 48h view (~1492 rows) unless the user asked for all.
-  const capPerHub = (slBoardWindow >= 48 && !slBoardShowAll) ? 40 : Infinity;
+  // Tame the default. The all-hubs 12h list is ~180 rows — a wall that buries the roster and the
+  // ledger below it. Cap to a tight per-hub slice in the all-hubs view (the "Show all" button
+  // expands it); a single-hub 12h view shows everything; the wide 48h view stays capped at 40/hub.
+  const capPerHub = slBoardShowAll ? Infinity
+    : !slBoardHub ? 6
+    : slBoardWindow >= 48 ? 40
+    : Infinity;
 
   const data = buildDeparturesBoard(STARLINK_FLIGHTS_BY_TAIL, aircraftByTail, airborneByTail, HUB_CODES, {
     now, windowSec, graceSec: 1800, hub: slBoardHub, capPerHub,
@@ -3039,7 +3027,7 @@ function renderSlRoutesBoard() {
     for (const r of bucket.rows) html += renderSlBoardRow(r, now);
   }
   if (data.hiddenCount > 0) {
-    html += `<button class="sl-board-showall" data-action="sl-board-show-all">Show all · ${data.hiddenCount} more capped at 40/hub ▾</button>`;
+    html += `<button class="sl-board-showall" data-action="sl-board-show-all">Show all · ${data.hiddenCount} more departures ▾</button>`;
   }
   body.innerHTML = html;
 }
@@ -6838,6 +6826,12 @@ document.addEventListener('click', function(e) {
     case 'sl-board-show-all': {
       slBoardShowAll = true;
       renderSlRoutesBoard();
+      break;
+    }
+    case 'sl-jump-verify': {
+      // Hero "N disputed" → verification ledger. scrollIntoView (not a hash link) because the ledger
+      // lives inside the #tab-starlink scroll container, which a fragment URL can't reach.
+      document.getElementById('sl-verification')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
       break;
     }
     case 'aircraft-detail': {


### PR DESCRIPTION
Designer-eye pass on the live STARLINK tab (you asked: *do the charts tell a story? does the ordering make sense?*). It didn't have a spine — three modes interleaved, two trend charts saying the same thing separated by a 181-row wall, the best chart buried. This reorders into one story and merges the redundant chart. **Matches the approved mockup.**

### What changed
- **Order → one spine:** hero → **Installation Velocity (centrepiece)** → industry (demoted) → departures board → roster → verification ledger.
- **Merged the two trend charts:** the standalone *Install Pace* sparkline panel is removed; its two useful stats (trailing pace, Express ETA) fold into the velocity card as its caption. Drops the partial-week **“0”** that read as a stalled feed.
- **Board no longer a wall:** the all-hubs view caps to a tight per-hub slice with a **“Show all”** expander instead of ~181 rows on load.
- **Hero “N disputed” → jump-link** to the ledger (`scrollIntoView`, since the ledger lives in the tab's scroll container).
- **Industry strip demoted** to quiet context.

### 🐛 Also fixes a real production bug
`.sl-board` was never closed (dropped `</div>` from the #204 rebase), so the velocity chart, the **400-row roster, and the verification ledger were all nested *inside* the departures board**. Confirmed on live prod (`closest('#sl-board')` true for all three). Now correct siblings.

### Verification
- `typecheck` clean · `build:dashboard` OK · **743/743** vitest.
- DOM-structure asserted on the built file: chart/table/verify no longer in board; panel order matches the spine; install-pace panel gone; velocity caption present.
- Visual reference = the mockup (real components rearranged into this exact order).

### One open call
The **industry strip** is *demoted*, not cut — it's a true stat but editorially negative ("United's last") on United's own page. Easy to drop entirely if you'd rather.

⚠️ **merge = deploy to prod — review before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)