### PR TITLE
fix(audit-jun19): honest stale banner + graceful aircraft-history/flight-times + log hygiene (zero-risk)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to The Blue Board are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.21] - 2026-06-19
+
+### Fixed
+- Stale schedule boards show a staleness banner again. A complete board served from cache past its fresh window is correctly flagged `stale` but `degraded:false`, and the dashboard banner only checked `partial`/`degraded` — so an hours-old complete board (e.g. an 18h-old arrivals board) rendered with no warning at all. The banner now also fires on `stale`, with amber (1–6h) → red (6h+) age escalation and an honest "Showing complete data from Xh ago" message instead of the misleading "Some flights may be missing."
+- The manual connection checker no longer blames the user for a backend outage. While the flight-times feed is unavailable (an HTTP error) it now shows "Flight times are temporarily unavailable" rather than "Could not find one or both flights. Check the flight numbers." — which it displayed for every valid input while the feed was down. A genuine 200-but-not-found still shows the check-the-numbers message.
+
+### Changed
+- `/api/aircraft-history` returns HTTP 200 with `success:false` (instead of 502) when the upstream FR24 API declines on billing/auth/rate limits (402/403/429). The frontend degrades identically, but this stops a known-dead upstream from being the site's only 5xx — which polluted the error dashboard and would trip any uptime canary. Genuine upstream 5xx and network faults still return 502.
+- The "AeroDataBox daily unit budget exhausted" log warning is throttled to once per instance per UTC day instead of firing on every gated request (previously dozens per hour for ~11h a day), so it no longer buries genuine warnings.
+
 ## [1.5.20] - 2026-06-10
 
 ### Changed

--- a/api/_schedule-aerodatabox.ts
+++ b/api/_schedule-aerodatabox.ts
@@ -12,6 +12,16 @@ const ADB_UNITS_PER_REQUEST = 2;
 // spend far below this.
 const ADB_BYPASS_CEILING_MULTIPLIER = 3;
 
+// The "budget exhausted" warning previously fired on every gated organic request — dozens/hour for
+// ~11h/day once the budget trips, burying genuine warnings and inflating log-query latency. Throttle
+// it to once per instance per UTC day (mirrors warnedAdbSchemaMissing in _cost-state.ts).
+let lastBudgetWarnDay = '';
+
+/** Test-only: clear the once-per-day warn throttle so per-test assertions start from a clean slate. */
+export function __resetScheduleWarnsForTests(): void {
+  lastBudgetWarnDay = '';
+}
+
 // Persist the spend write even if Vercel freezes the lambda right after the response is sent —
 // a dropped RPC undercounts the cross-instance counter that IS the global spend ceiling.
 function recordAdbUnitsDurable(units: number): void {
@@ -357,9 +367,15 @@ export async function fetchViaAeroDataBox(
       return null;
     }
   } else if (isAdbBudgetExhausted()) {
-    console.warn(
-      `AeroDataBox daily unit budget exhausted (${getAdbUnitsToday()}/${getAdbDailyUnitBudget()}); skipping ${hub} ${dir} until next UTC day`
-    );
+    // Throttle: once the day's budget trips, every organic board load would otherwise log this —
+    // emit it once per instance per UTC day so the signal isn't drowned in its own repetition.
+    const today = new Date().toISOString().slice(0, 10);
+    if (lastBudgetWarnDay !== today) {
+      lastBudgetWarnDay = today;
+      console.warn(
+        `AeroDataBox daily unit budget exhausted (${getAdbUnitsToday()}/${getAdbDailyUnitBudget()}); skipping further organic schedule fetches until next UTC day`
+      );
+    }
     return null;
   }
 

--- a/api/aircraft-history.ts
+++ b/api/aircraft-history.ts
@@ -148,7 +148,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       // Echo the upstream status so the failure is diagnosable from the response
       // alone (e.g. 402/403 = credit-blocked vs 5xx = outage). The frontend only
       // reads `success`, so this extra field is inert for consumers.
-      return res.status(502).json({ success: false, error: 'FR24 API error', upstreamStatus: resp.status });
+      //
+      // A BILLING/auth/rate decline (402 credit-blocked, 403 forbidden, 429 throttled) is not a
+      // gateway fault — answering 5xx for it violates HTTP semantics, is the only 5xx class this
+      // service emits in prod, and would trip any 5xx uptime canary. Map those to 200 + success:false
+      // (the frontend degrades identically); reserve 502 for a genuine upstream 5xx / outage.
+      const billingDeclined = resp.status === 402 || resp.status === 403 || resp.status === 429;
+      return res
+        .status(billingDeclined ? 200 : 502)
+        .json({ success: false, error: 'FR24 API error', upstreamStatus: resp.status });
     }
 
     const data = await resp.json();

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "notjbg/the-blue-board",
   "private": true,
   "type": "module",
-  "version": "1.5.20",
+  "version": "1.5.21",
   "packageManager": "bun@1.3.14",
   "engines": {
     "node": "24.x"

--- a/src/dashboard/main.js
+++ b/src/dashboard/main.js
@@ -4522,7 +4522,7 @@ async function loadScheduleData() {
     document.getElementById('sched-timerange').value = '';
     document.getElementById('sched-risk').value = '';
     loadEl.style.display = 'none';
-    if (result.partial || result.degraded) {
+    if (result.partial || result.degraded || result.stale) {
       const meta = result.meta || {};
       let msg = '';
       if (result.degraded && meta.dataAge != null) {
@@ -4533,6 +4533,13 @@ async function loadScheduleData() {
         msg = result.partial
           ? `Showing cached partial data from ${age} ago.`
           : `Showing cached complete data from ${age} ago.`;
+      } else if (result.stale && !result.partial && meta.dataAge != null) {
+        // Complete but aged out of the fresh window (degraded=false: nothing is missing). PR #207
+        // made these boards degraded=false for honesty, but the banner gate never checked
+        // result.stale — so hours-old complete boards rendered with NO warning. This branch (and
+        // the gate above) restores the warning; without it the chain falls to the misleading
+        // "Some flights may be missing." default, a lie for a complete board.
+        msg = `Showing complete data from ${formatDataAge(meta.dataAge)} ago.`;
       } else if (meta.liveFeedFallbackAdded) {
         msg = `Added ${meta.liveFeedFallbackAdded} live active flight(s) while the full schedule feed recovers.`;
       } else if (meta.partialReason === 'live_feed_fallback') {
@@ -4548,7 +4555,7 @@ async function loadScheduleData() {
       } else {
         msg = 'Some flights may be missing.';
       }
-      const pct = meta.completeness != null && meta.partialReason !== 'actual_only_official'
+      const pct = meta.completeness != null && meta.partialReason !== 'actual_only_official' && (result.partial || result.degraded)
         ? result.degraded && result.partial
           ? ` ${Math.round(meta.completeness * 100)}% previously loaded.`
           : !result.degraded
@@ -4557,7 +4564,7 @@ async function loadScheduleData() {
         : '';
       // Escalate the banner with data age: teal reads as "all good", which is a lie for a board
       // that is hours old. 1-6h → amber caution; 6h+ (past a full cache lifetime) → red (--ua-red).
-      const ageSeverity = result.degraded && meta.dataAge != null ? dataAgeSeverity(meta.dataAge) : null;
+      const ageSeverity = (result.degraded || result.stale) && meta.dataAge != null ? dataAgeSeverity(meta.dataAge) : null;
       const palette = ageSeverity === 'stale'
         ? { bg: 'rgba(239,68,68,.12)', border: 'rgba(239,68,68,.3)', text: 'var(--ua-red)', icon: '⚠️' }
         : ageSeverity === 'aging'
@@ -6445,7 +6452,15 @@ async function checkManualConnection() {
       fetch('/api/flight-times?flight=' + encodeURIComponent(normalize(inFlt))).then(r => r.ok ? r.json() : null),
       fetch('/api/flight-times?flight=' + encodeURIComponent(normalize(outFlt))).then(r => r.ok ? r.json() : null)
     ]);
-    if (!r1 || !r2 || r1.success === false || r2.success === false) {
+    // r===null means the HTTP request itself failed (404/5xx). Right now the flight-times feed is
+    // dark for every flight (FlightAware soft-blocks server-side scrapes; the FR24 summary fallback
+    // is credit-dead), so the old blanket "check the flight numbers" blamed the user for a backend
+    // outage on every valid input. Distinguish a feed outage (neutral) from a genuine 200+not-found.
+    if (r1 === null || r2 === null) {
+      resultEl.innerHTML = '<div style="color:var(--ua-muted);font-size:11px">Flight times are temporarily unavailable. Please try again later.</div>';
+      return;
+    }
+    if (r1.success === false || r2.success === false) {
       resultEl.innerHTML = '<div style="color:var(--ua-red);font-size:11px">Could not find one or both flights. Check the flight numbers.</div>';
       return;
     }

--- a/tests/aircraft-history.test.js
+++ b/tests/aircraft-history.test.js
@@ -131,6 +131,29 @@ describe('aircraft-history API', () => {
     expect(res.body.error).toMatch(/FR24 API error/);
   });
 
+  it('returns HTTP 200 (not 5xx) when FR24 declines on billing/auth (402/403/429)', async () => {
+    // An upstream BILLING/auth decline is not a gateway fault: returning 5xx for a credit-blocked
+    // (402) feed violates HTTP semantics, is the only 5xx class in prod, and would trip any
+    // 5xx-based uptime canary. The frontend reads only `success`, so a 200 + success:false degrades
+    // identically. Genuine upstream 5xx / network faults still return 502 (see tests above/below).
+    for (const status of [402, 403, 429]) {
+      vi.restoreAllMocks();
+      process.env.FR24_API_TOKEN = 'test-token';
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: false,
+        status,
+        text: async () => 'declined',
+      });
+
+      const res = createRes();
+      await handler(makeReq(), res);
+
+      expect(res.statusCode, `upstream ${status} should map to HTTP 200`).toBe(200);
+      expect(res.body.success).toBe(false);
+      expect(res.body.upstreamStatus).toBe(status);
+    }
+  });
+
   it('returns 504 on fetch timeout (AbortError)', async () => {
     vi.spyOn(globalThis, 'fetch').mockRejectedValue(
       Object.assign(new Error('aborted'), { name: 'AbortError' })

--- a/tests/cost-state-adb.test.js
+++ b/tests/cost-state-adb.test.js
@@ -15,7 +15,7 @@ import {
   hydrateAdbSpend,
   __resetAdbSpendForTests,
 } from '../api/_cost-state.js';
-import { fetchViaAeroDataBox } from '../api/_schedule-aerodatabox.js';
+import { fetchViaAeroDataBox, __resetScheduleWarnsForTests } from '../api/_schedule-aerodatabox.js';
 
 describe('AeroDataBox daily unit budget (cost-state)', () => {
   beforeEach(() => {
@@ -186,6 +186,26 @@ describe('fetchViaAeroDataBox budget enforcement', () => {
     const result = await fetchViaAeroDataBox('ORD', 'departures', Math.floor(Date.now() / 1000), 5000);
     expect(result).toBeNull();
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs the budget-exhausted warning at most ONCE per UTC day (no per-request log spam)', async () => {
+    // The warning previously fired on EVERY gated organic request — dozens/hour for ~11h/day,
+    // burying genuine warnings and inflating log-query latency. It must throttle to once per
+    // instance per UTC day (reset here so prior exhausted-path tests don't consume the one allowance).
+    __resetScheduleWarnsForTests();
+    await recordAdbUnits(400);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false, status: 500, headers: { get: () => null }, json: async () => ({}), text: async () => '',
+    });
+
+    const ts = Math.floor(Date.now() / 1000);
+    await fetchViaAeroDataBox('ORD', 'departures', ts, 5000);
+    await fetchViaAeroDataBox('SFO', 'arrivals', ts, 5000);
+    await fetchViaAeroDataBox('DEN', 'departures', ts, 5000);
+
+    const budgetWarns = warnSpy.mock.calls.filter((c) => /daily unit budget exhausted/.test(String(c[0])));
+    expect(budgetWarns).toHaveLength(1);
   });
 
   it('bypassDailyBudget (authorized cron warms, ring-bounded at ~288/day) skips the gate but still records spend', async () => {


### PR DESCRIPTION
Zero-risk slice of the **Jun-19 health audit** (22-agent, adversarially verified). These four fixes touch **no budget/quota/env decisions** — they only make the existing degradation **honest and observable**. The deeper freshness root-cause (a stale `SCHEDULE_WARM_TASKS_PER_RUN` env var + the 400-unit budget self-strangling the warm cron) is left for a separate change that needs the RapidAPI monthly-ceiling check first.

## What & why

**#2 — Stale boards show a banner again (P1, the biggest honesty win).**
PR #207 correctly made a complete-but-old cached board `degraded:false` (nothing is missing) while keeping `stale:true`. But the dashboard banner gate only checked `partial`/`degraded` and never `stale` — so an **18h-old complete board rendered with no warning at all**, and #207's own amber→red age-escalation was dead code for it. The banner now also fires on `result.stale`, escalates by data age (amber 1–6h, red 6h+, reusing the tested `data-age` helpers), and shows an honest `Showing complete data from Xh ago` instead of the misleading `Some flights may be missing.`

**#3 — `/api/aircraft-history` 402 → 200, not 502 (P2 observability).**
A billing/auth/rate decline (402 credit-blocked / 403 / 429) from the known-dead FR24 official API was returned as HTTP **502 — the site's only 5xx class**, polluting the error dashboard and able to trip any uptime canary the moment one is wired. Now mapped to `200 {success:false, upstreamStatus}`; the frontend degrades **identically** (verified at `main.js:5937-5950`). Genuine upstream 5xx / network faults still return 502.

**#5 — Connection checker stops blaming the user for an outage (P1 UX).**
While the flight-times feed is dark (FlightAware soft-blocks server-side scrapes + FR24 summary is credit-dead), the manual connection checker showed `Could not find one or both flights. Check the flight numbers.` for **every valid input**. It now distinguishes an HTTP failure (`Flight times are temporarily unavailable`) from a genuine 200-but-not-found (keeps the check-the-numbers copy).

**#7 — Throttle the budget-exhausted log warning (P3 hygiene).**
`AeroDataBox daily unit budget exhausted` fired on every gated organic request — dozens/hour for ~11h/day once the budget trips. Throttled to **once per instance per UTC day**, so it no longer buries genuine warnings.

## Tests / verification
- **TDD** for both server-side changes (failing test first): aircraft-history 402/403/429→200 (`tests/aircraft-history.test.js`) and the once-per-day budget-warn throttle (`tests/cost-state-adb.test.js`, via a new `__resetScheduleWarnsForTests`).
- Frontend banner + copy are DOM-inline (no unit harness) — verified by build + review; the banner reuses the already-tested `data-age` helpers.
- ✅ `tsc --noEmit` clean · ✅ **745/745** vitest (743 baseline + 2 new) · ✅ `bun run build` OK.

## Not included (deliberately)
- The freshness **root cause**: `SCHEDULE_WARM_TASKS_PER_RUN` stale prod env (→ stride-2 cron) + unset `AERODATABOX_DAILY_UNIT_BUDGET` (→ 400 default the budget-exempt cron itself blows by ~13:00 UTC). Those are env changes that must go together and need the RapidAPI **monthly** ceiling verified first.
- `ALERT_WEBHOOK_URL` / `EMAIL_POSTAL_ADDRESS` (env).
- The global-search "Look up flight" fr24 console.error (close cousin of #5; easy follow-up).

> ⚠️ Merge = production deploy (preview deploys are disabled on this project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
