### PR TITLE
fix: board flapping, honest stale/degraded labels, warm cadence, RLS hole (Jun-17 audit)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,23 @@ SCHEDULE_LIVE_FEED_FALLBACK_ENABLED=true
 AERODATABOX_API_KEY=
 # AERODATABOX_BASE_URL=https://prod.api.market/api/v1/aedbx/aerodatabox
 
+# Warm-cron cadence + AeroDataBox pacing (optional; defaults shown). The hourly warm cron
+# (api/cron/warm-schedules.ts) strides SCHEDULE_WARM_TASKS_PER_RUN boards/fire through the 72-slot
+# today/tomorrow ring. Default 4 (clamp 1-4) => each today board refreshes ~every 6h, ~384 units/day
+# (= 96 boards/day x 4 units); drop to 3 for ~8h cadence / ~288 units/day if you need to cut spend.
+# Each board fetches 2 sequential FIDS windows paced AERODATABOX_INTER_WINDOW_DELAY_MS apart, and
+# consecutive boards are paced SCHEDULE_WARM_DELAY_MS apart — both keep the warm fan-out under the
+# provider's ~1 req/s throttle (429s). Raising the inter-window delay reduces 429s but trims each
+# window's fetch timeout, so keep it modest.
+# SCHEDULE_WARM_TASKS_PER_RUN=4
+# SCHEDULE_WARM_DELAY_MS=3000
+# AERODATABOX_INTER_WINDOW_DELAY_MS=1500
+# Organic (non-cron) AeroDataBox spend gate, units/day. The warm cron BYPASSES this gate but still
+# records against it, so at the default stride the cron alone books ~384/day; raise this (e.g. 600)
+# if on-demand "yesterday" boards start getting blocked late in the UTC day. 0 = hard kill switch
+# for ALL metered spend. Default 400.
+# AERODATABOX_DAILY_UNIT_BUDGET=400
+
 # ScrapingBee has been REMOVED. The FR24 web scrape is Cloudflare-challenge-dead from datacenter IPs;
 # no free plain-fetch proxy can pass it, so there is no scraper transport in production.
 # A generic http-json proxy mode still exists but is normally UNSET (used only if FR24 ever reopens):
@@ -33,7 +50,8 @@ CRON_SECRET=
 
 # Operational alerting (optional): Discord webhook URL. When set, the hourly warm-schedules cron
 # POSTs a compact alert when the schedule pipeline is degraded (total warm failure, frozen/stale-
-# served boards, 0-flight boards, AeroDataBox spend >= 80% of the daily budget, or starlink down).
+# served boards, 0-flight boards, partial nonempty-but-incomplete boards, AeroDataBox spend >= 80%
+# of the daily budget, or starlink down).
 # Leave unset to disable alerting entirely. For Slack, api/_alert.ts would need `text` not `content`.
 ALERT_WEBHOOK_URL=
 

--- a/api/_schedule-aerodatabox.ts
+++ b/api/_schedule-aerodatabox.ts
@@ -343,7 +343,7 @@ export async function fetchViaAeroDataBox(
   // Cross-instance daily spend stop: behave exactly as if the provider were unconfigured so
   // callers fall through to their existing degraded paths instead of burning more quota.
   // Authorized cron warms bypass the organic gate — their spend is hard-bounded by the warm ring
-  // itself (~288 units/day) and they are the one path that keeps boards from freezing, so organic
+  // itself (~384 units/day) and they are the one path that keeps boards from freezing, so organic
   // traffic must never starve them. Their units are still recorded against the organic budget,
   // and they keep a 3x absolute ceiling so a leaked cron secret cannot spend unboundedly. Both
   // gates hydrate first: an unhydrated ceiling reads a cold instance's 0 and is per-instance
@@ -373,8 +373,12 @@ export async function fetchViaAeroDataBox(
   const rawFlights: any[] = [];
   const failedWindows: number[] = [];
   // Free RapidAPI plans throttle by requests-per-second, so pause between the sequential window
-  // calls. Reserve that pause out of the budget when sizing each window's timeout.
-  const interWindowDelayMs = Math.max(0, Number(process.env.AERODATABOX_INTER_WINDOW_DELAY_MS ?? 1100) || 0);
+  // calls. 1500ms (was 1100) keeps the two FIDS calls comfortably under the 1 req/s ceiling even
+  // when an organic request is competing for the same per-second budget, cutting 429s; on the warm
+  // path (~30s provider budget) it only trims each window's timeout by ~100ms, and on the organic
+  // path (~12s budget) by ~200ms — both stay well above the 2000ms floor below. Reserve that pause
+  // out of the budget when sizing each window's timeout.
+  const interWindowDelayMs = Math.max(0, Number(process.env.AERODATABOX_INTER_WINDOW_DELAY_MS ?? 1500) || 0);
   const reserved = interWindowDelayMs * (windows.length - 1);
   const perWindowTimeout = Math.max(2000, Math.floor((timeoutMs - reserved) / windows.length));
 

--- a/api/aircraft-history.ts
+++ b/api/aircraft-history.ts
@@ -145,7 +145,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (!resp.ok) {
       const text = await resp.text().catch(() => '');
       console.error(`FR24 aircraft history error for ${reg}: status=${resp.status} ${text.slice(0, 200)}`);
-      return res.status(502).json({ success: false, error: 'FR24 API error' });
+      // Echo the upstream status so the failure is diagnosable from the response
+      // alone (e.g. 402/403 = credit-blocked vs 5xx = outage). The frontend only
+      // reads `success`, so this extra field is inert for consumers.
+      return res.status(502).json({ success: false, error: 'FR24 API error', upstreamStatus: resp.status });
     }
 
     const data = await resp.json();

--- a/api/cron/warm-schedules.ts
+++ b/api/cron/warm-schedules.ts
@@ -18,17 +18,20 @@ import { getStartOfHubDay } from '../../src/lib/hubTz.js';
 const HUBS = UNITED_HUBS;
 // Serialized with INTER_TASK_DELAY_MS between tasks. Budget math: each task worst-case is ~58s
 // (55s schedule fetch + 3s gap). maxDuration for this cron is 300s in vercel.json, so the clamp
-// ceiling of 4 tasks → 4 × 58s = 232s stays under the Lambda limit. Default is 3 on an HOURLY
-// cron: 3 tasks × 24 fires = 72 warm slots/day = exactly one full ring (today boards 3×/day,
-// tomorrow boards 1×/day) ≈ 72 fresh boards × 4 units = 288 AeroDataBox units/day, the metered
-// plan's budget. Serial (not Promise.allSettled) respects the provider's 1 req/s limit.
+// ceiling of 4 tasks → 4 × 55s + 3 × 3s = 229s, plus the ~20s starlink ping and ~5s alerting
+// (≈254s), stays under the Lambda limit. Default is 4 on an HOURLY cron: 4 tasks × 24 fires = 96
+// warm slots/day = 1.33 passes over the 72-task ring, so each today board warms 4×/day (~every 6h
+// — the low-traffic intl hubs NRT/LAX/IAD no longer drift 8–10h stale) and each tomorrow board
+// ~1.33×/day. That is ≈ 96 fresh boards × 4 units = 384 AeroDataBox units/day. (Default was 3 →
+// 8h cadence / 288 units/day; the +96 units/day buys the fresher cadence and stays far under the
+// 3× organic-budget bypass ceiling.) Serial (not Promise.allSettled) respects the 1 req/s limit.
 function envNumber(name: string, fallback: number): number {
   const value = Number(process.env[name]);
   return Number.isFinite(value) ? value : fallback;
 }
 // Read per call (not at module load) so a runtime env change — or a test — actually takes effect,
 // and so an explicit '0' delay is honoured instead of being swallowed by `|| fallback`.
-const getWarmTasksPerRun = () => Math.max(1, Math.min(4, Math.floor(envNumber('SCHEDULE_WARM_TASKS_PER_RUN', 3))));
+const getWarmTasksPerRun = () => Math.max(1, Math.min(4, Math.floor(envNumber('SCHEDULE_WARM_TASKS_PER_RUN', 4))));
 const getInterTaskDelayMs = () => Math.max(0, envNumber('SCHEDULE_WARM_DELAY_MS', 3000));
 // A warm that came back stale/degraded did not warm anything — the handler served a frozen
 // fallback instead of refetching. Anything older than the clean-board TTL (6h) counts as failed.
@@ -57,9 +60,14 @@ function windowTasks(dayOffset: 0 | 1, label: 'today' | 'tomorrow'): WarmTask[] 
 }
 
 // The warm ring: TODAY_ROUNDS rounds of all 18 today windows, with the 18 tomorrow windows split
-// evenly across the rounds. Striding through it sequentially warms each today board TODAY_ROUNDS
-// times per ring (~every 8h — delays/cancellations stay current) and each tomorrow board once
-// (schedule data is stable; it just needs to exist before midnight).
+// evenly across the rounds. Striding through it sequentially (SCHEDULE_WARM_TASKS_PER_RUN windows
+// per fire) warms each today board TODAY_ROUNDS times per ring and each tomorrow board once. At
+// the default stride of 4/fire the 72-slot ring completes ~1.33×/day, so each today board
+// refreshes ~every 6h (delays/cancellations stay current) and each tomorrow board ~1.33×/day
+// (schedule data is stable; it just needs to exist before midnight). TODAY_ROUNDS stays 3 so the
+// ring length (72) divides evenly by the stride (4) — that clean tiling is what gives an even 6h
+// spacing with no skipped windows; bumping TODAY_ROUNDS to 4+ would make the ring (90+) outrun a
+// single day's 96 slots and leave some tomorrow boards unwarmed.
 const TODAY_ROUNDS = 3;
 function buildWarmRing(): WarmTask[] {
   const today = windowTasks(0, 'today');
@@ -235,6 +243,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       scheduleEntries.filter(([, r]) => statuses.includes(r?.status)).map(([k]) => k);
     const frozen = byStatus('stale_served', 'not_refreshed'); // the frozen-board signature
     const emptyBoards = byStatus('degraded_empty');
+    // Nonempty-but-incomplete boards: a window 429'd/timed out so the board fetched fewer flights
+    // than it should. The schedule run still returns a NONEMPTY board (no 503, no frozen/empty
+    // signature), so without this a busy hub flapping to a partial board never pages.
+    const degradedPartial = byStatus('degraded_partial');
     const erroredKeys = scheduleEntries
       .filter(([, r]) => r?.status === 'error' || String(r?.status || '').startsWith('http_'))
       .map(([k]) => k);
@@ -246,11 +258,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const budgetHot = budget > 0 && unitsToday >= budget * 0.8;
 
     const totalFailure = scheduleWarmed === 0 && scheduleFailed > 0;
-    if (totalFailure || frozen.length > 0 || emptyBoards.length > 0 || budgetHot || (starlinkStatus && starlinkStatus !== 'ok')) {
+    if (totalFailure || frozen.length > 0 || emptyBoards.length > 0 || degradedPartial.length > 0 || budgetHot || (starlinkStatus && starlinkStatus !== 'ok')) {
       await sendAlert('⚠️ Blue Board schedule pipeline degraded', [
         `warmed=${scheduleWarmed} failed=${scheduleFailed} (plan size ${warmPlan.length}, ~${estUnits} units this run)`,
         frozen.length ? `frozen/stale-served boards (warm did NOT refetch): ${frozen.join(', ')}` : '',
         emptyBoards.length ? `0-flight boards: ${emptyBoards.join(', ')}` : '',
+        degradedPartial.length ? `partial boards (nonempty but a window failed — incomplete): ${degradedPartial.join(', ')}` : '',
         erroredKeys.length ? `errors/http: ${erroredKeys.join(', ')}` : '',
         budgetHot ? `AeroDataBox budget: ${unitsToday}/${budget} units today (≥80%)` : '',
         starlinkStatus && starlinkStatus !== 'ok' ? `starlink: ${starlinkStatus}` : '',

--- a/api/schedule.ts
+++ b/api/schedule.ts
@@ -23,7 +23,7 @@ type ScheduleFetchOptions = {
   disableProviderFallback?: boolean;
   disableScraperFallback?: boolean;
   // Authorized cron warms only: their provider spend is already hard-bounded by the warm ring
-  // (~288 units/day), so the organic daily budget must not starve the one path that keeps boards
+  // (~384 units/day), so the organic daily budget must not starve the one path that keeps boards
   // from freezing. Never set from user input.
   providerBudgetExempt?: boolean;
 };
@@ -150,6 +150,14 @@ async function getPersistentFallback(key: string) {
   };
 }
 
+// A board served from the fallback tier is not automatically "degraded". 'degraded' must mean the
+// board is INCOMPLETE (partial), and 'stale' must mean it is old (>=1h) OR incomplete — not merely
+// "served from cache". The old blanket stale:true + degraded:true mislabeled a complete board that
+// the cron warmed minutes ago as a degraded/stale snapshot. 1h mirrors the frontend recent<1h
+// bucket in src/lib/data-age.js (dataAgeSeverity). cached:true is always set so the client still
+// knows the board came from a cache/snapshot tier; meta.dataAge stays informational.
+const STALE_AGE_SECONDS = 3600;
+
 function buildDegradedResponse(
   entry: { data: any; time: number },
   fallbackScope: 'exact' | 'hub_dir' | 'persistent' | 'persistent_partial'
@@ -159,8 +167,8 @@ function buildDegradedResponse(
   return {
     ...entry.data,
     cached: true,
-    stale: true,
-    degraded: true,
+    stale: isBestKnownPartial || dataAge >= STALE_AGE_SECONDS,
+    degraded: isBestKnownPartial,
     meta: {
       ...(entry.data?.meta || {}),
       dataAge,
@@ -168,6 +176,14 @@ function buildDegradedResponse(
       bestKnownPartial: isBestKnownPartial,
     }
   };
+}
+
+// A board is "fresh + complete" when it is non-partial AND younger than the staleness threshold.
+// Such a board has nothing to refresh — a background refresh can only DEGRADE it (the live-feed
+// fallback returns a ~35% partial that would then poison the hot cache and flap the board). The
+// fallback serve tiers use this to skip the pointless refresh. (Audit: busy-hub board flapping.)
+function isFreshComplete(entry: { data: any; time: number }): boolean {
+  return entry.data?.partial !== true && (Date.now() - entry.time) < STALE_AGE_SECONDS * 1000;
 }
 
 function shouldAttemptTargetedOfficialRescue(hub: string, ts: number, options?: ScheduleFetchOptions): boolean {
@@ -195,6 +211,22 @@ function cacheSet(key: string, data: any, ttlMs: number): void {
     if (firstKey !== undefined) cache.delete(firstKey);
   }
   cache.set(key, { data, expires: Date.now() + ttlMs, time: Date.now() });
+}
+
+// Mirror saveComplete's empty/partial protection on the HOT cache: never let a partial (or empty)
+// result overwrite an existing complete, non-empty board for the same key. A background refresh
+// that returns the ~35%-complete live-feed partial would otherwise replace the full ~650-flight
+// board in memory and make the very next request serve the 74-flight partial — the busy-hub flap.
+// A complete (or higher-value) result always writes through. (Audit: partial-overwrites-complete.)
+function cacheSetGuarded(key: string, data: any, ttlMs: number): void {
+  const incomingIsWorse = data?.partial === true || Number(data?.total || 0) === 0;
+  if (incomingIsWorse) {
+    const existing = cache.get(key);
+    if (existing && existing.data?.partial !== true && Number(existing.data?.total || 0) > 0) {
+      return; // keep the better complete entry
+    }
+  }
+  cacheSet(key, data, ttlMs);
 }
 
 function setAggregateCacheHeader(res: VercelResponse, data: any, cdnMaxAge: number, swr: number, noStore = false): void {
@@ -1157,7 +1189,7 @@ function triggerBackgroundRefresh(
   if (pendingAggs.has(aggKey)) return;
   const refreshHub = String(hub);
   const promise = fetchAllPages(refreshHub, dir, ts, undefined, Date.now() + 55000, options).then(async result => {
-    cacheSet(aggKey, result, result.partial ? 60000 : ttl);
+    cacheSetGuarded(aggKey, result, result.partial ? 60000 : ttl);
     saveComplete(aggKey, result);
     await saveScheduleSnapshot({ cacheKey: aggKey, hub: refreshHub, dir, ts, data: result });
     return result;
@@ -1305,7 +1337,10 @@ async function fetchAllPages(
   // if FR24 ever drops the challenge. NOTE: officialFallback=0 (cron / disableOfficialSource) used
   // to force 'scrape-only'; we no longer let it override 'provider', so background warming can use
   // the working provider without burning FR24 credits.
-  const envPriority = (process.env.SCHEDULE_SOURCE_PRIORITY || 'scrape').toLowerCase();
+  // FAIL-CLOSED DEFAULT: when SCHEDULE_SOURCE_PRIORITY is unset (e.g. an env wipe), default to
+  // 'provider' — the working paid AeroDataBox feed — not the Cloudflare-dead 'scrape', so a missing
+  // env degrades to a source that returns a real board instead of an empty/blocked one.
+  const envPriority = (process.env.SCHEDULE_SOURCE_PRIORITY || 'provider').toLowerCase();
   const srcPriority = (options.disableOfficialSource && envPriority !== 'provider')
     ? 'scrape-only'
     : envPriority;
@@ -1698,37 +1733,56 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       (allowScraperFallback && hasConfiguredFr24ScraperTransport()) ||
       (allowProviderFallback && !!process.env.AERODATABOX_API_KEY) ||
       shouldAttemptLiveFeedFallback(hub, ts);
-    const shouldBypassEmptyPartialCache = cached?.data?.partial === true && Number(cached?.data?.total || 0) === 0 && hasImmediateScheduleRecovery;
-    if (cached && !shouldBypassEmptyPartialCache) {
+    const cachedIsPartial = cached?.data?.partial === true;
+    const shouldBypassEmptyPartialCache = cachedIsPartial && Number(cached?.data?.total || 0) === 0 && hasImmediateScheduleRecovery;
+    // A NONEMPTY cached partial (e.g. the ~35% live-feed fallback) must not outrank a complete board.
+    // When the hot cache holds a partial but a complete last-known board is available in memory, fall
+    // through so the cascade below serves that complete board (honestly flagged via
+    // buildDegradedResponse) instead of the partial. This stops the busy-hub flap between the full
+    // board and a 74-flight partial, and prefers the complete AeroDataBox snapshot over the live-feed
+    // fallback while the FR24 official rescue is credit-dead. We only bypass when a complete board
+    // actually exists, so a usable partial is never discarded for a fresh (metered) fetch with
+    // nothing better to serve. (Audit: partial-outranks-complete flap; fix #5.)
+    const shouldBypassPartialForComplete = !!cached && cachedIsPartial && Number(cached?.data?.total || 0) > 0 &&
+      !!(getLastComplete(currentAggKey) || getLastCompleteByHubDir(hub, dir, ts));
+    if (cached && !shouldBypassEmptyPartialCache && !shouldBypassPartialForComplete) {
       setAggregateCacheHeader(res, cached.data, cdnMaxAge, swr, wantsForce);
       return res.status(200).json({ ...cached.data, cached: true });
     }
 
     const stale = forceRefresh ? null : cacheGetStale(currentAggKey);
     if (stale && !stale.data.partial) {
-      triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, {
-        allowTargetedOfficialRescue: false,
-        disableOfficialSource: !allowOfficialFallback,
-        disableProviderFallback: pendingAggs.has(currentAggKey) || !shouldEnableProviderForBackgroundRefresh(
-          currentAggKey, Date.now() - stale.time, allowProviderFallback
-        ),
-        disableScraperFallback: true,
-      });
+      // Skip the refresh for a fresh + complete board: there is nothing to refresh and the refresh
+      // can only degrade it to a partial. (Audit: busy-hub board flapping.)
+      if (!isFreshComplete(stale)) {
+        triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, {
+          allowTargetedOfficialRescue: false,
+          disableOfficialSource: !allowOfficialFallback,
+          disableProviderFallback: pendingAggs.has(currentAggKey) || !shouldEnableProviderForBackgroundRefresh(
+            currentAggKey, Date.now() - stale.time, allowProviderFallback
+          ),
+          disableScraperFallback: true,
+        });
+      }
       res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
-      return res.status(200).json({ ...stale.data, cached: true, stale: true });
+      return res.status(200).json({ ...stale.data, cached: true, stale: !isFreshComplete(stale) });
     }
 
     const exactLastComplete = forceRefresh ? null : getLastComplete(currentAggKey);
     const fallbackComplete = forceRefresh ? null : (exactLastComplete || getLastCompleteByHubDir(hub, dir, ts));
     if (fallbackComplete) {
-      triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, {
-        allowTargetedOfficialRescue: false,
-        disableOfficialSource: !allowOfficialFallback,
-        disableProviderFallback: pendingAggs.has(currentAggKey) || !shouldEnableProviderForBackgroundRefresh(
-          currentAggKey, Date.now() - fallbackComplete.time, allowProviderFallback
-        ),
-        disableScraperFallback: true,
-      });
+      // Skip the refresh for a fresh + complete last-known board: refreshing it can only replace the
+      // full board with a partial. Only refresh once it is genuinely old. (Audit: board flapping.)
+      if (!isFreshComplete(fallbackComplete)) {
+        triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, {
+          allowTargetedOfficialRescue: false,
+          disableOfficialSource: !allowOfficialFallback,
+          disableProviderFallback: pendingAggs.has(currentAggKey) || !shouldEnableProviderForBackgroundRefresh(
+            currentAggKey, Date.now() - fallbackComplete.time, allowProviderFallback
+          ),
+          disableScraperFallback: true,
+        });
+      }
       res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
       return res.status(200).json(buildDegradedResponse(fallbackComplete, exactLastComplete ? 'exact' : 'hub_dir'));
     }
@@ -1740,14 +1794,19 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       if (canAttemptRecoveryNow) {
         partialPersistentFallback = persistentFallback;
       } else {
-        triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, {
-          allowTargetedOfficialRescue: allowOfficialFallback && persistentFallback.fallbackScope === 'persistent_partial',
-          disableOfficialSource: !allowOfficialFallback,
-          disableProviderFallback: pendingAggs.has(currentAggKey) || !shouldEnableProviderForBackgroundRefresh(
-            currentAggKey, Date.now() - persistentFallback.time, allowProviderFallback
-          ),
-          disableScraperFallback: true,
-        });
+        // Skip the refresh for a fresh + complete persisted snapshot: it is already the best board and
+        // a refresh can only degrade it. A partial snapshot (or an old one) still refreshes so the
+        // frozen-board recovery path is preserved. (Audit: board flapping.)
+        if (!isFreshComplete(persistentFallback)) {
+          triggerBackgroundRefresh(hub, dir, ts, currentAggKey, ttl, {
+            allowTargetedOfficialRescue: allowOfficialFallback && persistentFallback.fallbackScope === 'persistent_partial',
+            disableOfficialSource: !allowOfficialFallback,
+            disableProviderFallback: pendingAggs.has(currentAggKey) || !shouldEnableProviderForBackgroundRefresh(
+              currentAggKey, Date.now() - persistentFallback.time, allowProviderFallback
+            ),
+            disableScraperFallback: true,
+          });
+        }
         res.setHeader('Cache-Control', `s-maxage=60, stale-while-revalidate=${swr}`);
         return res.status(200).json(buildDegradedResponse(persistentFallback, persistentFallback.fallbackScope));
       }
@@ -1772,7 +1831,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       disableScraperFallback: !allowScraperFallback,
       providerBudgetExempt: forceRefresh,
     }).then(async result => {
-      cacheSet(currentAggKey, result, result.partial ? 60000 : ttl);
+      cacheSetGuarded(currentAggKey, result, result.partial ? 60000 : ttl);
       saveComplete(currentAggKey, result);
       await saveScheduleSnapshot({ cacheKey: currentAggKey, hub, dir, ts, data: result });
       return result;

--- a/sql/011_cep_review_comments_rls.sql
+++ b/sql/011_cep_review_comments_rls.sql
@@ -1,0 +1,69 @@
+-- Close the permissive RLS UPDATE hole on public.cep_review_comments.
+--
+-- This table backs the CEP review-comments board (~94 comments live in prod). It was created
+-- ad-hoc directly in the database and was never tracked in this repo's sql/ set, so THIS FILE is
+-- the canonical record of its access policy going forward.
+--
+-- The hole (verified live 2026-06-17): the table has a permissive UPDATE policy
+--   cep_anon_resolve  FOR UPDATE TO public  USING (true) WITH CHECK (true)
+-- and the anon role also holds the UPDATE grant. Postgres evaluates USING(true)/WITH CHECK(true)
+-- as "any row, any new value," so ANY holder of the public anon key can overwrite ALL review
+-- comments. This is the same WITH CHECK(true) anti-pattern that was remediated on the waitlist
+-- table in sql/010_waitlist_drop_open_policy.sql.
+--
+-- Fix: drop the open UPDATE policy AND revoke the UPDATE table grant from every public-facing
+-- role. Comment "resolution" moves server-side via the service_role key (which bypasses RLS), so
+-- we add NO replacement anon UPDATE policy — anonymous clients must no longer mutate comments.
+--
+-- What we deliberately KEEP:
+--   * The constrained INSERT policy (with its length caps) — untouched, still the only anon write path.
+--   * RLS stays ENABLED.
+--   * The public SELECT policy cep_anon_read (USING true) — public read is INTENTIONAL; this board
+--     is meant to be world-readable. We do NOT remove it and do NOT expose anything new.
+--   * No DELETE policy exists, so deletes remain blocked for anon — we add none.
+--
+-- Idempotent + safe to re-run: DROP POLICY IF EXISTS suppresses the missing-policy case, REVOKE is
+-- a no-op (notice only) when the grant is already absent, and ENABLE ROW LEVEL SECURITY is a no-op
+-- when already enabled. The whole block is guarded by to_regclass so a fresh sql/ bootstrap that
+-- has not created this ad-hoc table simply skips instead of erroring.
+--
+-- APPLY MANUALLY via the Supabase SQL editor / MCP (this repo keeps migrations in sql/, not
+-- supabase/migrations/ — `supabase db push` would apply nothing while looking successful). The
+-- exact statements to run against prod are reproduced verbatim at the END of this file.
+
+DO $$
+BEGIN
+  IF to_regclass('public.cep_review_comments') IS NULL THEN
+    RAISE NOTICE 'public.cep_review_comments not present; skipping (ad-hoc table not in this database)';
+    RETURN;
+  END IF;
+
+  -- Keep row-level security on (no-op if already enabled).
+  ALTER TABLE public.cep_review_comments ENABLE ROW LEVEL SECURITY;
+
+  -- Drop the permissive UPDATE policy that let anon overwrite every comment.
+  DROP POLICY IF EXISTS cep_anon_resolve ON public.cep_review_comments;
+
+  -- Revoke the UPDATE table grant from all public-facing roles so no UPDATE path survives for
+  -- anonymous (or signed-in) clients. service_role bypasses RLS and grants and is unaffected.
+  REVOKE UPDATE ON public.cep_review_comments FROM anon;
+  REVOKE UPDATE ON public.cep_review_comments FROM authenticated;
+  REVOKE UPDATE ON public.cep_review_comments FROM PUBLIC;
+END $$;
+
+-- Verify after applying:
+--   SELECT polname, polcmd FROM pg_policy WHERE polrelid = 'public.cep_review_comments'::regclass;
+--   -- expect NO row with polcmd = 'w' (UPDATE); the INSERT ('a') and SELECT ('r') policies remain.
+--   SELECT grantee, privilege_type FROM information_schema.role_table_grants
+--    WHERE table_schema = 'public' AND table_name = 'cep_review_comments' AND privilege_type = 'UPDATE';
+--   -- expect no anon / authenticated / PUBLIC rows.
+
+-- =====================================================================================
+-- EXACT statements to run against prod (orchestrator applies these via Supabase MCP):
+--
+--   DROP POLICY IF EXISTS cep_anon_resolve ON public.cep_review_comments;
+--   REVOKE UPDATE ON public.cep_review_comments FROM anon;
+--   REVOKE UPDATE ON public.cep_review_comments FROM authenticated;
+--   REVOKE UPDATE ON public.cep_review_comments FROM PUBLIC;
+--   ALTER TABLE public.cep_review_comments ENABLE ROW LEVEL SECURITY;
+-- =====================================================================================

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -5918,15 +5918,36 @@ function buildJourneyContextStr(reg, segments, myFlight, origCode, destCode) {
 async function fetchAircraftJourney(reg, myFlight, origCode, destCode) {
   if (!reg) return;
 
+  // Replace a stuck "Loading aircraft journey…" placeholder with a graceful
+  // unavailable state. Guarded on .mf-journey-loading so it never clobbers a
+  // live "Where's My Plane?" inbound card already rendered for this tail.
+  function showJourneyUnavailable() {
+    var el = document.getElementById('journey-' + reg);
+    if (el && el.querySelector('.mf-journey-loading')) {
+      el.innerHTML = '<div class="mf-journey-loading">Flight history unavailable</div>';
+    }
+  }
+
   // Check cache
   var cached = aircraftJourneyCache[reg];
   if (cached && Date.now() - cached.ts < 300000) return; // 5min TTL
 
   try {
     var resp = await fetch('/api/aircraft-history?reg=' + encodeURIComponent(reg));
-    if (!resp.ok) return;
+    if (!resp.ok) {
+      // Upstream error (e.g. FR24 502 / credit-blocked): cache an empty marker so
+      // the post-fetch re-render renders the graceful state instead of rebuilding
+      // a perpetual loading line, and update the live placeholder now.
+      aircraftJourneyCache[reg] = { segments: [], ts: Date.now() };
+      showJourneyUnavailable();
+      return;
+    }
     var data = await resp.json();
-    if (!data.success || !data.segments) return;
+    if (!data.success || !data.segments) {
+      aircraftJourneyCache[reg] = { segments: [], ts: Date.now() };
+      showJourneyUnavailable();
+      return;
+    }
 
     aircraftJourneyCache[reg] = { segments: data.segments, ts: Date.now() };
 
@@ -5943,12 +5964,15 @@ async function fetchAircraftJourney(reg, myFlight, origCode, destCode) {
         });
       }
     } else if (container) {
-      container.innerHTML = ''; // No history available — remove loading placeholder
+      // Lookup succeeded but no recent segments — surface the graceful state
+      // (matches the failed-fetch path) instead of leaving an empty section.
+      showJourneyUnavailable();
     }
   } catch (e) {
-    // Silently fail — journey chain is supplementary
-    var c = document.getElementById('journey-' + reg);
-    if (c) c.innerHTML = '';
+    // Network/parse failure — cache an empty marker and replace the loading
+    // placeholder with the graceful state (journey chain is supplementary).
+    aircraftJourneyCache[reg] = { segments: [], ts: Date.now() };
+    showJourneyUnavailable();
   }
 }
 
@@ -6090,7 +6114,8 @@ function buildMyFlightCard(watched, td) {
     }
     // Check if we already have cached journey data for richer inbound context
     const cached = aircraftJourneyCache[reg];
-    if (cached && cached.segments && cached.segments.length > 0 && Date.now() - cached.ts < 300000) {
+    const cacheFresh = cached && Date.now() - cached.ts < 300000;
+    if (cacheFresh && cached.segments && cached.segments.length > 0) {
       inboundHtml = buildJourneyChainHtml(reg, cached.segments, watched.flight, origCode, destCode);
       inboundStr = buildJourneyContextStr(reg, cached.segments, watched.flight, origCode, destCode);
     } else if (inbound) {
@@ -6100,9 +6125,16 @@ function buildMyFlightCard(watched, td) {
         Your aircraft is currently operating <strong>${escapeHtml(inbound.flightIATA)}</strong> from ${escapeHtml(inbCity)} (${escapeHtml(inbound.origin)}) \u2192 ${escapeHtml(origCity)} (${escapeHtml(origCode)}) at ${Math.round(inbound.alt * 3.28084).toLocaleString()}ft
       </div>`;
     }
-    // Placeholder for async journey chain load
+    // Async journey chain slot. While the history fetch is still pending (no fresh
+    // cache yet) show a loading line; once it has completed but produced nothing
+    // usable \u2014 upstream error or no recent segments \u2014 show a graceful unavailable
+    // state instead of a perpetual "Loading\u2026" line. (The fetch won't re-run until
+    // the 5-min TTL, and the post-fetch re-render rebuilds this card from cache.)
     if (!inboundHtml && reg) {
-      inboundHtml = `<div class="mf-journey" id="journey-${escapeHtml(reg)}"><div class="mf-journey-loading">Loading aircraft journey\u2026</div></div>`;
+      const journeyBody = cacheFresh
+        ? '<div class="mf-journey-loading">Flight history unavailable</div>'
+        : '<div class="mf-journey-loading">Loading aircraft journey\u2026</div>';
+      inboundHtml = `<div class="mf-journey" id="journey-${escapeHtml(reg)}">${journeyBody}</div>`;
     } else if (inboundHtml && reg) {
       // Wrap existing html with an ID for async update
       inboundHtml = `<div id="journey-${escapeHtml(reg)}">${inboundHtml}</div>`;

--- a/src/pages/tsa.astro
+++ b/src/pages/tsa.astro
@@ -166,6 +166,14 @@ const faqEntries = getAllFaqEntries();
     <p>Complete checkpoint guide for United Airlines terminals at all 7 domestic hubs. Standard, Pre✓, CLEAR, and Priority lane availability — hours, tips, and which checkpoint to use.</p>
   </div>
 
+  <!-- Live wait-time feed status. The MyTSA public feed is decommissioned (api/tsa.ts
+       reports feedDown with all-null waits), so live minute-by-minute numbers are
+       unavailable. Surface that explicitly rather than leaving the "TSA Wait Times"
+       hub cards looking broken / empty. Static checkpoint guide below stays accurate. -->
+  <div class="tsa-tip" role="status" style="margin-bottom:32px">
+    <span class="tsa-tip-icon">⏳</span>Live checkpoint wait times are temporarily unavailable — the TSA's public wait-time feed is offline. The checkpoint guide below (lanes, hours, and tips) is current.
+  </div>
+
   <!-- Jump nav -->
   <nav class="tsa-jump-nav" aria-label="Hub navigation">
     {tsaHubOrder.map((code) => (
@@ -260,8 +268,8 @@ const faqEntries = getAllFaqEntries();
 <div class="tsa-gate-overlay tsa-hidden" id="tsa-gate">
   <div class="tsa-gate-modal">
     <div class="tsa-gate-logo">The Blue Board</div>
-    <h2 class="tsa-gate-title">Unlock Live TSA Wait Times</h2>
-    <p class="tsa-gate-text">Enter your email for live checkpoint wait times at United terminals — plus delay alerts, fleet updates, and hub intel.</p>
+    <h2 class="tsa-gate-title">United Hub Intel &amp; Delay Alerts</h2>
+    <p class="tsa-gate-text">Live TSA wait times are temporarily offline. Enter your email for delay alerts, fleet updates, and hub intel — and we'll let you know the moment checkpoint wait times return.</p>
     <input class="tsa-gate-input" type="email" id="tsa-gate-email" placeholder="you@airline.com" autocomplete="email">
     <button class="tsa-gate-btn" id="tsa-gate-submit">Get Free Access &rarr;</button>
     <div class="tsa-gate-error" id="tsa-gate-error"></div>

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -338,7 +338,8 @@ describe('schedule API', () => {
 
   it('scrape-first: scraping succeeds, official API never called', async () => {
     process.env.FR24_API_TOKEN = 'test-token-12345678';
-    // Default SCHEDULE_SOURCE_PRIORITY is 'scrape'
+    // The fail-closed default is now 'provider'; pin 'scrape' to exercise the legacy scrape path.
+    process.env.SCHEDULE_SOURCE_PRIORITY = 'scrape';
 
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
       const urlStr = String(url);
@@ -396,6 +397,7 @@ describe('schedule API', () => {
 
   it('scrape-first: historical failures do not trigger official API rescue', async () => {
     process.env.FR24_API_TOKEN = 'test-token-12345678';
+    process.env.SCHEDULE_SOURCE_PRIORITY = 'scrape'; // pin legacy scrape path (default is now 'provider')
 
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
       const urlStr = String(url);
@@ -522,6 +524,7 @@ describe('schedule API', () => {
 
   it('scrape-first: official fallback can still be disabled by env', async () => {
     process.env.FR24_API_TOKEN = 'test-token-12345678';
+    process.env.SCHEDULE_SOURCE_PRIORITY = 'scrape'; // pin legacy scrape path (default is now 'provider')
     process.env.SCHEDULE_OFFICIAL_FALLBACK_ENABLED = '0';
 
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
@@ -717,6 +720,9 @@ describe('schedule API', () => {
   it('uses AeroDataBox schedule fallback before FR24 official fallback when scraping fails', async () => {
     process.env.FR24_API_TOKEN = 'test-token-12345678';
     process.env.AERODATABOX_API_KEY = 'adb-test-key';
+    // Pin the legacy scrape path (default is now 'provider'): this test asserts the scrape→provider
+    // rescue ordering (meta.fallbackFrom='scraping'), which only happens in scrape mode.
+    process.env.SCHEDULE_SOURCE_PRIORITY = 'scrape';
 
     const ts = getStartOfDayForHub('GUM') + 86400;
     const depTime = ts + 9 * 3600;
@@ -796,6 +802,9 @@ describe('schedule API', () => {
     process.env.SCHEDULE_SCRAPER_TOKEN = 'proxy-secret';
     process.env.AERODATABOX_API_KEY = 'adb-test-key';
     process.env.FR24_API_TOKEN = 'test-token-12345678';
+    // Pin the legacy scrape path (default is now 'provider'): this asserts the scraper transport is
+    // tried before provider fallbacks when the DIRECT scrape is blocked — a scrape-mode ordering.
+    process.env.SCHEDULE_SOURCE_PRIORITY = 'scrape';
 
     const ts = getStartOfDayForHub('SFO') + 86400;
     const depTime = ts + 7 * 3600;
@@ -1201,6 +1210,7 @@ describe('schedule API', () => {
 
   it('scrape-first: empty schedule (not partial) does not trigger fallback', async () => {
     process.env.FR24_API_TOKEN = 'test-token-12345678';
+    process.env.SCHEDULE_SOURCE_PRIORITY = 'scrape'; // pin legacy scrape path (default is now 'provider')
 
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
       const urlStr = String(url);
@@ -1328,9 +1338,13 @@ describe('schedule API', () => {
     expect(res.body.meta.source).toBe('scraping');
   });
 
-  it('returns persisted exact snapshot on cold start while refreshing in the background', async () => {
+  it('returns a fresh+complete persisted snapshot honestly flagged, without a pointless refresh', async () => {
     // Two days back: the snapped day is never "today", so the empty-board live-feed rescue
     // (a today-only path) cannot add clock-dependent fetches to this test.
+    // The snapshot is COMPLETE and only 5 min old, so it is genuinely fresh: the handler must serve
+    // it as cached:true but stale:false, degraded:false (honest labeling) and must NOT trigger a
+    // background refresh — a refresh of a fresh+complete board can only degrade it to a partial.
+    // (Audit: stale/degraded mislabeling + busy-hub flapping.)
     const ts = Math.floor(Date.now() / 1000) - 172800;
     const tsSnapped = getStartOfHubDay('ORD', 0, new Date(ts * 1000));
     scheduleSnapshotMocks.loadScheduleSnapshot.mockResolvedValue({
@@ -1367,7 +1381,7 @@ describe('schedule API', () => {
     });
 
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
-      throw new Error('fetch should not run when an exact persisted snapshot is available');
+      throw new Error('fetch should not run when a fresh+complete persisted snapshot is available');
     });
 
     const req = {
@@ -1381,14 +1395,22 @@ describe('schedule API', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.body.total).toBe(1);
-    expect(res.body.degraded).toBe(true);
+    expect(res.body.cached).toBe(true);
+    // Fresh (5 min) + complete → honestly flagged, NOT stale/degraded.
+    expect(res.body.stale).toBe(false);
+    expect(res.body.degraded).toBe(false);
     expect(res.body.meta.fallbackScope).toBe('persistent');
     expect(scheduleSnapshotMocks.loadScheduleSnapshot).toHaveBeenCalledWith(`agg:ORD:departures:${tsSnapped}`);
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    expect(vercelFunctionMocks.waitUntil).toHaveBeenCalledTimes(1);
+    // No background refresh: a fresh+complete board has nothing to refresh.
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(vercelFunctionMocks.waitUntil).not.toHaveBeenCalled();
   });
 
   it('returns persisted partial snapshot on cold start while refreshing in the background', async () => {
+    // A partial snapshot is NOT fresh+complete, so the background refresh still fires. Pin the legacy
+    // scrape path (default is now 'provider') so the refresh deterministically hits the scrape
+    // first-page (one fetch) rather than adding async provider/official hops before that fetch.
+    process.env.SCHEDULE_SOURCE_PRIORITY = 'scrape';
     const ts = getStartOfDayForHub('ORD') + 86400;
     scheduleSnapshotMocks.loadScheduleSnapshot.mockResolvedValue({
       data: {
@@ -1703,6 +1725,7 @@ describe('schedule API', () => {
 
   it('scrape-first: heavy rate limiting uses official rescue on targeted windows when explicitly enabled', { timeout: 15000 }, async () => {
     process.env.FR24_API_TOKEN = 'test-token-12345678';
+    process.env.SCHEDULE_SOURCE_PRIORITY = 'scrape'; // pin legacy scrape path (default is now 'provider')
     process.env.SCHEDULE_OFFICIAL_FALLBACK_ENABLED = '1';
 
     let pagesFetched = [];
@@ -2123,7 +2146,7 @@ describe('background provider refresh age gate', () => {
     expect(aeroCalls.length).toBeGreaterThan(0);
   });
 
-  it('keeps the provider off on background refresh of a young snapshot', async () => {
+  it('keeps the provider off for a young+complete snapshot (no pointless refresh)', async () => {
     process.env.AERODATABOX_API_KEY = 'test-key';
     process.env.SCHEDULE_SOURCE_PRIORITY = 'provider';
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
@@ -2143,7 +2166,9 @@ describe('background provider refresh age gate', () => {
       headers: { origin: 'http://localhost:3000' },
       query: { hub: 'ORD', dir: 'departures', timestamp: String(getStartOfHubDay('ORD', 0)) },
     }, res);
-    expect(res.body.stale).toBe(true);
+    // A 10-min-old COMPLETE board is fresh: honestly flagged stale:false, and no background refresh
+    // fires at all (the refresh could only degrade it), so the paid provider is never touched.
+    expect(res.body.stale).toBe(false);
 
     await Promise.all(vercelFunctionMocks.waitUntil.mock.calls.map(c => c[0]));
     const aeroCalls = fetchSpy.mock.calls.filter(([url]) => /aerodatabox|aedbx/i.test(String(url)));


### PR DESCRIPTION
Fixes the six issues from the Jun-17 reliability audit. Built in an isolated worktree off `origin/main`, 4 implementers on disjoint files + an adversarial diff review (**verdict: pass**).

## What changed
| # | Fix | Where |
|---|-----|-------|
| **1** | **Board flapping (the big one):** a ~35%-complete live-feed partial can no longer overwrite a complete board. `cacheSetGuarded` (partial/empty never replaces complete+nonempty), background refresh gated behind `isFreshComplete` (a fresh <1h complete board isn't refreshed — the refresh could only degrade it), and a nonempty cached partial now defers to an available complete snapshot. ORD/DEN/SFO stop oscillating **650↔74 flights** on reload. | `schedule.ts` |
| **3** | **Honest flags:** `buildDegradedResponse` no longer hardcodes `stale+degraded`. `degraded` = INCOMPLETE only; `stale` = genuinely old (≥1h) or partial. A complete <1h board served from cache is no longer mislabeled. | `schedule.ts` |
| **5** (code) | Prefer the complete AeroDataBox snapshot over the 35% live-feed fallback while FR24's official rescue is credit-blocked. | `schedule.ts` |
| — | **Fail-closed:** `SCHEDULE_SOURCE_PRIORITY` default `scrape`→`provider`, so an env wipe degrades to the working paid feed instead of the Cloudflare-dead scrape (the Jun-9 freeze class). | `schedule.ts` |
| **2** | **Warm cadence:** `tasksPerRun` 3→4 (~8h→~6h per-board) + inter-window delay 1100→1500ms to cut 429s; added `degraded_partial` to the alert trigger so a flapping busy hub pages. | `warm-schedules.ts`, `_schedule-aerodatabox.ts` |
| **6** | **Graceful widgets:** `aircraft-history` no longer leaves a stuck "Loading aircraft journey…" line (→ "Flight history unavailable"); TSA page shows an explicit "wait times unavailable" notice instead of empty/null cells. | `main.js`, `aircraft-history.ts`, `tsa.astro` |
| **4** | **Security:** `sql/011` closes the `cep_review_comments` anon-UPDATE RLS hole (`USING(true)/WITH CHECK(true)` dropped + `UPDATE` revoked from anon/authenticated/PUBLIC). Insert + public-read kept. | `sql/011_*.sql` |

## Verification
- `tsc --noEmit` → **0 errors** · `bun run test` → **743/743 pass** (53 files) · `bun run build` → **OK** (42 pages)
- Adversarial reviewer checked all 7 risk areas (stale_served detection, cache-overwrite off-by-one, refresh-wedge, source-priority flip, maxDuration, JS brace balance, SQL idempotency) — none present.
- 7 `schedule.test.js` cases updated to the new (correct) contract; no meaningful assertions removed.

## ⚠️ Action required (can't be done in this PR)
1. **Apply the RLS migration to prod.** I verified the hole is live (`cep_anon_resolve` = `UPDATE USING(true) WITH CHECK(true)` to PUBLIC + anon holds the UPDATE grant), but applying DDL to prod was correctly gated. Run via Supabase SQL editor:
   ```sql
   DROP POLICY IF EXISTS cep_anon_resolve ON public.cep_review_comments;
   REVOKE UPDATE ON public.cep_review_comments FROM anon;
   REVOKE UPDATE ON public.cep_review_comments FROM authenticated;
   REVOKE UPDATE ON public.cep_review_comments FROM PUBLIC;
   ```
2. **FR24 official-API billing decision (#5):** the official rescue is credit-blocked ("top up your account"). This PR makes the data path degrade gracefully without it, but decide: top up FR24, or retire that tier. *(Note: it's FlightRadar24's API, NOT RapidAPI/AeroDataBox.)*
3. **Warm-cadence spend (#2):** cron now books ~384 AeroDataBox units/day (was ~288). Because organic refresh is gated at the same 400 budget, **total daily spend stays ~flat** (spend reallocates organic→cron, which is what fixes NRT/LAX/IAD). If you want organic headroom back, bump `AERODATABOX_DAILY_UNIT_BUDGET` to ~600 in Vercel env. To hold cron spend flat instead, set `SCHEDULE_WARM_TASKS_PER_RUN=3`.

Heads up: **merge = prod deploy** here, so apply the RLS migration around merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
